### PR TITLE
Add group supporting text

### DIFF
--- a/src/core/components/choice-card/README.md
+++ b/src/core/components/choice-card/README.md
@@ -18,6 +18,7 @@ const Form = () => (
         <ChoiceCardGroup
             name="consent"
             label="Do you accept the terms?"
+            supporting="Answer as honestly as possible"
             multi={false}
         >
             <ChoiceCard
@@ -49,6 +50,12 @@ Gets passed as the name attribute for each choice card
 **`string`**
 
 Set as the legend for the fieldset
+
+### `supporting`
+
+**`string`**
+
+Additional text that appears below the `label`
 
 ### `multi`
 

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -5,14 +5,23 @@ import {
 	groupLabel,
 	input,
 	choiceCard,
+	groupLabelSupporting,
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
 
+const SupportingText = ({ children }: { children: ReactNode }) => {
+	return (
+		<div css={theme => groupLabelSupporting(theme.textInput && theme)}>
+			{children}
+		</div>
+	)
+}
 interface ChoiceCardGroupProps extends Props {
 	name: string
 	label?: string
+	supporting?: string
 	multi?: boolean
 	error?: string
 	children: JSX.Element | JSX.Element[]
@@ -21,6 +30,7 @@ interface ChoiceCardGroupProps extends Props {
 const ChoiceCardGroup = ({
 	name,
 	label,
+	supporting,
 	multi,
 	error,
 	cssOverrides,
@@ -29,7 +39,14 @@ const ChoiceCardGroup = ({
 }: ChoiceCardGroupProps) => {
 	return (
 		<fieldset css={[fieldset, cssOverrides]} {...props}>
-			{label ? <legend css={groupLabel}>{label}</legend> : ""}
+			{label ? (
+				<legend css={theme => groupLabel(theme.choiceCard && theme)}>
+					{label}
+				</legend>
+			) : (
+				""
+			)}
+			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
 			<div css={flexContainer}>
 				{React.Children.map(children, child => {
 					return React.cloneElement(

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -91,6 +91,32 @@ singleStateWithLabelLight.story = {
 	},
 }
 
+const multiStateWithSupportingLabelLight = () => (
+	<ThemeProvider theme={choiceCardDefault}>
+		<div css={narrow}>
+			<ChoiceCardGroup
+				name="colours"
+				multi={true}
+				label="What are your favourite colours?"
+				supporting="Select all that apply"
+			>
+				{choiceCards.map((choiceCard, index) =>
+					React.cloneElement(choiceCard, { key: index }),
+				)}
+			</ChoiceCardGroup>
+		</div>
+	</ThemeProvider>
+)
+
+multiStateWithSupportingLabelLight.story = {
+	name: `multi state with supporting label light`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+	},
+}
+
 // const errorLight = () => (
 // 	<ThemeProvider theme={choiceCardDefault}>
 // 		<ChoiceCardGroup name="colours" error="Please select a colour">
@@ -110,4 +136,9 @@ singleStateWithLabelLight.story = {
 // 	},
 // }
 
-export { singleStateLight, multiStateLight, singleStateWithLabelLight }
+export {
+	singleStateLight,
+	multiStateLight,
+	singleStateWithLabelLight,
+	multiStateWithSupportingLabelLight,
+}

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -21,9 +21,22 @@ export const flexContainer = css`
 	justify-content: flex-start;
 `
 
-export const groupLabel = css`
+export const groupLabel = ({
+	choiceCard,
+}: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
 	${textSans.medium({ fontWeight: "bold" })};
+	color: ${choiceCard.textGroupLabel};
 	margin-bottom: ${space[1]}px;
+`
+
+export const groupLabelSupporting = ({
+	choiceCard,
+}: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
+	${textSans.small()};
+	color: ${choiceCard.textGroupLabelSupporting};
+	margin-bottom: ${space[3]}px;
+	/* Negate the user agent spacing between legend and fieldset content */
+	margin-top: ${-space[2]}px;
 `
 
 export const input = ({
@@ -54,12 +67,11 @@ export const choiceCard = ({
 	margin: 0 ${space[2]}px 0 0;
 	align-items: center;
 	justify-content: center;
-	/* TODO: prefer curentColor unless it has to be different to text colour */
 	box-shadow: inset 0 0 0 2px ${choiceCard.borderColor};
 	border-radius: 4px;
 	position: relative;
 
-	color: ${choiceCard.text};
+	color: ${choiceCard.textLabel};
 	${textSans.medium({ fontWeight: "bold" })};
 	cursor: pointer;
 

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -14,4 +14,6 @@ export const text = {
 	inputSupporting: neutral[46],
 	inputChecked: brand[400],
 	inputHover: brand[400],
+	groupLabel: neutral[7],
+	groupLabelSupporting: neutral[46],
 }

--- a/src/core/foundations/src/themes/choice-card.ts
+++ b/src/core/foundations/src/themes/choice-card.ts
@@ -2,7 +2,10 @@ import { border, text } from "../index"
 import { InlineErrorTheme, inlineErrorDefault } from "./inline-error"
 
 export type ChoiceCardTheme = {
-	text: string
+	textLabel: string
+	textLabelSupporting: string
+	textGroupLabel: string
+	textGroupLabelSupporting: string
 	borderColor: string
 	textChecked: string
 	backgroundChecked: string
@@ -16,7 +19,10 @@ export const choiceCardDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	choiceCard: {
-		text: text.supporting,
+		textLabel: text.supporting,
+		textLabelSupporting: text.supporting,
+		textGroupLabel: text.groupLabel,
+		textGroupLabelSupporting: text.groupLabelSupporting,
 		borderColor: border.input,
 		textChecked: text.inputChecked,
 		backgroundChecked: "#E3F6FF",


### PR DESCRIPTION
## What is the purpose of this change?

The label for a choice card group can contain supporting text, which helps users make an appropriate selection.

## What does this change?

- add relevant colours to choice card default theme for group label and supporting text
- add logic to component to support the supporting text
- add new functional colours to support fieldset labels and supporting text (will be shared with checkbox groups and radio groups)

## Design

### Screenshots

<img width="339" alt="Screenshot 2020-03-09 at 20 59 22" src="https://user-images.githubusercontent.com/5931528/76257069-e1949580-6248-11ea-817b-b7dce16d344a.png">

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
