### PR TITLE
Add dark mode bg colour to theme

### DIFF
--- a/src/core/foundations/src/palette/background/default.ts
+++ b/src/core/foundations/src/palette/background/default.ts
@@ -1,7 +1,7 @@
 import { neutral, brand } from "../global"
 
 const primary = neutral[100]
-const inverse = "#1A1A1A"
+const inverse = neutral[10]
 const checkableChecked = brand[500]
 const ctaPrimary = brand[400]
 const ctaPrimaryHover = "#234B8A"

--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -50,13 +50,14 @@ export const brandYellow = brandAlt
 export const neutral = {
 	0: colors.grays[0],
 	7: colors.grays[1],
-	20: colors.grays[2],
-	46: colors.grays[3],
-	60: colors.grays[4],
-	86: colors.grays[5],
-	93: colors.grays[6],
-	97: colors.grays[7],
-	100: colors.grays[8],
+	10: colors.grays[2],
+	20: colors.grays[3],
+	46: colors.grays[4],
+	60: colors.grays[5],
+	86: colors.grays[6],
+	93: colors.grays[7],
+	97: colors.grays[8],
+	100: colors.grays[9],
 }
 export const error = {
 	400: colors.reds[3],
@@ -163,13 +164,13 @@ export const labs = {
 }
 
 export const specialReport = {
-	100: colors.grays[9],
-	200: colors.grays[10],
-	300: colors.grays[11],
-	400: colors.grays[12],
-	500: colors.grays[13],
+	100: colors.grays[10],
+	200: colors.grays[11],
+	300: colors.grays[12],
+	400: colors.grays[13],
+	500: colors.grays[14],
 }
 
 export const dynamo = {
-	400: colors.grays[14],
+	400: colors.grays[15],
 }

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -108,6 +108,7 @@ const colors = {
 	grays: [
 		"#000000", //neutral-0
 		"#121212", //neutral-7
+		"#1A1A1A", //neutral-10
 		"#333333", //neutral-20
 		"#767676", //neutral-46
 		"#999999", //neutral-60


### PR DESCRIPTION
## What is the purpose of this change?

The dark mode background colour `#1A1A1A` is currently treated as a snowflake, but we should add it to the palette

## What does this change?

Add `#1A1A1A`  to palette (`neutral[10]`)