### PR TITLE
Avoid component colors

### DIFF
--- a/src/core/foundations/src/palette/background/brand.ts
+++ b/src/core/foundations/src/palette/background/brand.ts
@@ -1,7 +1,7 @@
 import { neutral, brand } from "../global"
 
 const primary = brand[400]
-const checkableChecked = neutral[100]
+const inputChecked = neutral[100]
 const ctaPrimary = neutral[100]
 const ctaPrimaryHover = "#E0E0E0"
 const ctaSecondary = brand[600]
@@ -9,7 +9,7 @@ const ctaSecondaryHover = "#234B8A"
 
 const root = {
 	primary,
-	checkableChecked,
+	inputChecked,
 	ctaPrimary,
 	ctaPrimaryHover,
 	ctaSecondary,
@@ -24,11 +24,11 @@ const button = {
 }
 
 const checkbox = {
-	checkboxChecked: checkableChecked,
+	checkboxChecked: inputChecked,
 }
 
 const radio = {
-	radioChecked: checkableChecked,
+	radioChecked: inputChecked,
 }
 
 export const brandBackground = {

--- a/src/core/foundations/src/palette/background/default.ts
+++ b/src/core/foundations/src/palette/background/default.ts
@@ -2,20 +2,22 @@ import { neutral, brand } from "../global"
 
 const primary = neutral[100]
 const inverse = neutral[10]
-const checkableChecked = brand[500]
 const ctaPrimary = brand[400]
 const ctaPrimaryHover = "#234B8A"
 const ctaSecondary = brand[800]
 const ctaSecondaryHover = "#ACC9F7"
+const input = neutral[100]
+const inputChecked = brand[500]
 
 const root = {
 	primary,
 	inverse,
-	checkableChecked,
 	ctaPrimary,
 	ctaPrimaryHover,
 	ctaSecondary,
 	ctaSecondaryHover,
+	input,
+	inputChecked,
 }
 
 const button = {
@@ -26,15 +28,15 @@ const button = {
 }
 
 const checkbox = {
-	checkboxChecked: checkableChecked,
+	checkboxChecked: inputChecked,
 }
 
 const radio = {
-	radioChecked: checkableChecked,
+	radioChecked: inputChecked,
 }
 
 const textInput = {
-	textInput: primary,
+	textInput: input,
 }
 
 export const background = {

--- a/src/core/foundations/src/palette/border/brand.ts
+++ b/src/core/foundations/src/palette/border/brand.ts
@@ -3,27 +3,29 @@ import { neutral, success as _success, error as _error, brand } from "../global"
 const primary = brand[800]
 const success = _success[400]
 const error = _error[500]
-const checkableChecked = neutral[100]
-const checkableHover = neutral[100]
+const input = brand[800]
+const inputChecked = neutral[100]
+const inputHover = neutral[100]
 
 const root = {
 	primary,
 	success,
 	error,
-	checkableChecked,
-	checkableHover,
+	input,
+	inputChecked,
+	inputHover,
 }
 
 const checkbox = {
-	checkbox: primary,
-	checkboxHover: checkableHover,
-	checkboxChecked: checkableChecked,
+	checkbox: input,
+	checkboxHover: inputHover,
+	checkboxChecked: inputChecked,
 	checkboxError: error,
 }
 
 const radio = {
-	radio: primary,
-	radioHover: checkableHover,
+	radio: input,
+	radioHover: inputHover,
 	radioError: error,
 }
 

--- a/src/core/foundations/src/palette/border/default.ts
+++ b/src/core/foundations/src/palette/border/default.ts
@@ -10,8 +10,9 @@ const primary = neutral[60]
 const secondary = neutral[86]
 const success = _success[400]
 const error = _error[400]
-const checkableChecked = brand[500]
-const checkableHover = brand[500]
+const input = neutral[60]
+const inputChecked = brand[500]
+const inputHover = brand[500]
 const focusHalo = sport[500]
 
 const root = {
@@ -19,32 +20,33 @@ const root = {
 	secondary,
 	success,
 	error,
-	checkableChecked,
-	checkableHover,
+	input,
+	inputChecked,
+	inputHover,
 	focusHalo,
 }
 
 const checkbox = {
-	checkbox: primary,
-	checkboxHover: checkableHover,
-	checkboxChecked: checkableChecked,
+	checkbox: input,
+	checkboxHover: inputHover,
+	checkboxChecked: inputChecked,
 	checkboxError: error,
 }
 
 const choiceCard = {
-	choiceCard: primary,
-	choiceCardHover: checkableHover,
-	choiceCardChecked: checkableChecked,
+	choiceCard: input,
+	choiceCardHover: inputHover,
+	choiceCardChecked: inputChecked,
 }
 
 const radio = {
-	radio: primary,
-	radioHover: checkableHover,
+	radio: input,
+	radioHover: inputHover,
 	radioError: error,
 }
 
 const textInput = {
-	textInput: primary,
+	textInput: input,
 	textInputError: error,
 }
 

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -8,6 +8,8 @@ const error = _error[500]
 const ctaPrimary = brand[400]
 const ctaSecondary = neutral[100]
 const anchorPrimary = neutral[100]
+const input = neutral[100]
+const inputSupporting = brand[800]
 
 const root = {
 	primary,
@@ -18,6 +20,8 @@ const root = {
 	ctaPrimary,
 	ctaSecondary,
 	anchorPrimary,
+	input,
+	inputSupporting,
 }
 
 const button = {
@@ -26,9 +30,9 @@ const button = {
 }
 
 const checkbox = {
-	checkbox: primary,
-	checkboxSupporting: supporting,
-	checkboxIndeterminate: supporting,
+	checkbox: input,
+	checkboxSupporting: inputSupporting,
+	checkboxIndeterminate: inputSupporting,
 }
 
 const link = {
@@ -37,8 +41,8 @@ const link = {
 }
 
 const radio = {
-	radio: primary,
-	radioSupporting: supporting,
+	radio: input,
+	radioSupporting: inputSupporting,
 }
 
 export const brandText = {

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -9,6 +9,10 @@ const ctaPrimary = neutral[100]
 const ctaSecondary = brand[400]
 const anchorPrimary = brand[500]
 const anchorSecondary = neutral[7]
+const input = neutral[7]
+const inputSupporting = neutral[46]
+const inputChecked = brand[400]
+const inputHover = brand[400]
 
 const root = {
 	primary,
@@ -20,6 +24,10 @@ const root = {
 	ctaSecondary,
 	anchorPrimary,
 	anchorSecondary,
+	input,
+	inputSupporting,
+	inputChecked,
+	inputHover,
 }
 
 const button = {
@@ -28,15 +36,15 @@ const button = {
 }
 
 const checkbox = {
-	checkbox: primary,
-	checkboxSupporting: supporting,
-	checkboxIndeterminate: supporting,
+	checkbox: input,
+	checkboxSupporting: inputSupporting,
+	checkboxIndeterminate: inputSupporting,
 }
 
 const choiceCard = {
-	choiceCard: supporting,
-	choiceCardChecked: ctaSecondary,
-	choiceCardHover: ctaSecondary,
+	choiceCard: inputSupporting,
+	choiceCardChecked: inputChecked,
+	choiceCardHover: inputChecked,
 }
 
 const link = {
@@ -47,15 +55,15 @@ const link = {
 }
 
 const radio = {
-	radio: primary,
-	radioSupporting: supporting,
+	radio: input,
+	radioSupporting: inputSupporting,
 }
 
 const textInput = {
-	textInput: primary,
-	textInputLabel: primary,
-	textInputOptionalLabel: supporting,
-	textInputSupporting: supporting,
+	textInput: input,
+	textInputLabel: input,
+	textInputOptionalLabel: inputSupporting,
+	textInputSupporting: inputSupporting,
 	textInputError: error,
 }
 

--- a/src/core/foundations/src/themes/button.ts
+++ b/src/core/foundations/src/themes/button.ts
@@ -21,39 +21,39 @@ export type ButtonTheme = {
 
 export const buttonDefault: { button: ButtonTheme } = {
 	button: {
-		textPrimary: text.buttonPrimary,
-		backgroundPrimary: background.buttonPrimary,
-		backgroundPrimaryHover: background.buttonPrimaryHover,
-		textSecondary: text.buttonSecondary,
-		backgroundSecondary: background.buttonSecondary,
-		backgroundSecondaryHover: background.buttonSecondaryHover,
-		textTertiary: text.buttonSecondary,
+		textPrimary: text.ctaPrimary,
+		backgroundPrimary: background.ctaPrimary,
+		backgroundPrimaryHover: background.ctaPrimaryHover,
+		textSecondary: text.ctaSecondary,
+		backgroundSecondary: background.ctaSecondary,
+		backgroundSecondaryHover: background.ctaSecondaryHover,
+		textTertiary: text.ctaSecondary,
 		backgroundTertiary: background.primary,
 	},
 }
 
 export const buttonBrand: { button: ButtonTheme } = {
 	button: {
-		textPrimary: brandText.buttonPrimary,
-		backgroundPrimary: brandBackground.buttonPrimary,
-		backgroundPrimaryHover: brandBackground.buttonPrimaryHover,
-		textSecondary: brandText.buttonSecondary,
-		backgroundSecondary: brandBackground.buttonSecondary,
-		backgroundSecondaryHover: brandBackground.buttonSecondaryHover,
-		textTertiary: brandText.buttonSecondary,
+		textPrimary: brandText.ctaPrimary,
+		backgroundPrimary: brandBackground.ctaPrimary,
+		backgroundPrimaryHover: brandBackground.ctaPrimaryHover,
+		textSecondary: brandText.ctaSecondary,
+		backgroundSecondary: brandBackground.ctaSecondary,
+		backgroundSecondaryHover: brandBackground.ctaSecondaryHover,
+		textTertiary: brandText.ctaSecondary,
 		backgroundTertiary: brandBackground.primary,
 	},
 }
 
 export const buttonBrandAlt: { button: ButtonTheme } = {
 	button: {
-		textPrimary: brandAltText.buttonPrimary,
-		backgroundPrimary: brandAltBackground.buttonPrimary,
-		backgroundPrimaryHover: brandAltBackground.buttonPrimaryHover,
-		textSecondary: brandAltText.buttonSecondary,
-		backgroundSecondary: brandAltBackground.buttonSecondary,
-		backgroundSecondaryHover: brandAltBackground.buttonSecondaryHover,
-		textTertiary: brandAltText.buttonSecondary,
+		textPrimary: brandAltText.ctaPrimary,
+		backgroundPrimary: brandAltBackground.ctaPrimary,
+		backgroundPrimaryHover: brandAltBackground.ctaPrimaryHover,
+		textSecondary: brandAltText.ctaSecondary,
+		backgroundSecondary: brandAltBackground.ctaSecondary,
+		backgroundSecondaryHover: brandAltBackground.ctaSecondaryHover,
+		textTertiary: brandAltText.ctaSecondary,
 		backgroundTertiary: brandAltBackground.primary,
 	},
 }

--- a/src/core/foundations/src/themes/checkbox.ts
+++ b/src/core/foundations/src/themes/checkbox.ts
@@ -28,14 +28,14 @@ export const checkboxDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: border.checkbox,
-		borderHover: border.checkboxHover,
-		borderChecked: border.checkboxChecked,
-		borderError: border.checkboxError,
-		backgroundChecked: background.checkboxChecked,
-		text: text.checkbox,
-		textSupporting: text.checkboxSupporting,
-		textIndeterminate: text.checkboxIndeterminate,
+		border: border.input,
+		borderHover: border.inputHover,
+		borderChecked: border.inputChecked,
+		borderError: border.error,
+		backgroundChecked: background.inputChecked,
+		text: text.primary,
+		textSupporting: text.supporting,
+		textIndeterminate: text.supporting,
 	},
 	...inlineErrorDefault,
 }
@@ -45,14 +45,14 @@ export const checkboxBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	checkbox: {
-		border: brandBorder.checkbox,
-		borderHover: brandBorder.checkboxHover,
-		borderChecked: brandBorder.checkboxChecked,
-		borderError: brandBorder.checkboxError,
-		backgroundChecked: brandBackground.checkboxChecked,
-		text: brandText.checkbox,
-		textSupporting: brandText.checkboxSupporting,
-		textIndeterminate: brandText.checkboxIndeterminate,
+		border: brandBorder.input,
+		borderHover: brandBorder.inputHover,
+		borderChecked: brandBorder.inputChecked,
+		borderError: brandBorder.error,
+		backgroundChecked: brandBackground.inputChecked,
+		text: brandText.primary,
+		textSupporting: brandText.supporting,
+		textIndeterminate: brandText.supporting,
 	},
 	...inlineErrorBrand,
 }

--- a/src/core/foundations/src/themes/choice-card.ts
+++ b/src/core/foundations/src/themes/choice-card.ts
@@ -16,13 +16,13 @@ export const choiceCardDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	choiceCard: {
-		text: text.choiceCard,
-		borderColor: border.choiceCard,
-		textChecked: text.choiceCardChecked,
+		text: text.supporting,
+		borderColor: border.input,
+		textChecked: text.inputChecked,
 		backgroundChecked: "#E3F6FF",
-		borderColorChecked: border.choiceCardChecked,
-		textHover: text.choiceCardHover,
-		borderColorHover: border.choiceCardHover,
+		borderColorChecked: border.inputChecked,
+		textHover: text.inputHover,
+		borderColorHover: border.inputHover,
 	},
 	...inlineErrorDefault,
 }

--- a/src/core/foundations/src/themes/link.ts
+++ b/src/core/foundations/src/themes/link.ts
@@ -9,24 +9,24 @@ export type LinkTheme = {
 
 export const linkDefault: { link: LinkTheme } = {
 	link: {
-		textPrimary: text.linkPrimary,
-		textPrimaryHover: text.linkPrimaryHover,
-		textSecondary: text.linkSecondary,
-		textSecondaryHover: text.linkSecondaryHover,
+		textPrimary: text.anchorPrimary,
+		textPrimaryHover: text.anchorPrimary,
+		textSecondary: text.anchorSecondary,
+		textSecondaryHover: text.anchorSecondary,
 	},
 }
 
 export const linkBrand: { link: LinkTheme } = {
 	link: {
-		textPrimary: brandText.linkPrimary,
-		textPrimaryHover: brandText.linkPrimaryHover,
+		textPrimary: brandText.anchorPrimary,
+		textPrimaryHover: brandText.anchorPrimary,
 	},
 }
 
 export const linkBrandAlt: { link: LinkTheme } = {
 	link: {
-		textPrimary: brandAltText.linkPrimary,
-		textPrimaryHover: brandAltText.linkPrimaryHover,
+		textPrimary: brandAltText.anchorPrimary,
+		textPrimaryHover: brandAltText.anchorPrimary,
 	},
 }
 

--- a/src/core/foundations/src/themes/radio.ts
+++ b/src/core/foundations/src/themes/radio.ts
@@ -26,12 +26,12 @@ export const radioDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		borderHover: border.radioHover,
-		border: border.radio,
-		backgroundChecked: background.radioChecked,
-		text: text.radio,
-		textSupporting: text.radioSupporting,
-		borderError: border.radioError,
+		borderHover: border.inputHover,
+		border: border.input,
+		backgroundChecked: background.inputChecked,
+		text: text.input,
+		textSupporting: text.inputSupporting,
+		borderError: border.error,
 	},
 	...inlineErrorLight,
 }
@@ -41,12 +41,12 @@ export const radioBrand: {
 	inlineError: InlineErrorTheme
 } = {
 	radio: {
-		borderHover: brandBorder.radioHover,
-		border: brandBorder.radio,
-		backgroundChecked: brandBackground.radioChecked,
-		text: brandText.radio,
-		textSupporting: brandText.radioSupporting,
-		borderError: brandBorder.radioError,
+		borderHover: brandBorder.inputHover,
+		border: brandBorder.input,
+		backgroundChecked: brandBackground.inputChecked,
+		text: brandText.input,
+		textSupporting: brandText.supporting,
+		borderError: brandBorder.error,
 	},
 	...inlineErrorBrand,
 }

--- a/src/core/foundations/src/themes/text-input.ts
+++ b/src/core/foundations/src/themes/text-input.ts
@@ -17,14 +17,14 @@ export const textInputDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	textInput: {
-		textInput: text.textInput,
-		textLabel: text.textInputLabel,
-		textOptionalLabel: text.textInputOptionalLabel,
-		textSupporting: text.textInputSupporting,
-		textError: text.textInputError,
-		backgroundInput: background.textInput,
-		border: border.textInput,
-		borderError: border.textInputError,
+		textInput: text.input,
+		textLabel: text.input,
+		textOptionalLabel: text.supporting,
+		textSupporting: text.supporting,
+		textError: text.error,
+		backgroundInput: background.input,
+		border: border.input,
+		borderError: border.error,
 	},
 	...inlineErrorDefault,
 }


### PR DESCRIPTION
## What is the purpose of this change?

Component colours are useful within foundations for helping to define a theme. However, exposing them to consumers of foundations is not so useful, and we end up with a lot of duplicated and redundant styles being shipped to the client.

We should stop exposing component colours to the client, but we should look at abstracting them away within foundations too.

## What does this change?

- create `input`-related styles as a more generic abstraction for styles that apply to checkboxes, radio buttons and text input fields.
- point to more generic functional colours, rather than component colours, from within themes, 
