### PR TITLE
Choice card error

### DIFF
--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -137,7 +137,10 @@ const ChoiceCard = ({
 				{...props}
 			/>
 			<label
-				css={theme => [choiceCard(theme.choiceCard && theme)]}
+				css={theme => [
+					choiceCard(theme.choiceCard && theme),
+					error ? errorChoiceCard(theme.choiceCard && theme) : "",
+				]}
 				htmlFor={id}
 			>
 				<span>{labelContent}</span>

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -14,7 +14,9 @@ import {
 	choiceCard,
 	groupLabelSupporting,
 	tick,
+	errorChoiceCard,
 } from "./styles"
+import { InlineError } from "@guardian/src-inline-error"
 import { Props } from "@guardian/src-helpers"
 
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
@@ -55,6 +57,7 @@ const ChoiceCardGroup = ({
 				""
 			)}
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
+			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			<div css={flexContainer}>
 				{React.Children.map(children, child => {
 					return React.cloneElement(

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -32,6 +32,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
-		"@guardian/src-helpers": "^0.15.0"
+		"@guardian/src-helpers": "^0.15.0",
+		"@guardian/src-inline-error": "^0.15.0"
 	}
 }

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -15,6 +15,11 @@ const choiceCards = [
 	/>,
 	<ChoiceCard value="blue" label="Blue" id="default-blue" />,
 ]
+const unselectedChoiceCards = [
+	<ChoiceCard value="red" label="Red" id="default-red" />,
+	<ChoiceCard value="green" label="Green" id="default-green" />,
+	<ChoiceCard value="blue" label="Blue" id="default-blue" />,
+]
 /* eslint-enable react/jsx-key */
 
 export default {
@@ -136,24 +141,26 @@ singleStateMobileLight.story = {
 	},
 }
 
-// const errorLight = () => (
-// 	<ThemeProvider theme={choiceCardDefault}>
-// 		<ChoiceCardGroup name="colours" error="Please select a colour">
-// 			{unselectedChoiceCards.map((radio, index) =>
-// 				React.cloneElement(radio, { key: index }),
-// 			)}
-// 		</ChoiceCardGroup>
-// 	</ThemeProvider>
-// )
+const errorLight = () => (
+	<ThemeProvider theme={choiceCardDefault}>
+		<div css={narrow}>
+			<ChoiceCardGroup name="colours" error="Please select a colour">
+				{unselectedChoiceCards.map((radio, index) =>
+					React.cloneElement(radio, { key: index }),
+				)}
+			</ChoiceCardGroup>
+		</div>
+	</ThemeProvider>
+)
 
-// errorLight.story = {
-// 	name: `error light`,
-// 	parameters: {
-// 		backgrounds: [
-// 			Object.assign({}, { default: true }, storybookBackgrounds.default),
-// 		],
-// 	},
-// }
+errorLight.story = {
+	name: `error light`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+	},
+}
 
 export {
 	singleStateLight,
@@ -161,4 +168,5 @@ export {
 	singleStateWithLabelLight,
 	singleStateWithSupportingLabelLight,
 	singleStateMobileLight,
+	errorLight,
 }

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -54,7 +54,7 @@ export const input = ({
 	}
 
 	&:checked + label {
-		box-shadow: inset 0 0 0 4px ${choiceCard.borderColorChecked};
+		box-shadow: inset 0 0 0 4px ${choiceCard.borderChecked};
 		background-color: ${choiceCard.backgroundChecked};
 
 		& > span {
@@ -126,7 +126,7 @@ export const choiceCard = ({
 	align-items: center;
 	justify-content: flex-start;
 	padding-left: ${space[5]}px;
-	box-shadow: inset 0 0 0 2px ${choiceCard.borderColor};
+	box-shadow: inset 0 0 0 2px ${choiceCard.border};
 	border-radius: 4px;
 	position: relative;
 	cursor: pointer;
@@ -146,7 +146,7 @@ export const choiceCard = ({
 	}
 
 	&:hover {
-		box-shadow: inset 0 0 0 4px ${choiceCard.borderColorHover};
+		box-shadow: inset 0 0 0 4px ${choiceCard.borderHover};
 
 		& > span {
 			color: ${choiceCard.textHover};
@@ -193,5 +193,15 @@ export const tick = ({
 		top: 100%;
 		width: 2px;
 		transition-delay: 0.1s;
+	}
+`
+
+export const errorChoiceCard = ({
+	choiceCard,
+}: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
+	box-shadow: inset 0 0 0 4px ${choiceCard.borderError};
+
+	& > span {
+		color: ${choiceCard.textError};
 	}
 `

--- a/src/core/foundations/src/themes/choice-card.ts
+++ b/src/core/foundations/src/themes/choice-card.ts
@@ -6,13 +6,15 @@ export type ChoiceCardTheme = {
 	textLabelSupporting: string
 	textGroupLabel: string
 	textGroupLabelSupporting: string
-	borderColor: string
+	border: string
 	textChecked: string
 	backgroundChecked: string
 	backgroundTick: string
-	borderColorChecked: string
+	borderChecked: string
 	textHover: string
-	borderColorHover: string
+	borderHover: string
+	textError: string
+	borderError: string
 }
 
 export const choiceCardDefault: {
@@ -24,13 +26,15 @@ export const choiceCardDefault: {
 		textLabelSupporting: text.supporting,
 		textGroupLabel: text.groupLabel,
 		textGroupLabelSupporting: text.groupLabelSupporting,
-		borderColor: border.input,
+		border: border.input,
 		textChecked: text.inputChecked,
 		backgroundChecked: "#E3F6FF",
 		backgroundTick: background.inputChecked,
-		borderColorChecked: border.inputChecked,
+		borderChecked: border.inputChecked,
 		textHover: text.inputHover,
-		borderColorHover: border.inputHover,
+		borderHover: border.inputHover,
+		textError: text.error,
+		borderError: border.error,
 	},
 	...inlineErrorDefault,
 }


### PR DESCRIPTION
## What is the purpose of this change?

Choice cards should have a way to indicate an error state, including an error message

## What does this change?

- add error styles to choice cards
- add inline error message to choice cards
- BONUS: refactor border colours

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

<img width="335" alt="Screenshot 2020-03-11 at 15 09 55" src="https://user-images.githubusercontent.com/5931528/76432107-69de7c00-63aa-11ea-9b6d-0a061938a17e.png">


### Accessibility

-   [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
-   [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
-   [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
