### PR TITLE
add focus halo to choice card

### DIFF
--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -19,6 +19,10 @@ export const input = ({
 }: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
 	${visuallyHidden};
 
+	&:focus + label {
+		${focusHalo};
+	}
+
 	&:checked + label {
 		color: ${choiceCard.textChecked};
 		border-width: 4px;
@@ -50,10 +54,6 @@ export const choiceCard = ({
 	color: ${choiceCard.text};
 	${textSans.medium({ fontWeight: "bold" })};
 	cursor: pointer;
-
-	&:focus {
-		${focusHalo};
-	}
 
 	&:hover {
 		color: ${choiceCard.textChecked};


### PR DESCRIPTION
## What is the purpose of this change?

Focus halo is currently missing form choice card, but it is needed to help keyboard users see where the focus is

## What does this change?

Adds focus halo to choice card when underlying form control is focused

## Design

![Screenshot 2020-03-02 at 10 46 16](https://user-images.githubusercontent.com/5931528/75669515-1023d680-5c73-11ea-860c-77f3323c5075.png)

### Screenshots

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
