### PR TITLE
Add src-svgs as dependency of button

### DIFF
--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -16,11 +16,13 @@
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.13.0",
 		"@guardian/src-helpers": "^0.0.1",
-		"@guardian/src-svgs": "^0.2.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
 		"rollup-plugin-node-resolve": "^5.2.0"
+	},
+	"dependencies": {
+		"@guardian/src-svgs": "^0.2.0"
 	},
 	"files": [
 		"dist/*.js",


### PR DESCRIPTION
## What is the purpose of this change?

`src-svgs` is currently a `devDependency` of the button component, but ought to be a dependency. The right arrow SVG is used in the LinkButton component

## What does this change?

- move src-svgs from devDependencies into dependencies
