### PR TITLE
Multi-state choice card

### DIFF
--- a/src/core/components/choice-card/README.md
+++ b/src/core/components/choice-card/README.md
@@ -15,7 +15,7 @@ import { ChoiceCardGroup, ChoiceCard } from "@guardian/src-choice-card"
 
 const Form = () => (
     <form>
-        <ChoiceCardGroup name="consent" orientation="vertical">
+        <ChoiceCardGroup name="consent" multi={false}>
             <ChoiceCard
                 value="no"
                 label="No"
@@ -39,6 +39,13 @@ const Form = () => (
 **`string`**
 
 Gets passed as the name attribute for each choice card
+
+### `multi`
+
+**`boolean`** _= false_
+
+If true, users may select more than one choice card (checkbox behaviour). By default, users
+may only select a single choice card (radio button behaviour).
 
 ### `error`
 

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -4,11 +4,13 @@ export { choiceCardDefault } from "@guardian/src-foundations/themes"
 
 const ChoiceCardGroup = ({
 	name,
+	multi,
 	error,
 	children,
 	...props
 }: {
 	name: string
+	multi?: boolean
 	error?: string
 	children: JSX.Element | JSX.Element[]
 }) => {
@@ -20,9 +22,12 @@ const ChoiceCardGroup = ({
 			{React.Children.map(children, child => {
 				return React.cloneElement(
 					child,
-					Object.assign(error ? { error: true } : {}, {
-						name,
-					}),
+					Object.assign(
+						{ error: !!error, type: multi ? "checkbox" : "radio" },
+						{
+							name,
+						},
+					),
 				)
 			})}
 		</div>

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -20,7 +20,7 @@ export default {
 	title: "ChoiceCard",
 }
 
-const defaultLight = () => (
+const singleStateLight = () => (
 	<ThemeProvider theme={choiceCardDefault}>
 		<ChoiceCardGroup name="colours">
 			{choiceCards.map((choiceCard, index) =>
@@ -30,8 +30,27 @@ const defaultLight = () => (
 	</ThemeProvider>
 )
 
-defaultLight.story = {
-	name: `default light`,
+singleStateLight.story = {
+	name: `single state light`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+	},
+}
+
+const multiStateLight = () => (
+	<ThemeProvider theme={choiceCardDefault}>
+		<ChoiceCardGroup name="colours" multi={true}>
+			{choiceCards.map((choiceCard, index) =>
+				React.cloneElement(choiceCard, { key: index }),
+			)}
+		</ChoiceCardGroup>
+	</ThemeProvider>
+)
+
+multiStateLight.story = {
+	name: `multi state light`,
 	parameters: {
 		backgrounds: [
 			Object.assign({}, { default: true }, storybookBackgrounds.default),
@@ -58,4 +77,4 @@ defaultLight.story = {
 // 	},
 // }
 
-export { defaultLight }
+export { singleStateLight, multiStateLight }


### PR DESCRIPTION
## What is the purpose of this change?

We should allow consumers to define choice cards that support multiple selections, similar to how checkboxes work

## What does this change?

- add multi-state selection support to choice cards. These will be rendered as checkboxes

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

<img width="488" alt="Screenshot 2020-02-17 at 21 19 28" src="https://user-images.githubusercontent.com/5931528/74687054-39e8f200-51cb-11ea-8d40-04699a8656f4.png">

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/) - Needs better focus state
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
