### PR TITLE
One script to bump them all

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "source",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"scripts": {
 		"storybook": "yarn watch:foundations & yarn watch:svgs & yarn watch:utilities & start-storybook",
 		"lint:styles": "stylelint src/core/**/styles.ts",
@@ -18,7 +18,8 @@
 		"clean:all": "node ./scripts/clean-all",
 		"build:all": "node ./scripts/build-all",
 		"ci:build": "NODE_ENV=production yarn build:all && yarn build:storybook",
-		"publish:release": "node ./scripts/publish-release"
+		"publish:release": "node ./scripts/publish-release",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"private": true,
 	"workspaces": [

--- a/scripts/paths.js
+++ b/scripts/paths.js
@@ -5,6 +5,7 @@ const { promisify } = require("util")
 const readdirP = promisify(fs.readdir)
 const statP = promisify(fs.stat)
 
+const root = path.join(__dirname, "..")
 const foundations = path.join(__dirname, "../src/core/foundations")
 const svgs = path.join(__dirname, "../src/core/svgs")
 const utilities = path.join(__dirname, "../src/core/utilities")
@@ -30,6 +31,7 @@ const getComponentPaths = () =>
 		.then(paths => Promise.resolve(paths.filter(path => !!path)))
 
 module.exports.paths = {
+	root,
 	foundations,
 	svgs,
 	utilities,

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -2,7 +2,7 @@ const execa = require("execa")
 const { version } = require("../package.json")
 const { paths, getComponentPaths } = require("./paths")
 
-const build = dir => {
+const publish = dir => {
 	return execa(
 		"yarn",
 		["--cwd", `${dir}`, "run", "publish:public", "--new-version", version],
@@ -14,7 +14,7 @@ const build = dir => {
 
 const { foundations, svgs, components } = paths
 
-// heavily depended on, build these first
+// heavily depended on, publish these first
 const highPriorityPackages = [foundations, svgs]
 
 // somewhat depended on
@@ -26,9 +26,9 @@ const lowPriorityPackages = getComponentPaths().then(paths =>
 	paths.filter(path => !mediumPriorityPackages.includes(path)),
 )
 
-Promise.all(highPriorityPackages.map(dir => build(dir)))
+Promise.all(highPriorityPackages.map(dir => publish(dir)))
 	.catch(err => console.log("Error publishing high priority packages:", err))
-	.then(() => Promise.all(mediumPriorityPackages.map(dir => build(dir))))
+	.then(() => Promise.all(mediumPriorityPackages.map(dir => publish(dir))))
 	.catch(err =>
 		console.log("Error publishing medium priority packages:", err),
 	)
@@ -37,7 +37,7 @@ Promise.all(highPriorityPackages.map(dir => build(dir)))
 			packages.forEach(package => {
 				if (!package) return
 
-				build(package).catch(err =>
+				publish(package).catch(err =>
 					console.log("Error publishing low priority package:", err),
 				)
 			})

--- a/scripts/verbump-all.js
+++ b/scripts/verbump-all.js
@@ -1,0 +1,22 @@
+const execa = require("execa")
+const { paths, getComponentPaths } = require("./paths")
+
+const verbump = dir => {
+	return execa("yarn", ["--cwd", `${dir}`, "run", "verbump:minor"], {
+		stdio: "inherit",
+	})
+}
+
+const { root, foundations, svgs } = paths
+
+const packages = getComponentPaths().then(paths =>
+	paths.concat([foundations, svgs, root]),
+)
+
+packages.then(ps => {
+	ps.forEach(dir => {
+		if (!dir) return
+
+		verbump(dir).catch(err => console.log("Error bumping packages:", err))
+	})
+})

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-button",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/button.js",
 	"module": "dist/button.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/checkbox/package.json
+++ b/src/core/components/checkbox/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-checkbox",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/checkbox.js",
 	"module": "dist/checkbox.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-choice-card",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/choice-card.js",
 	"module": "dist/choice-card.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/grid/package.json
+++ b/src/core/components/grid/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-grid",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/grid.js",
 	"module": "dist/grid.esm.js",
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"clean": "rm -rf dist *.d.ts",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/inline-error/package.json
+++ b/src/core/components/inline-error/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-inline-error",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-link",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/link.js",
 	"module": "dist/link.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-radio",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/radio.js",
 	"module": "dist/radio.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/components/text-input/package.json
+++ b/src/core/components/text-input/package.json
@@ -1,13 +1,14 @@
 {
 	"name": "@guardian/src-text-input",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/text-input.js",
 	"module": "dist/text-input.esm.js",
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-foundations",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "foundations.js",
 	"module": "foundations.esm.js",
 	"repository": {
@@ -13,7 +13,8 @@
 		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
 		"publish:public": "yarn publish --access public",
 		"prepublishOnly": "yarn build",
-		"postpublish": "yarn clean"
+		"postpublish": "yarn clean",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"files": [
 		"mq/*",

--- a/src/core/svgs/package.json
+++ b/src/core/svgs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guardian/src-svgs",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"main": "dist/index.js",
 	"module": "dist/index.esm.js",
 	"scripts": {
@@ -8,7 +8,8 @@
 		"watch": "rollup --config --watch",
 		"clean": "rm -rf dist *.d.ts",
 		"prepublish": "yarn build",
-		"publish:public": "yarn publish --access public"
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.8.0",


### PR DESCRIPTION
## What is the purpose of this change?

Verbumping all the packages is a tedious process. We should automate this as much as possible

## What does this change?

- add a script to bump versions of all packages
- demonstrate the efficacy by running that script
- BONUS: a tiny refactor of the publish release script to improve function naming