### PR TITLE
Expose more colours

### DIFF
--- a/src/core/foundations/src/palette/border/brand.ts
+++ b/src/core/foundations/src/palette/border/brand.ts
@@ -1,12 +1,14 @@
-import { neutral, error as _error, brand } from "../global"
+import { neutral, success as _success, error as _error, brand } from "../global"
 
 const primary = brand[800]
+const success = _success[400]
 const error = _error[500]
 const checkableChecked = neutral[100]
 const checkableHover = neutral[100]
 
 const root = {
 	primary,
+	success,
 	error,
 	checkableChecked,
 	checkableHover,

--- a/src/core/foundations/src/palette/border/default.ts
+++ b/src/core/foundations/src/palette/border/default.ts
@@ -1,7 +1,14 @@
-import { neutral, error as _error, brand, sport } from "../global"
+import {
+	neutral,
+	error as _error,
+	success as _success,
+	brand,
+	sport,
+} from "../global"
 
 const primary = neutral[60]
 const secondary = neutral[86]
+const success = _success[400]
 const error = _error[400]
 const checkableChecked = brand[500]
 const checkableHover = brand[500]
@@ -10,6 +17,7 @@ const focusHalo = sport[500]
 const root = {
 	primary,
 	secondary,
+	success,
 	error,
 	checkableChecked,
 	checkableHover,

--- a/src/core/foundations/src/palette/text/brand-alt.ts
+++ b/src/core/foundations/src/palette/text/brand-alt.ts
@@ -1,17 +1,19 @@
 import { neutral } from "../global"
 
 const primary = neutral[7]
-const secondary = neutral[60]
+const secondary = neutral[60] //TODO: deprecate?
+const supporting = neutral[60]
 const ctaPrimary = neutral[100]
 const ctaSecondary = neutral[7]
-const linkPrimary = neutral[7]
+const anchorPrimary = neutral[7]
 
 const root = {
 	primary,
 	secondary,
+	supporting,
 	ctaPrimary,
 	ctaSecondary,
-	linkPrimary,
+	anchorPrimary,
 }
 
 const button = {
@@ -20,8 +22,8 @@ const button = {
 }
 
 const link = {
-	linkPrimary: linkPrimary,
-	linkPrimaryHover: linkPrimary,
+	linkPrimary: anchorPrimary,
+	linkPrimaryHover: anchorPrimary,
 }
 
 export const brandAltText = {

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -1,8 +1,9 @@
-import { neutral, error as _error, brand } from "../global"
+import { neutral, success as _success, error as _error, brand } from "../global"
 
 const primary = neutral[100]
 const secondary = brand[800]
 const supporting = brand[800]
+const success = _success[400]
 const error = _error[500]
 const ctaPrimary = brand[400]
 const ctaSecondary = neutral[100]
@@ -12,6 +13,7 @@ const root = {
 	primary,
 	secondary,
 	supporting,
+	success,
 	error,
 	ctaPrimary,
 	ctaSecondary,

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -1,7 +1,7 @@
 import { neutral, success as _success, error as _error, brand } from "../global"
 
 const primary = neutral[100]
-const secondary = brand[800]
+const secondary = brand[800] //TODO: deprecate?
 const supporting = brand[800]
 const success = _success[400]
 const error = _error[500]

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -1,8 +1,9 @@
-import { neutral, error as _error, brand } from "../global"
+import { neutral, error as _error, success as _success, brand } from "../global"
 
 const primary = neutral[7]
 const secondary = neutral[46] //TODO: deprecate?
 const supporting = neutral[46]
+const success = _success[400]
 const error = _error[400]
 const ctaPrimary = neutral[100]
 const ctaSecondary = brand[400]
@@ -13,6 +14,7 @@ const root = {
 	primary,
 	secondary,
 	supporting,
+	success,
 	error,
 	ctaPrimary,
 	ctaSecondary,


### PR DESCRIPTION
## What is the purpose of this change?

Success colours are missing from brand and default themes. We should add them

## What does this change?

- expose success colours in default and brand themes for text and border
- correct some of the colour names we were exposing
