### PR TITLE
Reduce choice card dependencies

### DIFF
--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from "react"
 import { fieldset, input, choiceCard } from "./styles"
-import { InlineError } from "@guardian/src-inline-error"
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
 
 const ChoiceCardGroup = ({
@@ -18,7 +17,6 @@ const ChoiceCardGroup = ({
 	// https://bugs.chromium.org/p/chromium/issues/detail?id=375693
 	return (
 		<div css={[fieldset]} {...props}>
-			{error && <InlineError>{error}</InlineError>}
 			{React.Children.map(children, child => {
 				return React.cloneElement(
 					child,
@@ -35,7 +33,6 @@ const ChoiceCard = ({
 	id,
 	label: labelContent,
 	value,
-	supporting,
 	checked,
 	error,
 	...props

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-choice-card",
-	"version": "0.13.0-alpha.1",
+	"version": "0.13.0-alpha.2",
 	"main": "dist/choice-card.js",
 	"module": "dist/choice-card.esm.js",
 	"scripts": {
@@ -27,11 +27,7 @@
 	],
 	"peerDependencies": {
 		"@emotion/core": "^10.0.14",
-		"@guardian/src-foundations": "^0.13.0",
+		"@guardian/src-foundations": "^0.13.0-alpha.1",
 		"react": "^16.8.6"
-	},
-	"dependencies": {
-		"@guardian/src-inline-error": "^0.13.0",
-		"@guardian/src-svgs": "^0.13.0"
 	}
 }


### PR DESCRIPTION
## What is the purpose of this change?

We're not currently using choice card's dependencies
## What does this change?

Remove dependencies to speed up development