### PR TITLE
Explicitly build palette folder

### DIFF
--- a/packages/foundations/rollup.config.js
+++ b/packages/foundations/rollup.config.js
@@ -4,19 +4,19 @@ import resolve from "rollup-plugin-node-resolve"
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
 
-// NOTE: the palette folder (not included here) is built as a side effect of the
-// palette being exposed by src/index.ts
-const folders = ["accessibility", "mq", "themes", "typography"].map(folder => ({
-	input: `src/${folder}/index.ts`,
-	output: [
-		{
-			file: `${folder}/index.js`,
-			format: "cjs",
-		},
-	],
-	plugins,
-	external: ["@guardian/src-foundations"],
-}))
+const folders = ["accessibility", "mq", "palette", "themes", "typography"].map(
+	folder => ({
+		input: `src/${folder}/index.ts`,
+		output: [
+			{
+				file: `${folder}/index.js`,
+				format: "cjs",
+			},
+		],
+		plugins,
+		external: ["@guardian/src-foundations"],
+	}),
+)
 
 module.exports = [
 	{


### PR DESCRIPTION
## What is the purpose of this change?

There was an assumption that the palette folder gets built as part of the index build. This is incorrect. Types get created, but not runtime code.

## What does this change?

Exlicitly building the palette folder ensures runtime code as well as types get added to the built palette folder.
