### PR TITLE
REM Space

### DIFF
--- a/src/core/foundations/src/space.test.ts
+++ b/src/core/foundations/src/space.test.ts
@@ -1,0 +1,4 @@
+import { space, remSpace } from "./space"
+
+it("should provide a rem equivalent of the pixel space", () =>
+	expect(remSpace[2]).toBe(`${space[2] / 16}rem`))

--- a/src/core/foundations/src/space.ts
+++ b/src/core/foundations/src/space.ts
@@ -13,9 +13,17 @@ const space = {
 	24: _space[8],
 }
 
-const remSpace = Object.entries(space).reduce(
-	(acc, [k, v]) => ({ ...acc, [k]: `${v / rootPixelFontSize}rem` }),
-	{} as Record<keyof (typeof space), string>,
-)
+const pxToRem = (px: number): string => `${px / rootPixelFontSize}rem`
+
+const remSpace: { [K in keyof (typeof space)]: string } = {
+	1: pxToRem(space[1]),
+	2: pxToRem(space[2]),
+	3: pxToRem(space[3]),
+	5: pxToRem(space[5]),
+	6: pxToRem(space[6]),
+	9: pxToRem(space[9]),
+	12: pxToRem(space[12]),
+	24: pxToRem(space[24]),
+}
 
 export { space, remSpace }

--- a/src/core/foundations/src/space.ts
+++ b/src/core/foundations/src/space.ts
@@ -1,5 +1,7 @@
 import { space as _space } from "./theme"
 
+const rootPixelFontSize = 16
+
 const space = {
 	1: _space[1],
 	2: _space[2],
@@ -11,4 +13,9 @@ const space = {
 	24: _space[8],
 }
 
-export { space }
+const remSpace = Object.entries(space).reduce(
+	(acc, [k, v]) => ({ ...acc, [k]: `${v / rootPixelFontSize}rem` }),
+	{} as Record<keyof (typeof space), string>,
+)
+
+export { space, remSpace }


### PR DESCRIPTION
## What is the purpose of this change?

Adds a `rem` version of the `space` object.

**Note:** I've generated the new object using `reduce` and `as` (there may be a downside to this). Alternatively the new object could be created as a literal, with a type annotation to make sure it has the same keys as `space`. What do you think @SiAdcock?

## What does this change?

- Added a `remSpace` object derived from the `space` object.
