### PR TITLE
Denounce the palette export

### DIFF
--- a/src/core/foundations/src/accessibility/index.ts
+++ b/src/core/foundations/src/accessibility/index.ts
@@ -1,4 +1,4 @@
-import { palette } from "../index"
+import { border } from "../index"
 
 const visuallyHidden = `
 	position: absolute;
@@ -12,7 +12,7 @@ const visuallyHidden = `
 const focusHalo = `
 	outline: 0;
 	html:not(.src-focus-disabled) & {
-		box-shadow: 0 0 0 5px ${palette.border.focusHalo};
+		box-shadow: 0 0 0 5px ${border.focusHalo};
 		z-index: 9;
 	}
 `

--- a/src/core/foundations/src/index.ts
+++ b/src/core/foundations/src/index.ts
@@ -4,6 +4,18 @@ export * from "./palette"
 export * from "./size"
 export * from "./space"
 
+// Avoid importing the entire palette directly in your application. Prefer using the named exports
+// defined within the /palette folder
+//
+// Why?
+// 1) The entire palette consists of global + functional colours. This entails importing a lot of
+// largely usused or repeated values
+// 2) The palette is guaranteed to grow over time, as more components and functional colours are
+// added.
+//
+// Why is it even here?
+// Legacy reasons. Also for developer experience when prototyping.
+
 import {
 	background,
 	border,


### PR DESCRIPTION
## What is the purpose of this change?

The palette export is expensive and guaranteed to get heavier over time. It should be avoided at all costs.

## What does this change?

- add a public service announcement denouncing the `palette` export
- get the focusHalo colour from a named export rather than the full palette object
