### PR TITLE
Improve onClick event handler type

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from "react"
+import React, { ReactElement, ReactNode, MouseEvent } from "react"
 import {
 	button,
 	primary,
@@ -74,7 +74,7 @@ const Button = ({
 	iconSide: IconSide
 	icon?: ReactElement
 	tabIndex?: number
-	onClick?: () => void
+	onClick?: (e: MouseEvent<HTMLButtonElement>) => void
 	children?: ReactNode
 }) => {
 	const buttonContents = [children]

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -16,8 +16,15 @@ import { ThemeProvider } from "emotion-theming"
 
 /* eslint-disable react/jsx-key */
 const priorityButtons = [
-	<Button>Primary</Button>,
-	<Button priority="secondary">Secondary</Button>,
+	<Button onClick={e => console.log("Primary clicked:", e.target)}>
+		Primary
+	</Button>,
+	<Button
+		onClick={() => console.log("Secondary clicked")}
+		priority="secondary"
+	>
+		Secondary
+	</Button>,
 	<Button priority="tertiary">Tertiary</Button>,
 ]
 const sizeButtons = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,6 @@
 		"noImplicitAny": true,
 		"strictNullChecks": true,
 		"noUnusedLocals": true,
-		"declaration": true,
 		"allowSyntheticDefaultImports": true,
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true


### PR DESCRIPTION
## What is the purpose of this change?

The `onClick` handler for the Button component should be able to accept an Event. This is not currently specified in the type for the handler's singature.

## What does this change?

- Adds an argument for an event with the type `MouseEvent<HTMLButtonElement>` to the `onClick` handler
- Updates stories to add `onClick` handlers to some of our buttons. This would have caught the type mismatch during `yarn validate`
- Removes the `--declaration` flag from the `tsconfig`. We are not generating `*.d.ts` files for our components, so is redundant. However it was preventing compilation because React's `MouseEvent` is private and could not bee included in the Button's `*.d.ts` file (see [this comment](https://github.com/microsoft/TypeScript/issues/6307#issuecomment-168321011)).

