### PR TITLE
Reference foundations and helpers composite projects

### DIFF
--- a/src/core/components/grid/tsconfig.json
+++ b/src/core/components/grid/tsconfig.json
@@ -6,5 +6,9 @@
 		"jsx": "preserve",
 		"esModuleInterop": true
 	},
+	"references": [
+		{ "path": "../../foundations" },
+		{ "path": "../../helpers" }
+	],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What is the purpose of this change?

Foundations and helpers are now composite projects. They may be referenced from the Grid project, and the compiler won't attempt to add the types from these projects to Grid's emitted declaration files

## What does this change?

- reference foundations and helpers composite projects from grid project tsconfig
