### PR TITLE
Point brandAlt[300] (dark) at correct hex value

### DIFF
--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -38,11 +38,11 @@ export const brand = {
 }
 export const brandAlt = {
 	200: colors.yellows[0],
-	300: colors.yellows[0], // TODO: update to colors.yellow[1] (#FFD900)
+	300: colors.yellows[1],
 	400: colors.yellows[2],
 
 	// legacy names: please do not use
-	dark: colors.yellows[0], // TODO: update to colors.yellow[1] (#FFD900)
+	dark: colors.yellows[1],
 	main: colors.yellows[2],
 }
 // continue to expose legacy name for compatibility


### PR DESCRIPTION
## What is the purpose of this change?

As part of the introduction of dark mode, the value of `brandYellow.dark` has to change from `#F3C100` to `#FFD900`. The value `#F3C100` is now considered "extra dark" 🌚  and has been moved further down the numeric brightness scale as a result.

This should be treated as a breaking change to the design. The only reference I found to this global colour has been fixed in guardian/contributions-service#55

## What does this change?

- point `brandAlt[300]` (or `brandAlt.dark`) at the value `#FFD900`
