### PR TITLE
Better build script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,12 @@
 node_modules
 dist
 *.d.ts
+
+# ignore foundations dist files
+src/core/foundations/mq
+src/core/foundations/accessibility
+src/core/foundations/palette
+src/core/foundations/themes
+src/core/foundations/typography
+src/core/foundations/foundations.js
+src/core/foundations/foundations.esm.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,26 +1,10 @@
 {
-	"parser": "@typescript-eslint/parser",
-	"plugins": ["@typescript-eslint", "react", "prettier"],
-	"extends": [
-		"plugin:@typescript-eslint/recommended",
-		"plugin:react/recommended",
-		"prettier",
-		"prettier/@typescript-eslint",
-		"prettier/react"
-	],
+	"plugins": ["prettier"],
+	"extends": ["prettier"],
 	"rules": {
-		"prettier/prettier": "error",
-		"@typescript-eslint/explicit-function-return-type": "off"
+		"prettier/prettier": "error"
 	},
 	"parserOptions": {
-		"ecmaVersion": 2015,
-		"ecmaFeatures": {
-			"jsx": true
-		}
-	},
-	"settings": {
-		"react": {
-			"version": "detect"
-		}
+		"ecmaVersion": 2015
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+	"parser": "esprima",
 	"plugins": ["prettier"],
 	"extends": ["prettier"],
 	"rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
 	"parser": "@typescript-eslint/parser",
-	"plugins": [
-		"@typescript-eslint",
-		"react",
-		"prettier"
-	],
+	"plugins": ["@typescript-eslint", "react", "prettier"],
 	"extends": [
 		"plugin:@typescript-eslint/recommended",
 		"plugin:react/recommended",
@@ -17,6 +13,7 @@
 		"@typescript-eslint/explicit-function-return-type": "off"
 	},
 	"parserOptions": {
+		"ecmaVersion": 2015,
 		"ecmaFeatures": {
 			"jsx": true
 		}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"eslint-config-prettier": "^6.1.0",
 		"eslint-plugin-prettier": "^3.1.0",
 		"eslint-plugin-react": "^7.14.3",
+		"execa": "^4.0.0",
 		"jest": "^25.1.0",
 		"prettier": "^1.18.2",
 		"react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"babel-jest": "^25.1.0",
 		"babel-loader": "^8.0.6",
 		"emotion-theming": "^10.0.27",
-		"eslint": "^6.2.1",
+		"eslint": "^6.8.0",
 		"eslint-config-prettier": "^6.1.0",
 		"eslint-plugin-prettier": "^3.1.0",
 		"eslint-plugin-react": "^7.14.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"storybook": "yarn watch:foundations & yarn watch:svgs & yarn watch:utilities & start-storybook",
 		"lint:styles": "stylelint src/core/**/styles.ts",
-		"lint:js": "eslint . --ext .ts,.tsx",
+		"lint:js": "eslint . --ext .ts,.tsx,.js",
 		"lint": "yarn lint:js && yarn lint:styles",
 		"fix": "yarn lint:js --fix",
 		"tsc": "tsc",
@@ -12,21 +12,12 @@
 		"validate": "yarn tsc && yarn lint && yarn test",
 		"clean": "rm -rf dist",
 		"build:storybook": "build-storybook -o dist",
-		"build:foundations": "cd src/core/foundations && yarn build",
 		"watch:foundations": "cd src/core/foundations && yarn watch",
 		"watch:svgs": "cd src/core/svgs && yarn watch",
-		"build:svgs": "cd src/core/svgs && yarn build",
-		"build:utilities": "cd src/core/utilities && yarn build",
 		"watch:utilities": "cd src/core/utilities && yarn watch",
-		"build:button": "cd src/core/components/button && yarn build",
-		"build:checkbox": "cd src/core/components/checkbox && yarn build",
-		"build:choice-card": "cd src/core/components/choice-card && yarn build",
-		"build:grid": "cd src/core/components/grid && yarn build",
-		"build:inline-error": "cd src/core/components/inline-error && yarn build",
-		"build:link": "cd src/core/components/link && yarn build",
-		"build:radio": "cd src/core/components/radio && yarn build",
-		"build:text-input": "cd src/core/components/text-input && yarn build",
-		"ci:build": "NODE_ENV=production yarn build:foundations && yarn build:svgs && yarn build:utilities && yarn build:inline-error && yarn build:button && yarn build:checkbox && yarn build:choice-card && yarn build:grid && yarn build:link && yarn build:radio && yarn build:text-input && yarn build:storybook"
+		"clean:all": "node ./scripts/clean-all",
+		"build:all": "node ./scripts/build-all",
+		"ci:build": "NODE_ENV=production yarn build:all && yarn build:storybook"
 	},
 	"private": true,
 	"workspaces": [

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-	"parser": "espree",
-	"plugins": ["prettier"],
-	"extends": ["prettier"]
-}

--- a/scripts/.eslintrc.json
+++ b/scripts/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+	"parser": "espree",
+	"plugins": ["prettier"],
+	"extends": ["prettier"]
+}

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -1,0 +1,60 @@
+const fs = require("fs")
+const execa = require("execa")
+const paths = require("./paths")
+const { promisify } = require("util")
+
+const readdirP = promisify(fs.readdir)
+const statP = promisify(fs.stat)
+
+const build = dir => {
+	return execa("yarn", ["--cwd", `${dir}`, "run", "build"], {
+		stdio: "inherit",
+	})
+}
+const isDirectory = path => statP(path).then(stats => stats.isDirectory())
+
+const { foundations, svgs, utilities, components } = paths
+
+// heaviy depended on, build these first
+const highPriorityPackages = [foundations, svgs, utilities]
+
+// somewhat depended on
+// TODO: try to refactor!
+const mediumPriorityPackages = [`${components}/inline-error`]
+
+// not depended on
+const lowPriorityPackages = readdirP(components).then(componentDirs =>
+	Promise.all(
+		componentDirs.map(componentDirName =>
+			isDirectory(`${components}/${componentDirName}`).then(
+				isDirectory => {
+					if (!isDirectory) return Promise.resolve()
+					if (
+						mediumPriorityPackages.includes(
+							`${components}/${componentDirName}`,
+						)
+					)
+						return Promise.resolve()
+
+					return `${components}/${componentDirName}`
+				},
+			),
+		),
+	),
+)
+
+Promise.all(highPriorityPackages.map(dir => build(dir)))
+	.catch(err => console.log("Error building high priority packages:", err))
+	.then(() => Promise.all(mediumPriorityPackages.map(dir => build(dir))))
+	.catch(err => console.log("Error building medium priority packages:", err))
+	.then(() =>
+		lowPriorityPackages.then(packages => {
+			packages.forEach(package => {
+				if (!package) return
+
+				build(package).catch(err =>
+					console.log("Error building low priority package:", err),
+				)
+			})
+		}),
+	)

--- a/scripts/clean-all.js
+++ b/scripts/clean-all.js
@@ -1,0 +1,24 @@
+const fs = require("fs")
+const execa = require("execa")
+const paths = require("./paths")
+
+const { foundations, svgs, utilities, components } = paths
+
+const clean = dir => {
+	return execa("yarn", ["--cwd", `${dir}`, "run", "clean"], {
+		stdio: "inherit",
+	})
+}
+
+;[foundations, svgs, utilities].forEach(dir => {
+	clean(dir)
+})
+
+fs.readdir(components, (err, componentDirs) => {
+	componentDirs.forEach(componentDirName => {
+		fs.stat(`${components}/${componentDirName}`, (err, stats) => {
+			if (!stats.isDirectory()) return
+			clean(`${components}/${componentDirName}`)
+		})
+	})
+})

--- a/scripts/paths.js
+++ b/scripts/paths.js
@@ -1,0 +1,13 @@
+const path = require("path")
+
+const foundations = path.join(__dirname, "../src/core/foundations")
+const svgs = path.join(__dirname, "../src/core/svgs")
+const utilities = path.join(__dirname, "../src/core/utilities")
+const components = path.join(__dirname, "../src/core/components")
+
+module.exports = {
+	foundations,
+	svgs,
+	utilities,
+	components,
+}

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+	"parser": "@typescript-eslint/parser",
+	"plugins": ["@typescript-eslint", "react"],
+	"extends": [
+		"plugin:@typescript-eslint/recommended",
+		"plugin:react/recommended",
+		"prettier/@typescript-eslint",
+		"prettier/react"
+	],
+	"rules": {
+		"@typescript-eslint/explicit-function-return-type": "off"
+	},
+	"parserOptions": {
+		"ecmaFeatures": {
+			"jsx": true
+		}
+	},
+	"settings": {
+		"react": {
+			"version": "detect"
+		}
+	}
+}

--- a/src/core/svgs/rollup.config.js
+++ b/src/core/svgs/rollup.config.js
@@ -1,7 +1,7 @@
-import babel from "rollup-plugin-babel";
-import resolve from "rollup-plugin-node-resolve";
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
 
-const extensions = [".ts", ".tsx"];
+const extensions = [".ts", ".tsx"]
 
 module.exports = {
 	input: "index.ts",
@@ -10,17 +10,17 @@ module.exports = {
 			file: "dist/index.js",
 			format: "cjs",
 			globals: {
-				react: "React"
-			}
+				react: "React",
+			},
 		},
 		{
 			file: "dist/index.esm.js",
 			format: "esm",
 			globals: {
-				react: "React"
-			}
-		}
+				react: "React",
+			},
+		},
 	],
 	external: ["react"],
-	plugins: [babel({ extensions }), resolve({ extensions })]
-};
+	plugins: [babel({ extensions }), resolve({ extensions })],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5855,6 +5855,21 @@ execa@^3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
+  integrity sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 execall@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/execall/-/execall-2.0.0.tgz#16a06b5fe5099df7d00be5d9c06eecded1663b45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3260,10 +3260,10 @@ acorn-globals@^4.3.2:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.2.tgz#84b68ea44b373c4f8686023a551f61a21b7c4a4f"
-  integrity sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==
+acorn-jsx@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
+  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
 acorn-walk@^6.0.1:
   version "6.2.0"
@@ -3284,11 +3284,6 @@ acorn@^6.2.1:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
   integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
-
-acorn@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.0.0.tgz#26b8d1cd9a9b700350b71c0905546f64d1284e7a"
-  integrity sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==
 
 acorn@^7.1.0:
   version "7.1.0"
@@ -5688,22 +5683,29 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.4.0, eslint-utils@^1.4.2:
+eslint-utils@^1.4.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
   integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
+eslint-utils@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.2.1.tgz#66c2e4fe8b6356b9f01e828adc3ad04030122df1"
-  integrity sha512-ES7BzEzr0Q6m5TK9i+/iTpKjclXitOdDK4vT07OqbkBT2/VcN/gO9EL1C4HlK3TAOXYv2ItcmbVR9jO1MR0fJg==
+eslint@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -5712,19 +5714,19 @@ eslint@^6.2.1:
     debug "^4.0.1"
     doctrine "^3.0.0"
     eslint-scope "^5.0.0"
-    eslint-utils "^1.4.2"
+    eslint-utils "^1.4.3"
     eslint-visitor-keys "^1.1.0"
-    espree "^6.1.0"
+    espree "^6.1.2"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^11.7.0"
+    globals "^12.1.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.4.1"
+    inquirer "^7.0.0"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
@@ -5733,7 +5735,7 @@ eslint@^6.2.1:
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.2"
+    optionator "^0.8.3"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^6.1.2"
@@ -5743,13 +5745,13 @@ eslint@^6.2.1:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.0.tgz#a1e8aa65bf29a331d70351ed814a80e7534e0884"
-  integrity sha512-boA7CHRLlVWUSg3iL5Kmlt/xT3Q+sXnKoRYYzj1YeM10A76TEJBbotV5pKbnK42hEUIr121zTv+QLRM5LsCPXQ==
+espree@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d"
+  integrity sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
   dependencies:
-    acorn "^7.0.0"
-    acorn-jsx "^5.0.0"
+    acorn "^7.1.0"
+    acorn-jsx "^5.1.0"
     eslint-visitor-keys "^1.1.0"
 
 esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
@@ -6028,7 +6030,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -6536,10 +6538,17 @@ global@^4.3.2, global@^4.4.0:
     min-document "^2.19.0"
     process "^0.11.10"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.3.0.tgz#1e564ee5c4dded2ab098b0f88f24702a3c56be13"
+  integrity sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==
+  dependencies:
+    type-fest "^0.8.1"
 
 globalthis@^1.0.0:
   version "1.0.0"
@@ -7046,25 +7055,6 @@ inquirer@6.2.2:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
-    through "^2.3.6"
-
-inquirer@^6.4.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.1.tgz#8bfb7a5ac02dac6ff641ac4c5ff17da112fcdb42"
-  integrity sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^2.4.2"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.2.0"
-    rxjs "^6.4.0"
-    string-width "^4.1.0"
-    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 inquirer@^7.0.0:
@@ -9138,7 +9128,7 @@ opn@5.4.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -9149,18 +9139,6 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
-
-optionator@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.4"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    wordwrap "~1.0.0"
 
 original@^1.0.0:
   version "1.0.2"
@@ -12597,11 +12575,6 @@ word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
-
-wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 worker-farm@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
## What is the purpose of this change?

It's becoming unsustainable to add build scripts for each new component. It would be better if an automated process could detect available components and run `yarn build` against them

## What does this change?

- add a build-all script that builds components, foundations, SVGs and utilities, taking into account the dependency tree
- add a clean-all script that runs `yarn clean` against all packages
- rejig ESLint config to account for plain JS files under the new `scripts` directory
- upgrade ESLint
- change the ESLint parser to account for weird parse error thrown by `espree`
