### PR TITLE
Support className

### DIFF
--- a/src/common/props.ts
+++ b/src/common/props.ts
@@ -1,0 +1,3 @@
+export interface Props {
+	className?: string
+}

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -4,6 +4,9 @@ import React, {
 	ButtonHTMLAttributes,
 	AnchorHTMLAttributes,
 } from "react"
+import { SerializedStyles } from "@emotion/css"
+import { ButtonTheme } from "@guardian/src-foundations/themes"
+import { SvgArrowRightStraight } from "@guardian/src-svgs"
 import {
 	button,
 	primary,
@@ -19,9 +22,8 @@ import {
 	iconOnlySmall,
 	iconNudgeAnimation,
 } from "./styles"
-import { SerializedStyles } from "@emotion/css"
-import { ButtonTheme } from "@guardian/src-foundations/themes"
-import { SvgArrowRightStraight } from "@guardian/src-svgs"
+import { Props } from "../../../common/props"
+
 export {
 	buttonDefault,
 	buttonBrand,
@@ -67,7 +69,7 @@ const iconOnlySizes: {
 	small: iconOnlySmall,
 }
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonProps extends Props, ButtonHTMLAttributes<HTMLButtonElement> {
 	priority: Priority
 	size: Size
 	iconSide: IconSide
@@ -106,7 +108,9 @@ const Button = ({
 	)
 }
 
-interface LinkButtonProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+interface LinkButtonProps
+	extends Props,
+		AnchorHTMLAttributes<HTMLAnchorElement> {
 	priority: LinkButtonPriority
 	size: Size
 	showIcon: boolean

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -121,11 +121,7 @@ priorityYellow.story = {
 	name: "priority yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign(
-				{},
-				{ default: true },
-				storybookBackgrounds.brandYellow,
-			),
+			Object.assign({}, { default: true }, storybookBackgrounds.brandAlt),
 		],
 	},
 }
@@ -161,11 +157,7 @@ priorityReaderRevenueYellow.story = {
 	name: "priority reader revenue yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign(
-				{},
-				{ default: true },
-				storybookBackgrounds.brandYellow,
-			),
+			Object.assign({}, { default: true }, storybookBackgrounds.brandAlt),
 		],
 	},
 }

--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -1,4 +1,4 @@
-import { neutral, brand, brandYellow } from "@guardian/src-foundations/palette"
+import { neutral, brand, brandAlt } from "@guardian/src-foundations/palette"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
 
 const text = {
@@ -6,7 +6,7 @@ const text = {
 		primary: neutral[100],
 		secondary: neutral[60],
 		ctaPrimary: brand[400],
-		ctaSecondary: brandYellow[400],
+		ctaSecondary: brandAlt[400],
 	},
 	readerRevenueAlt: {
 		primary: neutral[7],
@@ -18,22 +18,22 @@ const text = {
 const background = {
 	readerRevenue: {
 		primary: brand[400],
-		ctaPrimary: brandYellow[400],
-		ctaPrimaryHover: brandYellow[300],
+		ctaPrimary: brandAlt[400],
+		ctaPrimaryHover: brandAlt[300],
 		ctaSecondary: brand[400],
 		ctaSecondaryHover: "#234B8A",
 	},
 	readerRevenueAlt: {
-		primary: brandYellow[400],
+		primary: brandAlt[400],
 		ctaPrimary: neutral[7],
 		ctaPrimaryHover: "#454545",
-		ctaSecondary: brandYellow[400],
-		ctaSecondaryHover: brandYellow[300],
+		ctaSecondary: brandAlt[400],
+		ctaSecondaryHover: brandAlt[300],
 	},
 }
 const border = {
 	readerRevenue: {
-		ctaSecondary: brandYellow[400],
+		ctaSecondary: brandAlt[400],
 	},
 	readerRevenueAlt: {
 		ctaSecondary: neutral[7],


### PR DESCRIPTION
## What is the purpose of this change?

There have been requests to pass custom CSS classes to components to override properties that don't work in specific contexts. 

We should allow this, as the alternative would be people not using Source components, leading to further fragmentation.

It is always worth remembering that overriding a component's CSS properties should be a last resort. Source maintainers cannot be responsible for checking whether changes to the Source components would break instances where CSS properties are overridden.

This change will be rolled out to all components.

Shoutout to @gtrufitt for the suggestion 🤗 

## What does this change?

- add a generic `Props` interface that may be extended by all Source components. This currently adds the `className` prop only.
- extend `ButtonProps` with the new `Props` interface
- BONUS: replace usages of `brandYellow` with `brandAlt`
