### PR TITLE
Check in yarn 1.21

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.21.1.js


### PR DESCRIPTION
## What is the purpose of this change?

Rather than assuming all Yarns are created equal, we should [check in the version of Yarn we support](https://legacy.yarnpkg.com/lang/en/docs/cli/policies/)

## What does this change?

Adds Yarn v1.21 to the project

