### PR TITLE
Choice card stacks on mobile viewport

### DIFF
--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -116,6 +116,26 @@ singleStateWithSupportingLabelLight.story = {
 	},
 }
 
+const singleStateMobileLight = () => (
+	<ThemeProvider theme={choiceCardDefault}>
+		<ChoiceCardGroup name="colours" label="What is your favourite colour?">
+			{choiceCards.map((choiceCard, index) =>
+				React.cloneElement(choiceCard, { key: index }),
+			)}
+		</ChoiceCardGroup>
+	</ThemeProvider>
+)
+
+singleStateMobileLight.story = {
+	name: `single state mobile light`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+		viewport: { defaultViewport: "mobileMedium" },
+	},
+}
+
 // const errorLight = () => (
 // 	<ThemeProvider theme={choiceCardDefault}>
 // 		<ChoiceCardGroup name="colours" error="Please select a colour">
@@ -140,4 +160,5 @@ export {
 	multiStateLight,
 	singleStateWithLabelLight,
 	singleStateWithSupportingLabelLight,
+	singleStateMobileLight,
 }

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -91,14 +91,13 @@ singleStateWithLabelLight.story = {
 	},
 }
 
-const multiStateWithSupportingLabelLight = () => (
+const singleStateWithSupportingLabelLight = () => (
 	<ThemeProvider theme={choiceCardDefault}>
 		<div css={narrow}>
 			<ChoiceCardGroup
 				name="colours"
-				multi={true}
-				label="What are your favourite colours?"
-				supporting="Select all that apply"
+				label="What is your favourite colour?"
+				supporting="Think about it"
 			>
 				{choiceCards.map((choiceCard, index) =>
 					React.cloneElement(choiceCard, { key: index }),
@@ -108,8 +107,8 @@ const multiStateWithSupportingLabelLight = () => (
 	</ThemeProvider>
 )
 
-multiStateWithSupportingLabelLight.story = {
-	name: `multi state with supporting label light`,
+singleStateWithSupportingLabelLight.story = {
+	name: `single state with supporting label light`,
 	parameters: {
 		backgrounds: [
 			Object.assign({}, { default: true }, storybookBackgrounds.default),
@@ -140,5 +139,5 @@ export {
 	singleStateLight,
 	multiStateLight,
 	singleStateWithLabelLight,
-	multiStateWithSupportingLabelLight,
+	singleStateWithSupportingLabelLight,
 }

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -3,6 +3,7 @@ import { space, size, transitions } from "@guardian/src-foundations"
 import { visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
+import { from } from "@guardian/src-foundations/mq"
 import {
 	ChoiceCardTheme,
 	choiceCardDefault,
@@ -17,8 +18,12 @@ export const fieldset = css`
 // on fieldset elements
 // https://bugs.chromium.org/p/chromium/issues/detail?id=375693
 export const flexContainer = css`
-	display: flex;
-	justify-content: flex-start;
+	width: 100%;
+
+	${from.mobileLandscape} {
+		display: flex;
+		justify-content: flex-start;
+	}
 `
 
 export const groupLabel = ({
@@ -113,26 +118,31 @@ export const choiceCard = ({
 	choiceCard,
 }: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
 	flex: 1 0 auto;
-	box-sizing: border-box;
 	display: flex;
+	box-sizing: border-box;
 	/* TODO: let's talk about size! */
 	min-height: ${size.large}px;
-	max-width: 150px;
-	margin: 0 ${space[2]}px 0 0;
+	margin: 0 0 ${space[2]}px 0;
 	align-items: center;
-	justify-content: center;
+	justify-content: flex-start;
+	padding-left: ${space[5]}px;
 	box-shadow: inset 0 0 0 2px ${choiceCard.borderColor};
 	border-radius: 4px;
 	position: relative;
 	cursor: pointer;
 
+	${from.mobileLandscape} {
+		justify-content: center;
+		padding-left: 0;
+		margin: 0 ${space[2]}px 0 0;
+		&:last-child {
+			margin: 0;
+		}
+	}
+
 	& > span {
 		color: ${choiceCard.textLabel};
 		${textSans.medium({ fontWeight: "bold" })};
-	}
-
-	&:last-child {
-		margin: 0;
 	}
 
 	&:hover {


### PR DESCRIPTION
## What is the purpose of this change?

On mobile viewports, choice cards should stack vertically rather than sit side by side

## What does this change?

- add styles to stack choice cards vertically on mobile
- add mobile view story

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

<img width="397" alt="Screenshot 2020-03-11 at 13 25 37" src="https://user-images.githubusercontent.com/5931528/76421736-0b120600-639c-11ea-8988-7f4e5ae8ba4e.png">

### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
