### PR TITLE
Use clearer functional colour names

### DIFF
--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -91,7 +91,7 @@ export const labelText = ({
 	checkbox,
 }: { checkbox: CheckboxTheme } = checkboxDefault) => css`
 	${textSans.medium()};
-	color: ${checkbox.text};
+	color: ${checkbox.textLabel};
 `
 
 export const labelTextWithSupportingText = css`
@@ -102,7 +102,7 @@ export const supportingText = ({
 	checkbox,
 }: { checkbox: CheckboxTheme } = checkboxDefault) => css`
 	${textSans.small({ lineHeight: "regular" })};
-	color: ${checkbox.textSupporting};
+	color: ${checkbox.textLabelSupporting};
 `
 
 export const tick = ({

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -86,7 +86,7 @@ export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 
 export const labelText = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 	${textSans.medium()};
-	color: ${radio.text};
+	color: ${radio.textLabel};
 `
 
 export const labelTextWithSupportingText = css`
@@ -97,7 +97,7 @@ export const supportingText = ({
 	radio,
 }: { radio: RadioTheme } = radioLight) => css`
 	${textSans.small({ lineHeight: "regular" })};
-	color: ${radio.textSupporting};
+	color: ${radio.textLabelSupporting};
 `
 
 export const horizontal = css`

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -19,7 +19,7 @@ export const textInput = ({
 }: { textInput: TextInputTheme } = textInputLight) => css`
 	height: ${size.large}px;
 	${textSans.medium()};
-	color: ${textInput.textInput};
+	color: ${textInput.textUserInput};
 	background-color: ${textInput.backgroundInput};
 	border: 2px solid ${textInput.border};
 	padding: 0 ${space[2]}px;
@@ -61,7 +61,7 @@ export const optionalLabel = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
 	${textSans.small()};
-	color: ${textInput.textOptionalLabel};
+	color: ${textInput.textLabelOptional};
 	font-style: italic;
 `
 
@@ -69,6 +69,6 @@ export const supportingText = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
 	${textSans.small()};
-	color: ${textInput.textSupporting};
+	color: ${textInput.textLabelSupporting};
 	margin-bottom: ${space[1]}px;
 `

--- a/src/core/foundations/src/palette/text/brand-alt.ts
+++ b/src/core/foundations/src/palette/text/brand-alt.ts
@@ -2,7 +2,7 @@ import { neutral } from "../global"
 
 export const brandAltText = {
 	primary: neutral[7],
-	secondary: neutral[60], //TODO: deprecate?
+	secondary: neutral[60], //TODO: deprecate in v0.16
 	supporting: neutral[60],
 	ctaPrimary: neutral[100],
 	ctaSecondary: neutral[7],

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -2,13 +2,14 @@ import { neutral, success as _success, error as _error, brand } from "../global"
 
 export const brandText = {
 	primary: neutral[100],
-	secondary: brand[800], //TODO: deprecate?
+	secondary: brand[800], //TODO: deprecate in v0.16
 	supporting: brand[800],
 	success: _success[400],
 	error: _error[500],
 	ctaPrimary: brand[400],
 	ctaSecondary: neutral[100],
 	anchorPrimary: neutral[100],
-	input: neutral[100],
-	inputSupporting: brand[800],
+	userInput: neutral[100],
+	inputLabel: neutral[100],
+	inputLabelSupporting: brand[800],
 }

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -2,7 +2,7 @@ import { neutral, error as _error, success as _success, brand } from "../global"
 
 export const text = {
 	primary: neutral[7],
-	secondary: neutral[46], //TODO: deprecate?
+	secondary: neutral[46], //TODO: deprecate in v0.16
 	supporting: neutral[46],
 	success: _success[400],
 	error: _error[400],
@@ -10,10 +10,11 @@ export const text = {
 	ctaSecondary: brand[400],
 	anchorPrimary: brand[500],
 	anchorSecondary: neutral[7],
-	input: neutral[7],
-	inputSupporting: neutral[46],
-	inputChecked: brand[400],
-	inputHover: brand[400],
+	userInput: neutral[7],
+	inputLabel: neutral[7],
+	inputLabelSupporting: neutral[46],
+	inputChecked: brand[400], //choice card only
+	inputHover: brand[400], //choice card only
 	groupLabel: neutral[7],
 	groupLabelSupporting: neutral[46],
 }

--- a/src/core/foundations/src/themes/checkbox.ts
+++ b/src/core/foundations/src/themes/checkbox.ts
@@ -18,8 +18,8 @@ export type CheckboxTheme = {
 	borderChecked: string
 	borderError: string
 	backgroundChecked: string
-	text: string
-	textSupporting: string
+	textLabel: string
+	textLabelSupporting: string
 	textIndeterminate: string
 }
 
@@ -33,8 +33,8 @@ export const checkboxDefault: {
 		borderChecked: border.inputChecked,
 		borderError: border.error,
 		backgroundChecked: background.inputChecked,
-		text: text.primary,
-		textSupporting: text.supporting,
+		textLabel: text.inputLabel,
+		textLabelSupporting: text.inputLabelSupporting,
 		textIndeterminate: text.supporting,
 	},
 	...inlineErrorDefault,
@@ -50,8 +50,8 @@ export const checkboxBrand: {
 		borderChecked: brandBorder.inputChecked,
 		borderError: brandBorder.error,
 		backgroundChecked: brandBackground.inputChecked,
-		text: brandText.primary,
-		textSupporting: brandText.supporting,
+		textLabel: brandText.inputLabel,
+		textLabelSupporting: brandText.inputLabelSupporting,
 		textIndeterminate: brandText.supporting,
 	},
 	...inlineErrorBrand,

--- a/src/core/foundations/src/themes/radio.ts
+++ b/src/core/foundations/src/themes/radio.ts
@@ -16,8 +16,8 @@ export type RadioTheme = {
 	borderHover: string
 	border: string
 	backgroundChecked: string
-	text: string
-	textSupporting: string
+	textLabel: string
+	textLabelSupporting: string
 	borderError: string
 }
 
@@ -29,8 +29,8 @@ export const radioDefault: {
 		borderHover: border.inputHover,
 		border: border.input,
 		backgroundChecked: background.inputChecked,
-		text: text.input,
-		textSupporting: text.inputSupporting,
+		textLabel: text.inputLabel,
+		textLabelSupporting: text.inputLabelSupporting,
 		borderError: border.error,
 	},
 	...inlineErrorLight,
@@ -44,8 +44,8 @@ export const radioBrand: {
 		borderHover: brandBorder.inputHover,
 		border: brandBorder.input,
 		backgroundChecked: brandBackground.inputChecked,
-		text: brandText.input,
-		textSupporting: brandText.supporting,
+		textLabel: brandText.inputLabel,
+		textLabelSupporting: brandText.supporting,
 		borderError: brandBorder.error,
 	},
 	...inlineErrorBrand,

--- a/src/core/foundations/src/themes/text-input.ts
+++ b/src/core/foundations/src/themes/text-input.ts
@@ -2,10 +2,10 @@ import { text, background, border } from "../index"
 import { inlineErrorDefault, InlineErrorTheme } from "./inline-error"
 
 export type TextInputTheme = {
-	textInput: string
+	textUserInput: string
 	textLabel: string
-	textOptionalLabel: string
-	textSupporting: string
+	textLabelOptional: string
+	textLabelSupporting: string
 	textError: string
 	backgroundInput: string
 	border: string
@@ -17,10 +17,10 @@ export const textInputDefault: {
 	inlineError: InlineErrorTheme
 } = {
 	textInput: {
-		textInput: text.input,
-		textLabel: text.input,
-		textOptionalLabel: text.supporting,
-		textSupporting: text.supporting,
+		textUserInput: text.userInput,
+		textLabel: text.inputLabel,
+		textLabelOptional: text.supporting,
+		textLabelSupporting: text.supporting,
 		textError: text.error,
 		backgroundInput: background.input,
 		border: border.input,


### PR DESCRIPTION
## What is the purpose of this change?

Some of the functional and component colour names are inconsisent and a little unclear.

## What does this change?

- clarifies names of functional colours for text
- clarifies names of component colours for text
- uses clearer component colour names in radio, checkbox and text input components
