### PR TITLE
Delete old theme names

### DIFF
--- a/src/core/components/inline-error/stories.tsx
+++ b/src/core/components/inline-error/stories.tsx
@@ -17,7 +17,7 @@ const themes: {
 	theme: { inlineError: InlineErrorTheme }
 }[] = [
 	{
-		name: "light",
+		name: "default",
 		theme: inlineErrorLight,
 	},
 	{ name: "brand", theme: inlineErrorBrand },

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -76,11 +76,7 @@ priorityYellow.story = {
 	name: "priority yellow",
 	parameters: {
 		backgrounds: [
-			Object.assign(
-				{},
-				{ default: true },
-				storybookBackgrounds.brandYellow,
-			),
+			Object.assign({}, { default: true }, storybookBackgrounds.brandAlt),
 		],
 	},
 }

--- a/src/core/components/radio/stories/error.tsx
+++ b/src/core/components/radio/stories/error.tsx
@@ -17,7 +17,7 @@ const themes: {
 	theme: {}
 }[] = [
 	{
-		name: "light",
+		name: "default",
 		theme: radioDefault,
 	},
 	{ name: "brand", theme: radioBrand },

--- a/src/core/components/radio/stories/supporting-text.tsx
+++ b/src/core/components/radio/stories/supporting-text.tsx
@@ -36,7 +36,7 @@ const themes: {
 	theme: {}
 }[] = [
 	{
-		name: "light",
+		name: "default",
 		theme: radioDefault,
 	},
 	{ name: "brand", theme: radioBrand },

--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -14,7 +14,7 @@ const themes: {
 	theme: {}
 }[] = [
 	{
-		name: "light",
+		name: "default",
 		theme: textInputLight,
 	},
 ]

--- a/src/core/helpers/storybook-bg.ts
+++ b/src/core/helpers/storybook-bg.ts
@@ -17,12 +17,6 @@ const storybookBackgrounds: {
 		name: "brandAlt",
 		value: brandAltBackground.primary,
 	},
-	// continue to expose legacy theme names
-	light: { name: "light", value: background.primary },
-	brandYellow: {
-		name: "brandYellow",
-		value: brandAltBackground.primary,
-	},
 }
 
 Object.freeze(storybookBackgrounds)

--- a/src/core/helpers/types.ts
+++ b/src/core/helpers/types.ts
@@ -1,11 +1,6 @@
 import { SerializedStyles } from "@emotion/core"
 
-export type ThemeName =
-	| "default"
-	| "light"
-	| "brand"
-	| "brandYellow"
-	| "brandAlt"
+export type ThemeName = "default" | "brand" | "brandAlt"
 
 export interface Props {
 	className?: string


### PR DESCRIPTION
## What is the purpose of this change?

The theme names `light` and `brandYellow` have been replaced by `default` and `brandAlt`, so should be deleted

## What does this change?

- delete old theme names
- refactor theme names in component stories
