### PR TITLE
Implement better build for helpers package

### DIFF
--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -7,10 +7,10 @@ const build = dir => {
 	})
 }
 
-const { foundations, svgs, utilities, components } = paths
+const { foundations, svgs, helpers, components } = paths
 
 // heaviy depended on, build these first
-const highPriorityPackages = [foundations, svgs, utilities]
+const highPriorityPackages = [foundations, svgs, helpers]
 
 // somewhat depended on
 // TODO: try to refactor!

--- a/scripts/clean-all.js
+++ b/scripts/clean-all.js
@@ -1,8 +1,8 @@
 const fs = require("fs")
 const execa = require("execa")
-const paths = require("./paths")
+const { paths } = require("./paths")
 
-const { foundations, svgs, utilities, components } = paths
+const { foundations, svgs, helpers, components } = paths
 
 const clean = dir => {
 	return execa("yarn", ["--cwd", `${dir}`, "run", "clean"], {
@@ -10,7 +10,7 @@ const clean = dir => {
 	})
 }
 
-;[foundations, svgs, utilities].forEach(dir => {
+;[foundations, svgs, helpers].forEach(dir => {
 	clean(dir)
 })
 

--- a/scripts/paths.js
+++ b/scripts/paths.js
@@ -8,7 +8,7 @@ const statP = promisify(fs.stat)
 const root = path.join(__dirname, "..")
 const foundations = path.join(__dirname, "../src/core/foundations")
 const svgs = path.join(__dirname, "../src/core/svgs")
-const utilities = path.join(__dirname, "../src/core/utilities")
+const helpers = path.join(__dirname, "../src/core/helpers")
 const components = path.join(__dirname, "../src/core/components")
 
 const isDirectory = path => statP(path).then(stats => stats.isDirectory())
@@ -34,7 +34,7 @@ module.exports.paths = {
 	root,
 	foundations,
 	svgs,
-	utilities,
+	helpers,
 	components,
 }
 module.exports.getComponentPaths = getComponentPaths

--- a/src/core/helpers/.babelrc.js
+++ b/src/core/helpers/.babelrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	presets: ["@babel/preset-env", "@babel/preset-typescript"],
+}

--- a/src/core/helpers/.gitignore
+++ b/src/core/helpers/.gitignore
@@ -1,0 +1,4 @@
+# Ignore built files
+*.d.ts
+*.tgz
+tsconfig.tsbuildinfo

--- a/src/core/helpers/package.json
+++ b/src/core/helpers/package.json
@@ -1,8 +1,34 @@
 {
 	"name": "@guardian/src-helpers",
 	"version": "0.16.0",
-	"main": "index.js",
+	"main": "dist/helpers.js",
+	"module": "dist/helpers.esm.js",
+	"types": "index.d.ts",
 	"license": "MIT",
+	"scripts": {
+		"build": "yarn clean && tsc && rollup --config",
+		"clean": "rm -rf dist *.d.ts tsconfig.tsbuildinfo",
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public",
+		"verbump:minor": "yarn version --minor --no-git-tag-version",
+		"verbump:patch": "yarn version --patch --no-git-tag-version"
+	},
+	"files": [
+		"*.d.ts",
+		"dist/helpers.esm.js"
+	],
+	"devDependencies": {
+		"@babel/core": "^7.8.0",
+		"@babel/preset-env": "^7.8.0",
+		"@babel/preset-react": "^7.8.0",
+		"@babel/preset-typescript": "^7.8.0",
+		"@guardian/src-foundations": "^0.16.0",
+		"rollup": "^1.17.0",
+		"rollup-plugin-babel": "^4.3.3",
+		"rollup-plugin-commonjs": "^10.0.2",
+		"rollup-plugin-node-resolve": "^5.2.0",
+		"typescript": "^3.7.2"
+	},
 	"dependencies": {
 		"@guardian/src-foundations": "^0.16.0"
 	}

--- a/src/core/helpers/rollup.config.js
+++ b/src/core/helpers/rollup.config.js
@@ -1,0 +1,23 @@
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
+import commonjs from "rollup-plugin-commonjs"
+
+const extensions = [".ts", ".tsx"]
+
+module.exports = {
+	input: "index.ts",
+	output: [
+		{
+			file: "dist/helpers.js",
+			format: "cjs",
+			sourceMap: true,
+		},
+		{
+			file: "dist/helpers.esm.js",
+			format: "esm",
+			sourceMap: true,
+		},
+	],
+	external: ["@guardian/src-foundations/palette"],
+	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
+}

--- a/src/core/helpers/tsconfig.json
+++ b/src/core/helpers/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"outDir": ".",
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"composite": true
+	},
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What is the purpose of this change?

The helpers package is now depended upon by production code (only types for now). We should put more love into the build and publish pipeline.

## What does this change?

- add rollup, babel and typescript config
- add build and publish scripts
- add output files to package.json
- add helpers to repo build, clean and publish scripts
- BONUS: remove utilities from repo build, clean and publish scripts
