### PR TITLE
Remove alpha component from choice card background colour

### DIFF
--- a/src/core/foundations/src/themes/choice-card.ts
+++ b/src/core/foundations/src/themes/choice-card.ts
@@ -19,7 +19,7 @@ export const choiceCardDefault: {
 		text: text.choiceCard,
 		borderColor: border.choiceCard,
 		textChecked: text.choiceCardChecked,
-		backgroundChecked: "rgba(0, 178, 255, 0.26)",
+		backgroundChecked: "#BDEBFF",
 		borderColorChecked: border.choiceCardChecked,
 		textHover: text.choiceCardHover,
 		borderColorHover: border.choiceCardHover,


### PR DESCRIPTION
## What is the purpose of this change?

The choice card background colour currently has an alpha (opacity) component and for no good reason, since it's always used on a white background.

We should convert this to a norma (snowflakey) hex value for maximum browser support and colour format consistency.

## What does this change?

- update choice card background colour to `#BDEBFF`

## Design

No visual change

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
