### PR TITLE
Use box shadow to apply choice card border

### DIFF
--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
 import { ChoiceCardGroup, ChoiceCard, choiceCardDefault } from "./index"
 import { ThemeProvider } from "emotion-theming"
@@ -20,13 +21,19 @@ export default {
 	title: "ChoiceCard",
 }
 
+const narrow = css`
+	width: 20em;
+`
+
 const singleStateLight = () => (
 	<ThemeProvider theme={choiceCardDefault}>
-		<ChoiceCardGroup name="colours">
-			{choiceCards.map((choiceCard, index) =>
-				React.cloneElement(choiceCard, { key: index }),
-			)}
-		</ChoiceCardGroup>
+		<div css={narrow}>
+			<ChoiceCardGroup name="colours">
+				{choiceCards.map((choiceCard, index) =>
+					React.cloneElement(choiceCard, { key: index }),
+				)}
+			</ChoiceCardGroup>
+		</div>
 	</ThemeProvider>
 )
 
@@ -41,11 +48,13 @@ singleStateLight.story = {
 
 const multiStateLight = () => (
 	<ThemeProvider theme={choiceCardDefault}>
-		<ChoiceCardGroup name="colours" multi={true}>
-			{choiceCards.map((choiceCard, index) =>
-				React.cloneElement(choiceCard, { key: index }),
-			)}
-		</ChoiceCardGroup>
+		<div css={narrow}>
+			<ChoiceCardGroup name="colours" multi={true}>
+				{choiceCards.map((choiceCard, index) =>
+					React.cloneElement(choiceCard, { key: index }),
+				)}
+			</ChoiceCardGroup>
+		</div>
 	</ThemeProvider>
 )
 

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -25,8 +25,7 @@ export const input = ({
 
 	&:checked + label {
 		color: ${choiceCard.textChecked};
-		border-width: 4px;
-		border-color: ${choiceCard.borderColorChecked};
+		box-shadow: inset 0 0 0 4px ${choiceCard.borderColorChecked};
 		background-color: ${choiceCard.backgroundChecked};
 	}
 `
@@ -43,11 +42,8 @@ export const choiceCard = ({
 	margin: 0 ${space[2]}px 0 0;
 	align-items: center;
 	justify-content: center;
-
-	border-width: 2px;
-	border-style: solid;
 	/* TODO: prefer curentColor unless it has to be different to text colour */
-	border-color: ${choiceCard.borderColor};
+	box-shadow: inset 0 0 0 2px ${choiceCard.borderColor};
 	border-radius: 4px;
 	position: relative;
 
@@ -57,7 +53,6 @@ export const choiceCard = ({
 
 	&:hover {
 		color: ${choiceCard.textChecked};
-		border-width: 4px;
-		border-color: ${choiceCard.borderColorChecked};
+		box-shadow: inset 0 0 0 4px ${choiceCard.borderColorChecked};
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

Using the border property to change the style of the border on hover
causes the layout to jump if the Choice Cards are < 150px wide. By
using `box-shadow: inset`, the border style is always applied within
the bounds of the Choice Card's label element, so the width of the
element is not changed.

Thanks to @tjsilver for spotting and helping to debug this issue

## What does this change?

- use box-shadow instead of border to apply Choice Card border style
- constrain width of Choice Cards in stories to better demonstrate the issue. This might catch future issues.

## Design

### Screenshots

**Before**

![Mar-02-2020 12-57-02](https://user-images.githubusercontent.com/5931528/75678330-54b86d80-5c85-11ea-9c1c-16c8145c0ba8.gif)

**After**

![Mar-02-2020 12-56-26](https://user-images.githubusercontent.com/5931528/75678344-5da93f00-5c85-11ea-8c33-c3847fd6b24c.gif)

