### PR TITLE
Move common props to helpers

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -22,7 +22,7 @@ import {
 	iconOnlySmall,
 	iconNudgeAnimation,
 } from "./styles"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 export {
 	buttonDefault,

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -15,13 +15,13 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
 		"rollup-plugin-node-resolve": "^5.2.0"
 	},
 	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0",
 		"@guardian/src-svgs": "^0.15.0"
 	},
 	"files": [

--- a/src/core/components/checkbox/index.tsx
+++ b/src/core/components/checkbox/index.tsx
@@ -13,7 +13,7 @@ import {
 	tickWithSupportingText,
 	errorCheckbox,
 } from "./styles"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 export {
 	checkboxDefault,

--- a/src/core/components/checkbox/package.json
+++ b/src/core/components/checkbox/package.json
@@ -15,7 +15,6 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -32,6 +31,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0",
 		"@guardian/src-inline-error": "^0.15.0"
 	}
 }

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
 import { fieldset, input, choiceCard } from "./styles"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
 

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -30,5 +30,8 @@
 		"@emotion/core": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
 		"react": "^16.8.6"
+	},
+	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0"
 	}
 }

--- a/src/core/components/grid/index.tsx
+++ b/src/core/components/grid/index.tsx
@@ -11,7 +11,7 @@ import {
 	createCustomGridRow,
 } from "./styles"
 import { CustomBreakpoint, GridBreakpoint } from "./data"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 type GridRowBreakpoints = {
 	[key in GridBreakpoint]: SerializedStyles

--- a/src/core/components/grid/package.json
+++ b/src/core/components/grid/package.json
@@ -4,7 +4,7 @@
 	"main": "dist/grid.js",
 	"module": "dist/grid.esm.js",
 	"scripts": {
-		"build": "yarn clean && rollup --config",
+		"build": "yarn clean && tsc && rollup --config",
 		"clean": "rm -rf dist *.d.ts",
 		"prepublish": "yarn build"
 	},
@@ -15,7 +15,6 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -33,5 +32,8 @@
 		"@emotion/core": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
 		"react": "^16.8.6"
+	},
+	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0"
 	}
 }

--- a/src/core/components/inline-error/index.tsx
+++ b/src/core/components/inline-error/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
 import { SvgAlert } from "@guardian/src-svgs"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 import { inlineError } from "./styles"
 export {
 	inlineErrorLight,

--- a/src/core/components/inline-error/package.json
+++ b/src/core/components/inline-error/package.json
@@ -15,7 +15,6 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -32,6 +31,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0",
 		"@guardian/src-svgs": "^0.15.0"
 	}
 }

--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -10,7 +10,7 @@ import {
 	iconRight,
 	iconLeft,
 } from "./styles"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 export {
 	linkLight,

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -31,5 +31,8 @@
 		"@emotion/core": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
 		"react": "^16.8.6"
+	},
+	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0"
 	}
 }

--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -12,7 +12,7 @@ import {
 	vertical,
 	errorRadio,
 } from "./styles"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 export { radioBrand, radioDefault } from "@guardian/src-foundations/themes"
 

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -15,7 +15,6 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -32,6 +31,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0",
 		"@guardian/src-inline-error": "^0.15.0",
 		"@guardian/src-svgs": "^0.15.0"
 	}

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -12,7 +12,7 @@ import {
 	optionalLabel,
 	supportingText,
 } from "./styles"
-import { Props } from "../../../common/props"
+import { Props } from "@guardian/src-helpers"
 
 export { textInputLight } from "@guardian/src-foundations/themes"
 export type Width = 30 | 10 | 4

--- a/src/core/components/text-input/package.json
+++ b/src/core/components/text-input/package.json
@@ -15,7 +15,6 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
@@ -32,6 +31,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
+		"@guardian/src-helpers": "^0.15.0",
 		"@guardian/src-inline-error": "^0.15.0"
 	}
 }

--- a/src/core/helpers/README.md
+++ b/src/core/helpers/README.md
@@ -1,9 +1,3 @@
 # Helpers
 
-Shared helper functions and types to assist with the development of components.
-
-**This package is not intended for publication**
-
-**Please don't add code intended for use in production**
-
-**Please don't add to the `dependencies` of any component. Prefer `devDependencies`**
+Shared helper functions and types used across all components.

--- a/src/core/helpers/package.json
+++ b/src/core/helpers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-helpers",
-	"version": "0.0.1",
+	"version": "0.15.0",
 	"main": "index.js",
 	"license": "MIT",
 	"dependencies": {

--- a/src/core/helpers/types.ts
+++ b/src/core/helpers/types.ts
@@ -1,6 +1,13 @@
+import { SerializedStyles } from "@emotion/core"
+
 export type ThemeName =
 	| "default"
 	| "light"
 	| "brand"
 	| "brandYellow"
 	| "brandAlt"
+
+export interface Props {
+	className?: string
+	cssOverrides?: SerializedStyles | SerializedStyles[]
+}


### PR DESCRIPTION
## What is the purpose of this change?

Common props needs to be published somewhere so cosumers of our components can access it. Helpers is a handy place for now. We can think about moving to `@guardian/types` when the repo is a bit more settled.

## What does this change?

- move common props to helpers
- move helpers to dependencies of every component
- reduce the helpers readme
