### PR TITLE
Add Space 4

### DIFF
--- a/src/core/foundations/src/space.ts
+++ b/src/core/foundations/src/space.ts
@@ -6,11 +6,12 @@ const space = {
 	1: _space[1],
 	2: _space[2],
 	3: _space[3],
-	5: _space[4],
-	6: _space[5],
-	9: _space[6],
-	12: _space[7],
-	24: _space[8],
+	4: _space[4],
+	5: _space[5],
+	6: _space[6],
+	9: _space[7],
+	12: _space[8],
+	24: _space[9],
 }
 
 const pxToRem = (px: number): string => `${px / rootPixelFontSize}rem`
@@ -19,6 +20,7 @@ const remSpace: { [K in keyof (typeof space)]: string } = {
 	1: pxToRem(space[1]),
 	2: pxToRem(space[2]),
 	3: pxToRem(space[3]),
+	4: pxToRem(space[4]),
 	5: pxToRem(space[5]),
 	6: pxToRem(space[6]),
 	9: pxToRem(space[9]),

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -125,7 +125,7 @@ const colors = {
 	],
 }
 
-const space = [0, 4, 8, 12, 20, 24, 36, 48, 96]
+const space = [0, 4, 8, 12, 16, 20, 24, 36, 48, 96]
 
 const size = [24, 36, 44]
 


### PR DESCRIPTION
## What is the purpose of this change?

We don't have a space `4` in the design system, but we do use it, for example in paragraph spacing on dotcom.

## What does this change?

- Added `16` to spaces in `theme.ts`
- Updated space module to account for new space (`4`)

## Design

This introduces a new space, number `4`, equiv to `16px` or `1rem`
