### PR TITLE
Delete secondary text colours

### DIFF
--- a/src/core/foundations/src/palette/text/brand-alt.ts
+++ b/src/core/foundations/src/palette/text/brand-alt.ts
@@ -2,7 +2,6 @@ import { neutral } from "../global"
 
 export const brandAltText = {
 	primary: neutral[7],
-	secondary: neutral[60], //TODO: deprecate in v0.16
 	supporting: neutral[60],
 	ctaPrimary: neutral[100],
 	ctaSecondary: neutral[7],

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -2,7 +2,6 @@ import { neutral, success as _success, error as _error, brand } from "../global"
 
 export const brandText = {
 	primary: neutral[100],
-	secondary: brand[800], //TODO: deprecate in v0.16
 	supporting: brand[800],
 	success: _success[400],
 	error: _error[500],

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -2,7 +2,6 @@ import { neutral, error as _error, success as _success, brand } from "../global"
 
 export const text = {
 	primary: neutral[7],
-	secondary: neutral[46], //TODO: deprecate in v0.16
 	supporting: neutral[46],
 	success: _success[400],
 	error: _error[400],


### PR DESCRIPTION
## What is the purpose of this change?

These colours are redundant. Use `text.supporting` instead

## What does this change?

- Delete secondary text colours
