### PR TITLE
Make foundations a composite project

### DIFF
--- a/src/core/foundations/.gitignore
+++ b/src/core/foundations/.gitignore
@@ -9,6 +9,7 @@ foundations.js
 foundations.esm.js
 *.d.ts
 *.tgz
+tsconfig.tsbuildinfo
 
 # Include src files
 !src/mq/

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "yarn clean && tsc && rollup --config --watch",
-		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts src/**/*.d.ts",
+		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts tsconfig.tsbuildinfo src/**/*.d.ts",
 		"publish:public": "yarn publish --access public",
 		"prepublishOnly": "yarn build",
 		"postpublish": "yarn clean",

--- a/src/core/foundations/tsconfig.json
+++ b/src/core/foundations/tsconfig.json
@@ -2,7 +2,8 @@
 	"compilerOptions": {
 		"outDir": ".",
 		"declaration": true,
-		"emitDeclarationOnly": true
+		"emitDeclarationOnly": true,
+		"composite": true
 	},
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What is the purpose of this change?

Making foundations [a composite project](https://www.typescriptlang.org/docs/handbook/project-references.html#composite) allows us to reference the types from other projects (e.g. Grid). This means the Typescript compiler won't attempt to declare the foundations types inside Grid's type declaration files.

## What does this change?

- make foundations a composite project
