### PR TITLE
Decouple text colours from globals

### DIFF
--- a/src/core/foundations/src/palette/text/brand-alt.ts
+++ b/src/core/foundations/src/palette/text/brand-alt.ts
@@ -1,0 +1,9 @@
+import { neutral } from "../global"
+export const brandAltText = {
+	primary: neutral[7],
+	secondary: neutral[60],
+	buttonPrimary: neutral[100],
+	buttonSecondary: neutral[7],
+	linkPrimary: neutral[7],
+	linkPrimaryHover: neutral[7],
+}

--- a/src/core/foundations/src/palette/text/brand-alt.ts
+++ b/src/core/foundations/src/palette/text/brand-alt.ts
@@ -1,9 +1,28 @@
 import { neutral } from "../global"
+
+const primary = neutral[7]
+const secondary = neutral[60]
+const ctaPrimary = neutral[100]
+const ctaSecondary = neutral[7]
+const linkPrimary = neutral[7]
+
+const root = {
+	primary,
+	secondary,
+}
+
+const button = {
+	buttonPrimary: ctaPrimary,
+	buttonSecondary: ctaSecondary,
+}
+
+const link = {
+	linkPrimary: linkPrimary,
+	linkPrimaryHover: linkPrimary,
+}
+
 export const brandAltText = {
-	primary: neutral[7],
-	secondary: neutral[60],
-	buttonPrimary: neutral[100],
-	buttonSecondary: neutral[7],
-	linkPrimary: neutral[7],
-	linkPrimaryHover: neutral[7],
+	...root,
+	...button,
+	...link,
 }

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -1,15 +1,48 @@
-import { neutral, error, brand } from "../global"
+import { neutral, error as _error, brand } from "../global"
+
+const primary = neutral[100]
+const secondary = brand[800]
+const supporting = brand[800]
+const error = _error[500]
+const ctaPrimary = brand[400]
+const ctaSecondary = neutral[100]
+const anchorPrimary = neutral[100]
+
+const root = {
+	primary,
+	secondary,
+	supporting,
+	error,
+	ctaPrimary,
+	ctaSecondary,
+	anchorPrimary,
+}
+
+const button = {
+	buttonPrimary: ctaPrimary,
+	buttonSecondary: ctaSecondary,
+}
+
+const checkbox = {
+	checkbox: primary,
+	checkboxSupporting: supporting,
+	checkboxIndeterminate: supporting,
+}
+
+const link = {
+	linkPrimary: anchorPrimary,
+	linkPrimaryHover: anchorPrimary,
+}
+
+const radio = {
+	radio: primary,
+	radioSupporting: supporting,
+}
+
 export const brandText = {
-	primary: neutral[100],
-	secondary: brand[800],
-	error: error[500],
-	buttonPrimary: brand[400],
-	buttonSecondary: neutral[100],
-	checkbox: neutral[100],
-	checkboxSupporting: brand[800],
-	checkboxIndeterminate: brand[800],
-	linkPrimary: neutral[100],
-	linkPrimaryHover: neutral[100],
-	radio: neutral[100],
-	radioSupporting: brand[800],
+	...root,
+	...button,
+	...checkbox,
+	...link,
+	...radio,
 }

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -1,0 +1,15 @@
+import { neutral, error, brand } from "../global"
+export const brandText = {
+	primary: neutral[100],
+	secondary: brand[800],
+	error: error[500],
+	buttonPrimary: brand[400],
+	buttonSecondary: neutral[100],
+	checkbox: neutral[100],
+	checkboxSupporting: brand[800],
+	checkboxIndeterminate: brand[800],
+	linkPrimary: neutral[100],
+	linkPrimaryHover: neutral[100],
+	radio: neutral[100],
+	radioSupporting: brand[800],
+}

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -1,0 +1,68 @@
+import { neutral, error as _error, brand } from "../global"
+
+const primary = neutral[7]
+const secondary = neutral[46] //TODO: deprecate?
+const supporting = neutral[46]
+const error = _error[400]
+const ctaPrimary = neutral[100]
+const ctaSecondary = brand[400]
+const anchorPrimary = brand[500]
+const anchorSecondary = neutral[7]
+
+const root = {
+	primary,
+	secondary,
+	supporting,
+	error,
+	ctaPrimary,
+	ctaSecondary,
+	anchorPrimary,
+	anchorSecondary,
+}
+
+const button = {
+	buttonPrimary: ctaPrimary,
+	buttonSecondary: ctaSecondary,
+}
+
+const checkbox = {
+	checkbox: primary,
+	checkboxSupporting: supporting,
+	checkboxIndeterminate: supporting,
+}
+
+const choiceCard = {
+	choiceCard: supporting,
+	choiceCardChecked: ctaSecondary,
+	choiceCardHover: ctaSecondary,
+}
+
+const link = {
+	linkPrimary: anchorPrimary,
+	linkPrimaryHover: anchorPrimary,
+	linkSecondary: anchorSecondary,
+	linkSecondaryHover: anchorSecondary,
+}
+
+const radio = {
+	radio: primary,
+	radioSupporting: supporting,
+}
+
+const textInput = {
+	textInput: primary,
+	textInputLabel: primary,
+	textInputOptionalLabel: supporting,
+	textInputSupporting: supporting,
+	textInputError: error,
+}
+
+export const text = {
+	...root,
+	...button,
+	...checkbox,
+	...choiceCard,
+	...link,
+	...radio,
+	...textInput,
+}

--- a/src/core/foundations/src/palette/text/index.ts
+++ b/src/core/foundations/src/palette/text/index.ts
@@ -1,0 +1,3 @@
+export { text } from "./default"
+export { brandText } from "./brand"
+export { brandAltText } from "./brand-alt"


### PR DESCRIPTION
## What is the purpose of this change?

Many apps still use global colour names predominantly. This leads to brittleness as the values the names refer to may change, leading to sweeping and unpredictable design changes across a large number of applications.

In order to make the system more predictable, we should provide a layer of indirection that lets us specify the context in which colours ought to be used.

Doing so also allows us to see at a glance which colours may be used in a given context for a given theme.

## What does this change?

- add a layer of indirection between global colours and the text-specific colours that get exported
