### PR TITLE
Improve style targetting in choice card

### DIFF
--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -137,9 +137,8 @@ const ChoiceCard = ({
 				css={theme => [choiceCard(theme.choiceCard && theme)]}
 				htmlFor={id}
 			>
-				{/* Hack: span is content and div is tick, for easier targetting in the styles */}
 				<span>{labelContent}</span>
-				<div css={theme => [tick(theme.checkbox && theme)]} />
+				<span css={theme => [tick(theme.checkbox && theme)]} />
 			</label>
 		</>
 	)

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -54,18 +54,21 @@ export const input = ({
 
 		& > span {
 			color: ${choiceCard.textChecked};
-		}
 
-		& > div:before {
-			right: 0;
-		}
-		& > div:after {
-			top: 0;
+			/* last child is the tick */
+			&:last-child {
+				&:before {
+					right: 0;
+				}
+				&:after {
+					top: 0;
+				}
+			}
 		}
 	}
 `
 
-// TODO: use aniimation durations defined in foundations
+// TODO: use animation durations defined in foundations
 export const tickAnimation = css`
 	@keyframes labelFadeOutIn {
 		0% {
@@ -97,11 +100,11 @@ export const tickAnimation = css`
 		& > span {
 			animation-duration: 1s;
 			animation-name: labelFadeOutIn;
-		}
 
-		& > div {
-			animation-duration: 1s;
-			animation-name: tickFadeInOut;
+			/* last child is the tick */
+			&:last-child {
+				animation-name: tickFadeInOut;
+			}
 		}
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

The styling for the label and tick is currently dependant on the label being in a span and the tick in a div. This is unsustainable as more features are added to the choice card.

We should instead target styles according to the order in which the elements appear 

## What does this change?

- use `:last-child` to target the tick
- make both tick and label into spans
