### PR TITLE
Automated release publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Source
 
-A shared components library for Guardian Digital. Uses the Guardian's [Source Design System](https://zeroheight.com/2a1e5182b).
+A shared components library for Guardian Digital. Uses the Guardian's [Source Design System](https://theguardian.design).
 
 ## Usage
 
 **This project is still in alpha.** If you'd like to start using our foundations and components, please drop an email to
 `digital.design.system` so we can add your project to our database.
 
-Check out our [Getting Started guide](https://zeroheight.com/2a1e5182b/p/876251).
+Check out our [Getting Started guide](https://theguardian.design/2a1e5182b/p/876251).
 
 ## Contributing
 
@@ -30,15 +30,4 @@ We develop components using Storybook:
 $ yarn storybook
 ```
 
-### Publish
-
-**1.** After merging your branch, our Storybook is automatically deployed to [GitHub pages](https://guardian.github.io/source). Storybook stories may used in our documentation site.
-
-**2.** Run the publish script within the component (you will need to be a member of the [`@guardian` npm organisation](https://www.npmjs.com/settings/guardian/members)):
-
-```sh
-$ cd src/core/components/my-component
-$ yarn publish --access public
-```
-
-**3.** Make necessary changes to the [documentation site](https://zeroheight.com/2a1e5182b)
+On merge, our Storybook instance is automatically deployed to [GitHub pages](https://guardian.github.io/source).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"watch:utilities": "cd src/core/utilities && yarn watch",
 		"clean:all": "node ./scripts/clean-all",
 		"build:all": "node ./scripts/build-all",
-		"ci:build": "NODE_ENV=production yarn build:all && yarn build:storybook"
+		"ci:build": "NODE_ENV=production yarn build:all && yarn build:storybook",
+		"publish:release": "node ./scripts/publish-release"
 	},
 	"private": true,
 	"workspaces": [

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -5,15 +5,7 @@ const { paths, getComponentPaths } = require("./paths")
 const build = dir => {
 	return execa(
 		"yarn",
-		[
-			"--cwd",
-			`${dir}`,
-			"run",
-			"publish:public",
-			"--",
-			"--new-version",
-			version,
-		],
+		["--cwd", `${dir}`, "run", "publish:public", "--new-version", version],
 		{
 			stdio: "inherit",
 		},
@@ -23,7 +15,7 @@ const build = dir => {
 const { foundations, svgs, components } = paths
 
 // heavily depended on, build these first
-const highPriorityPackages = [foundations]
+const highPriorityPackages = [foundations, svgs]
 
 // somewhat depended on
 // TODO: try to refactor!

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -1,0 +1,53 @@
+const execa = require("execa")
+const { version } = require("../package.json")
+const { paths, getComponentPaths } = require("./paths")
+
+const build = dir => {
+	return execa(
+		"yarn",
+		[
+			"--cwd",
+			`${dir}`,
+			"run",
+			"publish:public",
+			"--",
+			"--new-version",
+			version,
+		],
+		{
+			stdio: "inherit",
+		},
+	)
+}
+
+const { foundations, svgs, components } = paths
+
+// heavily depended on, build these first
+const highPriorityPackages = [foundations]
+
+// somewhat depended on
+// TODO: try to refactor!
+const mediumPriorityPackages = [`${components}/inline-error`]
+
+// not depended on
+const lowPriorityPackages = getComponentPaths().then(paths =>
+	paths.filter(path => !mediumPriorityPackages.includes(path)),
+)
+
+Promise.all(highPriorityPackages.map(dir => build(dir)))
+	.catch(err => console.log("Error publishing high priority packages:", err))
+	.then(() => Promise.all(mediumPriorityPackages.map(dir => build(dir))))
+	.catch(err =>
+		console.log("Error publishing medium priority packages:", err),
+	)
+	.then(() =>
+		lowPriorityPackages.then(packages => {
+			packages.forEach(package => {
+				if (!package) return
+
+				build(package).catch(err =>
+					console.log("Error publishing low priority package:", err),
+				)
+			})
+		}),
+	)

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/checkbox/package.json
+++ b/src/core/components/checkbox/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "@guardian/src-choice-card",
-	"version": "0.15.0-alpha.1",
+	"version": "0.15.0",
 	"main": "dist/choice-card.js",
 	"module": "dist/choice-card.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/choice-card/rollup.config.js
+++ b/src/core/components/choice-card/rollup.config.js
@@ -22,6 +22,7 @@ module.exports = {
 		"@emotion/css",
 		"@guardian/src-foundations",
 		"@guardian/src-foundations/accessibility",
+		"@guardian/src-foundations/mq",
 		"@guardian/src-foundations/themes",
 		"@guardian/src-foundations/typography",
 	],

--- a/src/core/components/grid/package.json
+++ b/src/core/components/grid/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"clean": "rm -rf dist *.d.ts",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/inline-error/package.json
+++ b/src/core/components/inline-error/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",
@@ -15,7 +16,6 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^0.15.0",
-		"@guardian/src-helpers": "^0.0.1",
 		"@guardian/src-svgs": "^0.15.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/text-input/package.json
+++ b/src/core/components/text-input/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -5,12 +5,13 @@
 	"module": "foundations.esm.js",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/guardian/source-components.git"
+		"url": "https://github.com/guardian/source.git"
 	},
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "yarn clean && tsc && rollup --config --watch",
 		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
+		"publish:public": "yarn publish --access public",
 		"prepublishOnly": "yarn build",
 		"postpublish": "yarn clean"
 	},

--- a/src/core/svgs/package.json
+++ b/src/core/svgs/package.json
@@ -7,7 +7,8 @@
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "rollup --config --watch",
 		"clean": "rm -rf dist *.d.ts",
-		"prepublish": "yarn build"
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",


### PR DESCRIPTION
## What is the purpose of this change?

Publishing all the packages takes ages. We should automate it to speed things up

## What does this change?

- Add a `publish:public` script to each package that runs `yarn publish --access public`
- Add a `publish-release` script that runs through all packages calling `publish:public` script
- Add `publish:release` as a script to the root `package.json`

The script passes the `--new-version` flag with the version specified in the root `package.json`. **This should be set to the next version before running this script.**