### PR TITLE
Update checkbox props to accept onclick

### DIFF
--- a/src/core/components/checkbox/index.tsx
+++ b/src/core/components/checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, ChangeEvent } from "react"
+import React, { ReactNode, ChangeEvent, MouseEvent } from "react"
 import {
 	fieldset,
 	label,
@@ -88,6 +88,7 @@ const Checkbox = ({
 	indeterminate: boolean
 	error: boolean
 	onChange?: (event: ChangeEvent<HTMLInputElement>) => void
+	onClick?: (event: MouseEvent<HTMLInputElement>) => void
 }) => {
 	const isChecked = (): boolean | "mixed" => {
 		// Note: the indeterminate prop takes precedence over the checked prop


### PR DESCRIPTION
## What is the purpose of this change?

Checkbox should be able to receive an onClick event allowing consumers to trigger side effects on mouse click. 

Thanks to @rBangay for raising this omission 🙏 

## What does this change?

- update Checkbox props to accept an `onClick` event that receives a `MouseEvent` object
