### PR TITLE
Add legacy font-families to foundations

### DIFF
--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -2,10 +2,12 @@ const fontSizes = [12, 15, 17, 20, 24, 28, 34, 42, 50, 70]
 
 const fonts = {
 	titlepiece: "GT Guardian Titlepiece, Georgia, serif",
-	headlineSerif: "GH Guardian Headline, Georgia, serif",
-	bodySerif: "GuardianTextEgyptian, Georgia, serif",
+	headlineSerif:
+		"GH Guardian Headline, Guardian Egyptian Web, Georgia, serif",
+	bodySerif:
+		"GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif",
 	bodySans:
-		"GuardianTextSans, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
+		"GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif",
 }
 
 const lineHeights = [1.15, 1.35, 1.5]


### PR DESCRIPTION
## What is the purpose of this change?

Frontend uses older font family names for the Guardian's custom fonts. These are not supported by Source, so Source components can't be used in the context of the Frontend application.

## What does this change?

Adds legacy `font-family` names which will be picked up if the newer names are not available. This _might_ be a temporary solution, as the preference would be to add them to the on-platform design system, rather than in core.

cc @GHaberis @andre1050 @oliverlloyd @tjmw 
