### PR TITLE
Install and configure storybook viewport addon

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
 	stories: ["../**/stories.tsx"],
-	addons: ["@storybook/addon-backgrounds"],
+	addons: ["@storybook/addon-backgrounds", "@storybook/addon-viewport"],
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,18 +2,60 @@ import React from "react"
 import { addParameters, addDecorator } from "@storybook/react"
 import { useEffect } from "@storybook/addons"
 import { FocusStyleManager } from "@guardian/src-foundations/utils"
-import { breakpoints } from "@guardian/src-foundations"
+import { breakpoints, Breakpoint } from "@guardian/src-foundations"
 
 const storiesOnly = process.env.NODE_ENV === "production"
+
+type ViewportMeta = {
+	[key in Breakpoint]: {
+		name: string
+		type: string
+	}
+}
+const viewportMeta: ViewportMeta = {
+	mobile: {
+		name: "Mobile",
+		type: "mobile",
+	},
+	mobileMedium: {
+		name: "Mobile Medium",
+		type: "mobile",
+	},
+	mobileLandscape: {
+		name: "Mobile Landscape",
+		type: "mobile",
+	},
+	phablet: {
+		name: "Phablet",
+		type: "mobile",
+	},
+	tablet: {
+		name: "Tablet",
+		type: "tablet",
+	},
+	desktop: {
+		name: "Desktop",
+		type: "desktop",
+	},
+	leftCol: {
+		name: "Left Col",
+		type: "desktop",
+	},
+	wide: {
+		name: "Wide",
+		type: "desktop",
+	},
+}
 const viewportEntries = Object.entries(breakpoints).map(([name, width]) => {
 	return [
 		name,
 		{
-			name,
+			name: viewportMeta[name].name,
 			styles: {
 				width: `${width}px`,
 				height: "100%",
 			},
+			type: viewportMeta[name].type,
 		},
 	]
 })

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -72,7 +72,7 @@ addParameters({
 	},
 	viewport: {
 		viewports,
-		defaultViewport: "wide",
+		defaultViewport: "desktop",
 	},
 })
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { addParameters, addDecorator } from "@storybook/react"
 import { useEffect } from "@storybook/addons"
-import { FocusStyleManager } from "@guardian/src-utilities"
+import { FocusStyleManager } from "@guardian/src-foundations/utils"
 
 const storiesOnly = process.env.NODE_ENV === "production"
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,18 +2,35 @@ import React from "react"
 import { addParameters, addDecorator } from "@storybook/react"
 import { useEffect } from "@storybook/addons"
 import { FocusStyleManager } from "@guardian/src-foundations/utils"
+import { breakpoints } from "@guardian/src-foundations"
 
 const storiesOnly = process.env.NODE_ENV === "production"
-
-// We hide the toolbar by default to make Storybook embeds
-// look nicer in Zeroheight. Related discussion:
-// https://github.com/storybookjs/storybook/issues/8129
-// https://spectrum.chat/zeroheight/feature-requests/swap-out-storybook-stories-in-situ~29d7760d-aba6-4bb3-bf4a-37c119dbc622
+const viewportEntries = Object.entries(breakpoints).map(([name, width]) => {
+	return [
+		name,
+		{
+			name,
+			styles: {
+				width: `${width}px`,
+				height: "100%",
+			},
+		},
+	]
+})
+const viewports = Object.fromEntries(viewportEntries)
 
 addParameters({
+	// We hide the toolbar by default to make Storybook embeds
+	// look nicer in Zeroheight. Related discussion:
+	// https://github.com/storybookjs/storybook/issues/8129
+	// https://spectrum.chat/zeroheight/feature-requests/swap-out-storybook-stories-in-situ~29d7760d-aba6-4bb3-bf4a-37c119dbc622
 	options: {
 		isToolshown: !storiesOnly,
 		isFullscreen: storiesOnly,
+	},
+	viewport: {
+		viewports,
+		defaultViewport: "wide",
 	},
 })
 

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = ({ config, mode }) => {
 				"@babel/preset-typescript",
 				"@emotion/babel-preset-css-prop",
 			],
+			plugins: ["@babel/plugin-proposal-class-properties"],
 		},
 	})
 	config.resolve.extensions.push(".ts", ".tsx")

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 	],
 	"devDependencies": {
 		"@babel/core": "^7.8.0",
+		"@babel/plugin-proposal-class-properties": "^7.8.3",
 		"@babel/preset-env": "^7.8.0",
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@emotion/core": "^10.0.27",
 		"@storybook/addon-backgrounds": "^5.3.1",
+		"@storybook/addon-viewport": "^5.3.14",
 		"@storybook/react": "^5.3.9",
 		"@types/jest": "^25.1.1",
 		"@types/react": "^16.9.2",

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -9,7 +9,7 @@
 	},
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
-		"watch": "rollup --config --watch",
+		"watch": "yarn clean && tsc && rollup --config --watch",
 		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
 		"prepublishOnly": "yarn build",
 		"postpublish": "yarn clean"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 			"@guardian/src-foundations/typography": [
 				"core/foundations/src/typography"
 			],
+			"@guardian/src-foundations/utils": ["core/foundations/src/utils"],
 			"@guardian/src-inline-error": ["core/components/inline-error"],
 			"@guardian/src-helpers": ["core/helpers"],
 			"@guardian/src-svgs": ["core/svgs"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,6 +2272,23 @@
     react "^16.8.3"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-viewport@^5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-5.3.14.tgz#7ec4b4f9f248525438a9669a2f2d2615f4766153"
+  integrity sha512-Eg/aP9I3csltaArXvPzhQZuXnAc4FVMo4BcVFTzNx93zaXYVDSLCoTFBAz4NWrnuJuLw9cdSKirJ2lsuu6ABeg==
+  dependencies:
+    "@storybook/addons" "5.3.14"
+    "@storybook/api" "5.3.14"
+    "@storybook/client-logger" "5.3.14"
+    "@storybook/components" "5.3.14"
+    "@storybook/core-events" "5.3.14"
+    "@storybook/theming" "5.3.14"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    prop-types "^15.7.2"
+    util-deprecate "^1.0.2"
+
 "@storybook/addons@5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.1.tgz#617a4c489b936fe9bb4fb04dc06d20f92a9eb065"
@@ -2281,6 +2298,19 @@
     "@storybook/channels" "5.3.1"
     "@storybook/client-logger" "5.3.1"
     "@storybook/core-events" "5.3.1"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    util-deprecate "^1.0.2"
+
+"@storybook/addons@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-5.3.14.tgz#ff96c2c46a617f777c3660395017d2aef5319f19"
+  integrity sha512-zoN1MYlArdThp93i+Ogil/pihyx8n7nkrdSO0j9HUh6jUsGeFFEluPQZdRFte9NIoY6ZWSWwuEMDgrv2Pw9r2Q==
+  dependencies:
+    "@storybook/api" "5.3.14"
+    "@storybook/channels" "5.3.14"
+    "@storybook/client-logger" "5.3.14"
+    "@storybook/core-events" "5.3.14"
     core-js "^3.0.1"
     global "^4.3.2"
     util-deprecate "^1.0.2"
@@ -2310,6 +2340,32 @@
     "@storybook/csf" "0.0.1"
     "@storybook/router" "5.3.1"
     "@storybook/theming" "5.3.1"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    prop-types "^15.6.2"
+    react "^16.8.3"
+    semver "^6.0.0"
+    shallow-equal "^1.1.0"
+    store2 "^2.7.1"
+    telejson "^3.2.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/api@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.14.tgz#8c2bb226a4a5de7974ee2ccce36986b72f462f1b"
+  integrity sha512-ANWRMTLEoAfu0IsXqbxmbTpxS8xTByZgLj20tH96bxgH1rJo9KAZnJ8A9kGYr+zklU8QnYvVIgmV3HESXII9zg==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/channels" "5.3.14"
+    "@storybook/client-logger" "5.3.14"
+    "@storybook/core-events" "5.3.14"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "5.3.14"
+    "@storybook/theming" "5.3.14"
     "@types/reach__router" "^1.2.3"
     core-js "^3.0.1"
     fast-deep-equal "^2.0.1"
@@ -2368,6 +2424,13 @@
   dependencies:
     core-js "^3.0.1"
 
+"@storybook/channels@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.14.tgz#9969e27761a80afb495bc1475f0173f9b6ef5a76"
+  integrity sha512-k9QBf9Kwe+iGmdEK/kW5xprqem2SPfBVwET6LWvJkWOl9UQ9VoMuCHgV55p0tzjcugaqWWKoF9+FRMWxWRfsQg==
+  dependencies:
+    core-js "^3.0.1"
+
 "@storybook/channels@5.3.9":
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-5.3.9.tgz#7ee8f6e6f4c9465227120d6711805b5e6862107f"
@@ -2405,6 +2468,13 @@
   dependencies:
     core-js "^3.0.1"
 
+"@storybook/client-logger@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.14.tgz#85068f1b665a52163191eb5976f1581bce6df0e4"
+  integrity sha512-YCHEsOvo6zPb4udlyAwqr5W0Kv9mAEQmcX73w9IDvAxbjR00T7empW7qmbjvviftKB/5MEgDdiYbj64ccs3aqg==
+  dependencies:
+    core-js "^3.0.1"
+
 "@storybook/client-logger@5.3.9":
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-5.3.9.tgz#06654be9caa8d37366270b0426c2d5acb217f504"
@@ -2419,6 +2489,33 @@
   dependencies:
     "@storybook/client-logger" "5.3.1"
     "@storybook/theming" "5.3.1"
+    "@types/react-syntax-highlighter" "11.0.2"
+    "@types/react-textarea-autosize" "^4.3.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.9.1"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    popper.js "^1.14.7"
+    prop-types "^15.7.2"
+    react "^16.8.3"
+    react-dom "^16.8.3"
+    react-focus-lock "^2.1.0"
+    react-helmet-async "^1.0.2"
+    react-popper-tooltip "^2.8.3"
+    react-syntax-highlighter "^11.0.2"
+    react-textarea-autosize "^7.1.0"
+    simplebar-react "^1.0.0-alpha.6"
+    ts-dedent "^1.1.0"
+
+"@storybook/components@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.3.14.tgz#0f2f90113674e14ee74d5d16d6b3b1220cb0fa16"
+  integrity sha512-AsjkIFBrrqcBDLxGdmUHiauZo5gOL65eXx8WA7/yJDF8s45VVZX5Z0buOnjFyEhGVus02gwTov8da2irjL862A==
+  dependencies:
+    "@storybook/client-logger" "5.3.14"
+    "@storybook/theming" "5.3.14"
     "@types/react-syntax-highlighter" "11.0.2"
     "@types/react-textarea-autosize" "^4.3.3"
     core-js "^3.0.1"
@@ -2470,6 +2567,13 @@
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.1.tgz#15e34ba8088a1e2a63bf78eb1979bb68c631affe"
   integrity sha512-ewR8jSeBvCBJJifEN2rvGN9ji2PKEM+AFna2zS/lNuX7WlAN1HdLIDeNEqhaZBqsgOx9w7p6CEPhnnoC7CmZjA==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-5.3.14.tgz#d476eea7032670db1a84bef7e5baadb04c2de529"
+  integrity sha512-VCPLKqRugsOSx/smMJiJOvRgAzTrMpsbRuFw48kBGkQMP9TEV82Qe/341dv+f4GllPyBZyANG0p0m5+w7ZCURQ==
   dependencies:
     core-js "^3.0.1"
 
@@ -2620,6 +2724,21 @@
     qs "^6.6.0"
     util-deprecate "^1.0.2"
 
+"@storybook/router@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.14.tgz#6535267624da5f54971c37e497df1c161f65be8f"
+  integrity sha512-O0KwQFncdBeq+O2Aq8UAFBVWjWmP5rtqoacUOFSGkXgObOnyniEraLiPH7rPtq2dAlSpgYI9+srQAZfo52Hz2A==
+  dependencies:
+    "@reach/router" "^1.2.1"
+    "@storybook/csf" "0.0.1"
+    "@types/reach__router" "^1.2.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/router@5.3.9":
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/@storybook/router/-/router-5.3.9.tgz#3c6e01f4dced9de8e8c5c314352fdc437f2441c2"
@@ -2643,6 +2762,24 @@
     "@emotion/core" "^10.0.20"
     "@emotion/styled" "^10.0.17"
     "@storybook/client-logger" "5.3.1"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    prop-types "^15.7.2"
+    resolve-from "^5.0.0"
+    ts-dedent "^1.1.0"
+
+"@storybook/theming@5.3.14":
+  version "5.3.14"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-5.3.14.tgz#4923739ad0d7d673b7844f27da8a3c6cf118790f"
+  integrity sha512-raqXC3yJycEt1CrCAfnBYUA6pyJI80E9M26EeQl3UfytJOL6euprOi+D17QvxqBn7jmmf9ZDw5XRkvJhQ17Y7Q==
+  dependencies:
+    "@emotion/core" "^10.0.20"
+    "@emotion/styled" "^10.0.17"
+    "@storybook/client-logger" "5.3.14"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"


### PR DESCRIPTION
## What is the purpose of this change?

Storybook's [viewport addon](https://www.npmjs.com/package/@storybook/addon-viewport) allows us to view our stories a various breakpoints. This comes in handy when we're building components that look different at different viewport widths.

We should add the addon and configure it so that we can view stories at breakpoints specified in our foundations.

## What does this change?

- add storybook/viewport-addon
- switch focus manager to version in src-foundations/utils
- configure viewport addon to use breakpoints defined in foundations
- update foundations watch script to build type definitions

## Design

### Screenshots

<img width="1060" alt="Screenshot 2020-03-11 at 12 00 15" src="https://user-images.githubusercontent.com/5931528/76414781-e748c300-638f-11ea-86c5-9e2d0602dcbf.png">
