### PR TITLE
Move focus style manager to foundations

### DIFF
--- a/src/core/foundations/.babelrc.js
+++ b/src/core/foundations/.babelrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-	presets: ["@babel/preset-env", "@babel/preset-typescript"]
-};
+	presets: ["@babel/preset-env", "@babel/preset-typescript"],
+	plugins: ["@babel/plugin-proposal-class-properties"],
+}

--- a/src/core/foundations/.gitignore
+++ b/src/core/foundations/.gitignore
@@ -4,6 +4,7 @@ accessibility/
 palette/
 themes/
 typography/
+utils/
 foundations.js
 foundations.esm.js
 *.d.ts
@@ -15,3 +16,4 @@ foundations.esm.js
 !src/palette
 !src/themes/
 !src/typography/
+!src/utils/

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "rollup --config --watch",
-		"clean": "rm -rf accessibility mq palette themes typography foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
+		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
 		"prepublishOnly": "yarn build",
 		"postpublish": "yarn clean"
 	},
@@ -32,7 +32,8 @@
 		"src/mq/index.ts",
 		"src/palette/**",
 		"src/themes/**",
-		"src/typography/index.ts"
+		"src/typography/index.ts",
+		"src/utils/**"
 	],
 	"devDependencies": {
 		"@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -35,6 +35,7 @@
 		"src/typography/index.ts"
 	],
 	"devDependencies": {
+		"@babel/plugin-proposal-class-properties": "^7.8.3",
 		"@babel/preset-env": "^7.8.0",
 		"@babel/preset-typescript": "^7.8.0",
 		"rollup": "^1.19.4",

--- a/src/core/foundations/rollup.config.js
+++ b/src/core/foundations/rollup.config.js
@@ -4,19 +4,24 @@ import resolve from "rollup-plugin-node-resolve"
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
 
-const folders = ["accessibility", "mq", "palette", "themes", "typography"].map(
-	folder => ({
-		input: `src/${folder}/index.ts`,
-		output: [
-			{
-				file: `${folder}/index.js`,
-				format: "cjs",
-			},
-		],
-		plugins,
-		external: ["@guardian/src-foundations"],
-	}),
-)
+const folders = [
+	"accessibility",
+	"mq",
+	"palette",
+	"themes",
+	"typography",
+	"utils",
+].map(folder => ({
+	input: `src/${folder}/index.ts`,
+	output: [
+		{
+			file: `${folder}/index.js`,
+			format: "cjs",
+		},
+	],
+	plugins,
+	external: ["@guardian/src-foundations"],
+}))
 
 module.exports = [
 	{

--- a/src/core/foundations/src/utils/focus-style-manager.ts
+++ b/src/core/foundations/src/utils/focus-style-manager.ts
@@ -1,0 +1,69 @@
+const TAB_KEY_CODE = 9
+
+/**
+ * Source: Blueprint https://blueprintjs.com/
+ * https://github.com/palantir/blueprint/blob/06a186c90758bbdca604ed6d7bf639c3d05b1fa0/packages/core/src/common/interactionMode.ts
+ * A nifty little class that maintains event handlers to add a class to the container element
+ * when entering "mouse mode" (on a `mousedown` event) and remove it when entering "keyboard mode"
+ * (on a `tab` key `keydown` event).
+ * Requires @babel/plugin-proposal-class-properties
+ */
+export class InteractionModeEngine {
+	private isRunning = false
+
+	// tslint:disable-next-line:no-constructor-vars
+	constructor(private container: Element, private className: string) {}
+
+	/** Returns whether the engine is currently running. */
+	public isActive() {
+		return this.isRunning
+	}
+
+	/** Enable behavior which applies the given className when in mouse mode. */
+	public start() {
+		this.container.addEventListener("mousedown", this.handleMouseDown)
+		this.isRunning = true
+	}
+
+	/** Disable interaction mode behavior and remove className from container. */
+	public stop() {
+		this.reset()
+		this.isRunning = false
+	}
+
+	private reset() {
+		this.container.classList.remove(this.className)
+		this.container.removeEventListener("keydown", this.handleKeyDown as (
+			evt: Event,
+		) => void)
+		this.container.removeEventListener("mousedown", this.handleMouseDown)
+	}
+
+	private handleKeyDown = (e: KeyboardEvent) => {
+		if (e.which === TAB_KEY_CODE) {
+			this.reset()
+			this.container.addEventListener("mousedown", this.handleMouseDown)
+		}
+	}
+
+	private handleMouseDown = () => {
+		this.reset()
+		this.container.classList.add(this.className)
+		this.container.addEventListener("keydown", this.handleKeyDown as (
+			evt: Event,
+		) => void)
+	}
+}
+
+const FOCUS_DISABLED = "src-focus-disabled"
+
+const focusEngine = new InteractionModeEngine(
+	document.documentElement,
+	FOCUS_DISABLED,
+)
+
+export const FocusStyleManager = {
+	alwaysShowFocus: () => focusEngine.stop(),
+	isActive: () => focusEngine.isActive(),
+	onlyShowFocusOnTabs: () => focusEngine.start(),
+}

--- a/src/core/foundations/src/utils/index.ts
+++ b/src/core/foundations/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { FocusStyleManager } from "./focus-style-manager"

--- a/yarn.lock
+++ b/yarn.lock
@@ -717,6 +717,14 @@
     "@babel/helper-create-class-features-plugin" "^7.7.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz#5e06654af5cd04b608915aada9b2a6788004464e"
+  integrity sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+
 "@babel/plugin-proposal-dynamic-import@^7.5.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz#e532202db4838723691b10a67b8ce509e397c506"


### PR DESCRIPTION
## What is the purpose of this change?

The focus style manager allows developers to disable the focus style until a user hits the tab key. This is a frequently-requested and important piece of functionality, and as such belongs in our foundations rather than in a separate installable utilities package.

## What does this change?

- add the focus style manager to foundations
- install `@babel/plugin-proposal-class-properties` into foundations
