### PR TITLE
Remove right margin from last choice card in group

### DIFF
--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -51,6 +51,10 @@ export const choiceCard = ({
 	${textSans.medium({ fontWeight: "bold" })};
 	cursor: pointer;
 
+	&:last-child {
+		margin: 0;
+	}
+
 	&:hover {
 		color: ${choiceCard.textChecked};
 		box-shadow: inset 0 0 0 4px ${choiceCard.borderColorChecked};


### PR DESCRIPTION
## What is the purpose of this change?

There's a right margin at the end of the choice card group that definitely doesn't belong there! We should remove it.

Thanks to @tjsilver and @jlieb10

## What does this change?

- remove right margin the last child choice card

## Design

### Screenshots

![Screenshot 2020-03-02 at 16 24 41](https://user-images.githubusercontent.com/5931528/75695666-59d7e580-5ca2-11ea-9472-ccbd173bba6a.png)
