### PR TITLE
Temporarily stop generating types for grid

### DIFF
--- a/src/core/components/grid/package.json
+++ b/src/core/components/grid/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/grid.js",
 	"module": "dist/grid.esm.js",
 	"scripts": {
-		"build": "yarn clean && tsc && rollup --config",
+		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist *.d.ts",
 		"prepublish": "yarn build"
 	},


### PR DESCRIPTION
## What is the purpose of this change?

Because we import common/props from a relative path outside of the grid's directory, TypeScript builds a really strange directory structure for the types it generates!

Rather than fix the problem, let's temporarily disable type generation. I honestly can't remember why we started doing this in the first place. Maybe this will jog my memory 😬 

## What does this change?

- temporarily stop generating types for grid
