### PR TITLE
Thicken border on check and hover

### DIFF
--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -21,6 +21,7 @@ export const input = ({
 
 	&:checked + label {
 		color: ${choiceCard.textChecked};
+		border-width: 4px;
 		border-color: ${choiceCard.borderColorChecked};
 		background-color: ${choiceCard.backgroundChecked};
 	}
@@ -56,6 +57,7 @@ export const choiceCard = ({
 
 	&:hover {
 		color: ${choiceCard.textChecked};
+		border-width: 4px;
 		border-color: ${choiceCard.borderColorChecked};
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

The choice card border needs to be 4px on hover and when the choice card is checked.

## What does this change?

- thicken border

## Design

### Screenshots

**Before**

![Screenshot 2020-03-02 at 10 32 09](https://user-images.githubusercontent.com/5931528/75668336-17e27b80-5c71-11ea-83f6-ea4109a58987.png)

**After**

![Screenshot 2020-03-02 at 10 31 47](https://user-images.githubusercontent.com/5931528/75668334-1749e500-5c71-11ea-9049-f7dc88685d61.png)
