### PR TITLE
Fix Opinion 300

### DIFF
--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -26,7 +26,7 @@ const colors = {
 		"#FFF4F2", //news-800
 	],
 	oranges: [
-		"#AB0613", //opinion-300
+		"#BD5318", //opinion-300
 		"#E05E00", //opinion-400
 		"#FF7F0F", //opinion-500
 		"#F9B376", //opinion-600


### PR DESCRIPTION
## What is the purpose of this change?

`opinion.300` is currently identical to `news.300`, but the [docs](https://www.theguardian.design/2a1e5182b/p/938810-colour/b/587ef3/t/258bf9) say that it should be `#BD5318`. Are they correct?

## What does this change?

- Updated hex value for `oranges[0]` to match the docs
