### PR TITLE
Dark mode

### DIFF
--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -19,7 +19,7 @@ const background = {
 	readerRevenue: {
 		primary: brand[400],
 		ctaPrimary: brandAlt[400],
-		ctaPrimaryHover: brandAlt[300],
+		ctaPrimaryHover: brandAlt[200],
 		ctaSecondary: brand[400],
 		ctaSecondaryHover: "#234B8A",
 	},
@@ -28,7 +28,7 @@ const background = {
 		ctaPrimary: neutral[7],
 		ctaPrimaryHover: "#454545",
 		ctaSecondary: brandAlt[400],
-		ctaSecondaryHover: brandAlt[300],
+		ctaSecondaryHover: brandAlt[200],
 	},
 }
 const border = {

--- a/src/core/foundations/src/palette/background.ts
+++ b/src/core/foundations/src/palette/background.ts
@@ -26,6 +26,6 @@ export const brandAltBackground = {
 	primary: brandAlt[400],
 	buttonPrimary: neutral[7],
 	buttonPrimaryHover: "#454545",
-	buttonSecondary: brandAlt[300],
+	buttonSecondary: brandAlt[200],
 	buttonSecondaryHover: "#F2AE00",
 }

--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -1,3 +1,24 @@
+// Global colour names that correspond to https://www.theguardian.design/2a1e5182b/p/938810-colour/b/587ef3
+//
+// As a general rule, avoid using these directly in your application. Prefer the context
+// specific colours:
+//
+// - background.ts
+// - border.ts
+// - line.ts
+// - text.ts
+//
+// Why?
+// 1) Using context-specific colours ensures your application's colour usage is consistent with
+// the Guardian's visual language.
+// 2) The higher level of abstraction provided. This means that
+// changes to colours at the theme level, or changes to global colours names, are less likely to
+// have a large impact on your application.
+// 3) Context-specific colours are tested and provide better accessibility guarantees.
+//
+// If a context-specific colour is not available for your use case, consider raising a pull
+// request to add it, rather than consuming the global colour.
+
 import { colors } from "../theme"
 
 export const brand = {

--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -38,11 +38,11 @@ export const brand = {
 }
 export const brandAlt = {
 	200: colors.yellows[0],
-	300: colors.yellows[1],
+	300: colors.yellows[0], // TODO: update to colors.yellow[1] (#FFD900)
 	400: colors.yellows[2],
 
 	// legacy names: please do not use
-	dark: colors.yellows[1],
+	dark: colors.yellows[0], // TODO: update to colors.yellow[1] (#FFD900)
 	main: colors.yellows[2],
 }
 // continue to expose legacy name for compatibility

--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -1,48 +1,49 @@
 import { colors } from "../theme"
 
 export const brand = {
-	300: colors.blues[5],
-	400: colors.blues[6],
-	500: colors.blues[7],
-	600: colors.blues[8],
-	800: colors.blues[9],
+	100: colors.blues[7],
+	300: colors.blues[8],
+	400: colors.blues[9],
+	500: colors.blues[10],
+	600: colors.blues[11],
+	800: colors.blues[12],
 
 	// legacy names: please do not use
-	dark: colors.blues[5],
-	main: colors.blues[6],
-	bright: colors.blues[7],
-	pastel: colors.blues[8],
-	faded: colors.blues[9],
+	dark: colors.blues[8],
+	main: colors.blues[9],
+	bright: colors.blues[10],
+	pastel: colors.blues[11],
+	faded: colors.blues[12],
 }
 export const brandAlt = {
-	300: colors.yellows[0],
-	400: colors.yellows[1],
+	200: colors.yellows[0],
+	300: colors.yellows[1],
+	400: colors.yellows[2],
 
 	// legacy names: please do not use
-	dark: colors.yellows[0],
-	main: colors.yellows[1],
+	dark: colors.yellows[1],
+	main: colors.yellows[2],
 }
 // continue to expose legacy name for compatibility
 export const brandYellow = brandAlt
 export const neutral = {
-	7: colors.grays[0],
-	20: colors.grays[1],
-	46: colors.grays[2],
-	60: colors.grays[3],
-	86: colors.grays[4],
-	93: colors.grays[5],
-	97: colors.grays[6],
-	100: colors.grays[7],
-	// TODO: move this into background.ts
-	specialReport: "#3F464A",
+	0: colors.grays[0],
+	7: colors.grays[1],
+	20: colors.grays[2],
+	46: colors.grays[3],
+	60: colors.grays[4],
+	86: colors.grays[5],
+	93: colors.grays[6],
+	97: colors.grays[7],
+	100: colors.grays[8],
 }
 export const error = {
-	400: colors.reds[1],
-	500: colors.reds[2],
+	400: colors.reds[3],
+	500: colors.reds[4],
 
 	// legacy names: please do not use
-	main: colors.reds[1],
-	bright: colors.reds[2],
+	main: colors.reds[3],
+	bright: colors.reds[4],
 }
 export const success = {
 	400: colors.greens[1],
@@ -51,80 +52,103 @@ export const success = {
 	main: colors.greens[1],
 }
 export const news = {
-	300: colors.reds[0],
-	400: colors.reds[1],
-	500: colors.reds[2],
-	600: colors.reds[3],
-	800: colors.reds[4],
+	100: colors.reds[0],
+	200: colors.reds[1],
+	300: colors.reds[2],
+	400: colors.reds[3],
+	500: colors.reds[4],
+	600: colors.reds[5],
+	800: colors.reds[6],
 
 	// legacy names: please do not use
-	dark: colors.reds[0],
-	main: colors.reds[1],
-	bright: colors.reds[2],
-	pastel: colors.reds[3],
-	faded: colors.reds[4],
+	dark: colors.reds[2],
+	main: colors.reds[3],
+	bright: colors.reds[4],
+	pastel: colors.reds[5],
+	faded: colors.reds[6],
 }
 export const opinion = {
-	300: colors.oranges[0],
-	400: colors.oranges[1],
-	500: colors.oranges[2],
-	600: colors.oranges[3],
-	800: colors.oranges[4],
+	100: colors.oranges[0],
+	200: colors.oranges[1],
+	300: colors.oranges[2],
+	400: colors.oranges[3],
+	500: colors.oranges[4],
+	600: colors.oranges[5],
+	800: colors.oranges[6],
 
 	// legacy names: please do not use
-	dark: colors.oranges[0],
-	main: colors.oranges[1],
-	bright: colors.oranges[2],
-	pastel: colors.oranges[3],
-	faded: colors.oranges[4],
+	dark: colors.oranges[2],
+	main: colors.oranges[3],
+	bright: colors.oranges[4],
+	pastel: colors.oranges[5],
+	faded: colors.oranges[6],
 }
 export const sport = {
-	300: colors.blues[0],
-	400: colors.blues[1],
-	500: colors.blues[2],
-	600: colors.blues[3],
-	800: colors.blues[4],
+	100: colors.blues[0],
+	200: colors.blues[1],
+	300: colors.blues[2],
+	400: colors.blues[3],
+	500: colors.blues[4],
+	600: colors.blues[5],
+	800: colors.blues[6],
 
 	// legacy names: please do not use
-	dark: colors.blues[0],
-	main: colors.blues[1],
-	bright: colors.blues[2],
-	pastel: colors.blues[3],
-	faded: colors.blues[4],
+	dark: colors.blues[2],
+	main: colors.blues[3],
+	bright: colors.blues[4],
+	pastel: colors.blues[5],
+	faded: colors.blues[6],
 }
 export const culture = {
-	300: colors.browns[0],
-	400: colors.browns[1],
-	500: colors.browns[2],
-	600: colors.browns[3],
-	800: colors.browns[4],
+	100: colors.browns[0],
+	200: colors.browns[1],
+	300: colors.browns[2],
+	400: colors.browns[3],
+	500: colors.browns[4],
+	600: colors.browns[5],
+	800: colors.browns[6],
 
 	// legacy names: please do not use
-	dark: colors.browns[0],
-	main: colors.browns[1],
-	bright: colors.browns[2],
-	pastel: colors.browns[3],
-	faded: colors.browns[4],
+	dark: colors.browns[2],
+	main: colors.browns[3],
+	bright: colors.browns[4],
+	pastel: colors.browns[5],
+	faded: colors.browns[6],
 }
 export const lifestyle = {
-	300: colors.pinks[0],
-	400: colors.pinks[1],
-	500: colors.pinks[2],
-	600: colors.pinks[3],
-	800: colors.pinks[4],
+	100: colors.pinks[0],
+	200: colors.pinks[1],
+	300: colors.pinks[2],
+	400: colors.pinks[3],
+	500: colors.pinks[4],
+	600: colors.pinks[5],
+	800: colors.pinks[6],
 
 	// legacy names: please do not use
-	dark: colors.pinks[0],
-	main: colors.pinks[1],
-	bright: colors.pinks[2],
-	pastel: colors.pinks[3],
-	faded: colors.pinks[4],
+	dark: colors.pinks[2],
+	main: colors.pinks[3],
+	bright: colors.pinks[4],
+	pastel: colors.pinks[5],
+	faded: colors.pinks[6],
 }
 export const labs = {
-	300: colors.greens[2],
-	400: colors.greens[3],
+	200: colors.greens[2],
+	300: colors.greens[3],
+	400: colors.greens[4],
 
 	// legacy names: please do not use
-	dark: colors.greens[2],
-	main: colors.greens[3],
+	dark: colors.greens[3],
+	main: colors.greens[4],
+}
+
+export const specialReport = {
+	100: colors.grays[9],
+	200: colors.grays[10],
+	300: colors.grays[11],
+	400: colors.grays[12],
+	500: colors.grays[13],
+}
+
+export const dynamo = {
+	400: colors.grays[14],
 }

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -1,3 +1,27 @@
+// The theme file is based on the specification at https://system-ui.com/theme
+//
+// WARNING!
+//
+// This is an internal file to be consumed by the src-foundations package only
+//
+// It contains the lowest level primitives for the entire design system.
+// Be very, *very* careful when changing the values in here, changes are likely
+// to have a wide-ranging impact across all applications
+//
+// DANGEROUS CHANGES
+//
+// The following will almost certainly require further changes to src-foundations.
+// They will likely also impact every application that consumes src-foundations
+//
+// - Updating a value
+// - Removing a value
+// - Inserting a value into an array
+//
+// SAFE CHANGES
+//
+// - Pushing a value onto the end of an array
+// - Exporting a new object or array
+
 const fontSizes = [12, 15, 17, 20, 24, 28, 34, 42, 50, 70]
 
 const fonts = {

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -19,6 +19,8 @@ const fontWeights = [300, 400, 500, 700]
 // const [sport300, sport400, sport500, sport600, sport800] = colors.blue
 const colors = {
 	reds: [
+		"#660505", //news-100
+		"#8B0000", //news-200
 		"#AB0613", //news-300
 		"#C70000", //news-400
 		"#FF5943", //news-500
@@ -26,6 +28,8 @@ const colors = {
 		"#FFF4F2", //news-800
 	],
 	oranges: [
+		"#672005", //opinion-100
+		"#8D2700", //opinion-200
 		"#BD5318", //opinion-300
 		"#E05E00", //opinion-400
 		"#FF7F0F", //opinion-500
@@ -33,11 +37,14 @@ const colors = {
 		"#FEF9F5", //opinion-800
 	],
 	blues: [
+		"#003C60", //sport-100
+		"#004E7C", //sport-200
 		"#005689", //sport-300
 		"#0084C6", //sport-400
 		"#00B2FF", //sport-500
 		"#90DCFF", //sport-600
 		"#F1F8FC", //sport-800
+		"#001536", //brand-100
 		"#041F4A", //brand-300
 		"#052962", //brand-400
 		"#007ABC", //brand-500
@@ -45,6 +52,8 @@ const colors = {
 		"#C1D8FC", //brand-800
 	],
 	browns: [
+		"#3E3323", //culture-100
+		"#574835", //culture-200
 		"#6B5840", //culture-300
 		"#A1845C", //culture-400
 		"#EACCA0", //culture-500
@@ -52,6 +61,8 @@ const colors = {
 		"#FBF6EF", //culture-800
 	],
 	pinks: [
+		"#510043", //lifestyle-100
+		"#650054", //lifestyle-200
 		"#7D0068", //lifestyle-300
 		"#BB3B80", //lifestyle-400
 		"#FFABDB", //lifestyle-500
@@ -59,16 +70,19 @@ const colors = {
 		"#FEEEF7", //lifestyle-800
 	],
 	yellows: [
-		"#F3C100", //highlight-300
-		"#FFE500", //highlight-400
+		"#F3C100", //brandAlt-200
+		"#FFD900", //brandAlt-300
+		"#FFE500", //brandAlt-400
 	],
 	greens: [
-		"#185E36",
-		"#22874D", //success-400
+		"#185E36", //green-200
+		"#22874D", //green-400
+		"#4B8878", //labs-200
 		"#65A897", //labs-300
 		"#69D1CA", //labs-400
 	],
 	grays: [
+		"#000000", //neutral-0
 		"#121212", //neutral-7
 		"#333333", //neutral-20
 		"#767676", //neutral-46
@@ -77,6 +91,12 @@ const colors = {
 		"#EDEDED", //neutral-93
 		"#F6F6F6", //neutral-97
 		"#FFFFFF", //neutral-100
+		"#222527", //specialReport-100
+		"#303538", //specialReport-200
+		"#3F464A", //specialReport-300
+		"#63717A", //specialReport-400
+		"#ABC2C9", //specialReport-500
+		"#33393D", //dynamo-400
 	],
 }
 


### PR DESCRIPTION
## What is the purpose of this change?

Dark mode is currently supported by apps. Source foundations should be the source of truth for the dark palette.

## What does this change?

- add dark mode colours to palette
- expose new colours as globals
- add usage guidelines to `theme.ts` and `global.ts`

## What does this _not_ change?

In code, `brandAlt[300]` (or `brandAlt.dark`) is defined as `#F3C100`. However, in Figma, it is defined as `#FFD900`. 

Changing the hex value that this name refers to would break the design for a lot of apps that refer directly to the global colour name. I'm in the process of moving these apps over to context-specific colours. When this is done, we can more safely update the value of this colour.