### PR TITLE
Include dist files in package

### DIFF
--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -22,6 +22,7 @@
 		"rollup-plugin-node-resolve": "^5.2.0"
 	},
 	"files": [
+		"dist/*.js",
 		"index.tsx",
 		"styles.ts"
 	],


### PR DESCRIPTION
## What is the purpose of this change?

The ESM-bundled version of the radio dist code is not included in the package. This is causing breakage in consumer applications that rely on ESM-bundled code being present

## What does this change?

- Explicitly add all dist files to the package
