### PR TITLE
Add group label for choice card group

### DIFF
--- a/src/core/components/choice-card/README.md
+++ b/src/core/components/choice-card/README.md
@@ -15,7 +15,11 @@ import { ChoiceCardGroup, ChoiceCard } from "@guardian/src-choice-card"
 
 const Form = () => (
     <form>
-        <ChoiceCardGroup name="consent" multi={false}>
+        <ChoiceCardGroup
+            name="consent"
+            label="Do you accept the terms?"
+            multi={false}
+        >
             <ChoiceCard
                 value="no"
                 label="No"
@@ -39,6 +43,12 @@ const Form = () => (
 **`string`**
 
 Gets passed as the name attribute for each choice card
+
+### `label`
+
+**`string`**
+
+Set as the legend for the fieldset
 
 ### `multi`
 

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -1,11 +1,18 @@
 import React, { ReactNode } from "react"
-import { fieldset, input, choiceCard } from "./styles"
+import {
+	fieldset,
+	flexContainer,
+	groupLabel,
+	input,
+	choiceCard,
+} from "./styles"
 import { Props } from "@guardian/src-helpers"
 
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
 
 interface ChoiceCardGroupProps extends Props {
 	name: string
+	label?: string
 	multi?: boolean
 	error?: string
 	children: JSX.Element | JSX.Element[]
@@ -13,29 +20,33 @@ interface ChoiceCardGroupProps extends Props {
 
 const ChoiceCardGroup = ({
 	name,
+	label,
 	multi,
 	error,
 	cssOverrides,
 	children,
 	...props
 }: ChoiceCardGroupProps) => {
-	// TODO: This is currently a div instead of a fieldset due to a Chrome / Safari
-	// bug that prevents flexbox model working on fieldset elements
-	// https://bugs.chromium.org/p/chromium/issues/detail?id=375693
 	return (
-		<div css={[fieldset, cssOverrides]} {...props}>
-			{React.Children.map(children, child => {
-				return React.cloneElement(
-					child,
-					Object.assign(
-						{ error: !!error, type: multi ? "checkbox" : "radio" },
-						{
-							name,
-						},
-					),
-				)
-			})}
-		</div>
+		<fieldset css={[fieldset, cssOverrides]} {...props}>
+			{label ? <legend css={groupLabel}>{label}</legend> : ""}
+			<div css={flexContainer}>
+				{React.Children.map(children, child => {
+					return React.cloneElement(
+						child,
+						Object.assign(
+							{
+								error: !!error,
+								type: multi ? "checkbox" : "radio",
+							},
+							{
+								name,
+							},
+						),
+					)
+				})}
+			</div>
+		</fieldset>
 	)
 }
 

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -67,6 +67,30 @@ multiStateLight.story = {
 	},
 }
 
+const singleStateWithLabelLight = () => (
+	<ThemeProvider theme={choiceCardDefault}>
+		<div css={narrow}>
+			<ChoiceCardGroup
+				name="colours"
+				label="What is your favourite colour?"
+			>
+				{choiceCards.map((choiceCard, index) =>
+					React.cloneElement(choiceCard, { key: index }),
+				)}
+			</ChoiceCardGroup>
+		</div>
+	</ThemeProvider>
+)
+
+singleStateWithLabelLight.story = {
+	name: `single state with label light`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+	},
+}
+
 // const errorLight = () => (
 // 	<ThemeProvider theme={choiceCardDefault}>
 // 		<ChoiceCardGroup name="colours" error="Please select a colour">
@@ -86,4 +110,4 @@ multiStateLight.story = {
 // 	},
 // }
 
-export { singleStateLight, multiStateLight }
+export { singleStateLight, multiStateLight, singleStateWithLabelLight }

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -9,9 +9,21 @@ import {
 } from "@guardian/src-foundations/themes"
 
 export const fieldset = css`
+	border: 0;
+`
+
+// TODO: This is currently applied to a div instead of the fieldset
+// due to a Chrome / Safari bug that prevents flexbox model working
+// on fieldset elements
+// https://bugs.chromium.org/p/chromium/issues/detail?id=375693
+export const flexContainer = css`
 	display: flex;
 	justify-content: flex-start;
-	border: 0;
+`
+
+export const groupLabel = css`
+	${textSans.medium({ fontWeight: "bold" })};
+	margin-bottom: ${space[1]}px;
 `
 
 export const input = ({


### PR DESCRIPTION
## What is the purpose of this change?

A group of choice cards is bound by a common purpose that may be expressed by a label above the group

## What does this change?

- add a label prop to ChoiceCardGroup that accepts a string and renders it as a legend
- work around Chromium issue in which fieldset children can't be laid out with flex

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots
<img width="324" alt="Screenshot 2020-03-04 at 23 39 58" src="https://user-images.githubusercontent.com/5931528/75933279-7c6c2900-5e71-11ea-92b2-1618fde4585e.png">

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
