### PR TITLE
Pass className and styles to ChoiceCard and ChoiceCardGroup

### DIFF
--- a/src/common/props.ts
+++ b/src/common/props.ts
@@ -1,3 +1,6 @@
+import { SerializedStyles } from "@emotion/core"
+
 export interface Props {
 	className?: string
+	cssOverrides?: SerializedStyles | SerializedStyles[]
 }

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -1,6 +1,15 @@
 import React, { ReactNode } from "react"
 import { fieldset, input, choiceCard } from "./styles"
+import { Props } from "../../../common/props"
+
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
+
+interface ChoiceCardGroupProps extends Props {
+	name: string
+	multi?: boolean
+	error?: string
+	children: JSX.Element | JSX.Element[]
+}
 
 const ChoiceCardGroup = ({
 	name,
@@ -8,12 +17,7 @@ const ChoiceCardGroup = ({
 	error,
 	children,
 	...props
-}: {
-	name: string
-	multi?: boolean
-	error?: string
-	children: JSX.Element | JSX.Element[]
-}) => {
+}: ChoiceCardGroupProps) => {
 	// TODO: This is currently a div instead of a fieldset due to a Chrome / Safari
 	// bug that prevents flexbox model working on fieldset elements
 	// https://bugs.chromium.org/p/chromium/issues/detail?id=375693
@@ -34,6 +38,15 @@ const ChoiceCardGroup = ({
 	)
 }
 
+interface ChoiceCardProps extends Props {
+	id: string
+	label: ReactNode
+	value: string
+	supporting?: ReactNode
+	checked?: boolean
+	error: boolean
+}
+
 const ChoiceCard = ({
 	id,
 	label: labelContent,
@@ -41,14 +54,7 @@ const ChoiceCard = ({
 	checked,
 	error,
 	...props
-}: {
-	id: string
-	label: ReactNode
-	value: string
-	supporting?: ReactNode
-	checked?: boolean
-	error: boolean
-}) => {
+}: ChoiceCardProps) => {
 	const setChoiceCardState = (el: HTMLInputElement | null) => {
 		if (el && checked != null) {
 			el.checked = checked

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -15,6 +15,7 @@ const ChoiceCardGroup = ({
 	name,
 	multi,
 	error,
+	cssOverrides,
 	children,
 	...props
 }: ChoiceCardGroupProps) => {
@@ -22,7 +23,7 @@ const ChoiceCardGroup = ({
 	// bug that prevents flexbox model working on fieldset elements
 	// https://bugs.chromium.org/p/chromium/issues/detail?id=375693
 	return (
-		<div css={[fieldset]} {...props}>
+		<div css={[fieldset, cssOverrides]} {...props}>
 			{React.Children.map(children, child => {
 				return React.cloneElement(
 					child,
@@ -52,6 +53,7 @@ const ChoiceCard = ({
 	label: labelContent,
 	value,
 	checked,
+	cssOverrides,
 	error,
 	...props
 }: ChoiceCardProps) => {
@@ -64,7 +66,7 @@ const ChoiceCard = ({
 	return (
 		<>
 			<input
-				css={theme => [input(theme.choiceCard && theme)]}
+				css={theme => [input(theme.choiceCard && theme), cssOverrides]}
 				id={id}
 				value={value}
 				aria-invalid={error}


### PR DESCRIPTION
## What is the purpose of this change?

See #227 

This change goes one step further than #227, adding `SerializedStyles` to the universal `Props`, and propagate these down to the respective Choice Card components and composing them correctly.

Usage example:

```jsx
<ChoiceCard
  value="red"
  label="Red"
  id="default-red"
  cssOverrides={css`
    & + label {
      background-color: red;
    }
    &:checked + label {
      background-color: hotpink;
    }
  `}
/>
```

## What does this change?

- extend `ChoiceCardProps` and `ChoiceCardGroupProps` with the `Props` interface
- add `cssOverrides` to the `Props` interface. This gets added to the end of the `css` prop for each component