### PR TITLE
Apply error styles when invalid

### DIFF
--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -165,8 +165,9 @@ const [constraintLight] = themes.map(({ name, theme }) => {
 			<div css={constrainedWith}>
 				<TextInput
 					label="Phone number"
-					supporting="Enter an 11 digit phone number. An invalid entry will show error styling."
+					supporting="An invalid entry will show error styling"
 					pattern="[0-9]{1,11}"
+					title="11 digit phone number"
 				/>
 			</div>
 		</ThemeProvider>

--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -159,10 +159,40 @@ const [errorWithMessageLight] = themes.map(({ name, theme }) => {
 	return story
 })
 
+const [constraintLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="Phone number"
+					supporting="Enter an 11 digit phone number. An invalid entry will show error styling."
+					pattern="[0-9]{1,11}"
+				/>
+			</div>
+		</ThemeProvider>
+	)
+
+	story.story = {
+		name: `with constraint ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
+
+	return story
+})
+
 export {
 	defaultLight,
 	optionalLight,
 	supportingTextLight,
 	widthsLight,
 	errorWithMessageLight,
+	constraintLight,
 }

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -7,6 +7,13 @@ import {
 	TextInputTheme,
 } from "@guardian/src-foundations/themes"
 
+export const errorInput = ({
+	textInput,
+}: { textInput: TextInputTheme } = textInputLight) => css`
+	border: 4px solid ${textInput.borderError};
+	color: ${textInput.textError};
+`
+
 export const textInput = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
@@ -19,6 +26,10 @@ export const textInput = ({
 
 	&:focus {
 		${focusHalo};
+	}
+
+	&:invalid {
+		${errorInput({ textInput })};
 	}
 `
 
@@ -44,13 +55,6 @@ export const text = ({
 	${textSans.medium()};
 	color: ${textInput.textLabel};
 	margin-bottom: ${space[1]}px;
-`
-
-export const errorInput = ({
-	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
-	border: 4px solid ${textInput.borderError};
-	color: ${textInput.textError};
 `
 
 export const optionalLabel = ({


### PR DESCRIPTION
## What is the purpose of this change?

Text input fields with a `pattern` attribute receive an `:invalid` pseudo class if the contents of the field do not match the pattern.

We can apply our error styling against this pseudo class to emphasise an invalid entry.

Shout-out to @rBangay for pioneering this idea

## What does this change?

- apply existing error styling if the input field has an `:invalid` pseudo class

## Design

### Screenshots

![Screenshot 2020-02-12 at 09 40 43](https://user-images.githubusercontent.com/5931528/74322382-c3d42d80-4d7b-11ea-843e-0f223e511833.png)

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
