### PR TITLE
Choice card tweaks

### DIFF
--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -16,6 +16,7 @@ import {
 	groupLabelSupporting,
 	tick,
 	errorChoiceCard,
+	contentWrapper,
 } from "./styles"
 import { InlineError } from "@guardian/src-inline-error"
 import { Props } from "@guardian/src-helpers"
@@ -146,8 +147,10 @@ const ChoiceCard = ({
 				]}
 				htmlFor={id}
 			>
-				{iconSvg ? iconSvg : ""}
-				<div>{labelContent}</div>
+				<div css={contentWrapper}>
+					{iconSvg ? iconSvg : ""}
+					<div>{labelContent}</div>
+				</div>
 				<span css={theme => [tick(theme.checkbox && theme)]} />
 			</label>
 		</>

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -67,6 +67,15 @@ const iconChoiceCards = [
 		icon={<SvgPayPal />}
 	/>,
 ]
+const wildlyVaryingContentChoiceCards = [
+	<ChoiceCard
+		value="option-1"
+		label="A very, very long piece of text"
+		id="option-1"
+	/>,
+	<ChoiceCard value="option-2" label="Something in between" id="option-2" />,
+	<ChoiceCard value="option-3" label="Short" id="option-3" />,
+]
 /* eslint-enable react/jsx-key */
 
 export default {
@@ -74,11 +83,11 @@ export default {
 }
 
 const medium = css`
-	width: 20em;
+	width: 30em;
 `
 
 const wide = css`
-	width: 30em;
+	width: 40em;
 `
 
 const singleStateLight = () => (
@@ -151,7 +160,7 @@ multiStateWithSupportingLabelLight.story = {
 
 const singleStateWithIconLight = () => (
 	<ThemeProvider theme={choiceCardDefault}>
-		<div css={wide}>
+		<div css={medium}>
 			<ChoiceCardGroup name="colours" label="Payment method">
 				{iconChoiceCards.map((choiceCard, index) =>
 					React.cloneElement(choiceCard, { key: index }),
@@ -212,7 +221,7 @@ singleStateWithIconMobileLight.story = {
 
 const errorLight = () => (
 	<ThemeProvider theme={choiceCardDefault}>
-		<div css={wide}>
+		<div css={medium}>
 			<ChoiceCardGroup
 				name="colours"
 				error="Please select a choice card to continue"
@@ -234,6 +243,27 @@ errorLight.story = {
 	},
 }
 
+const wildlyVaryingLengthLight = () => (
+	<ThemeProvider theme={choiceCardDefault}>
+		<div css={wide}>
+			<ChoiceCardGroup name="options">
+				{wildlyVaryingContentChoiceCards.map((choiceCard, index) =>
+					React.cloneElement(choiceCard, { key: index }),
+				)}
+			</ChoiceCardGroup>
+		</div>
+	</ThemeProvider>
+)
+
+wildlyVaryingLengthLight.story = {
+	name: `single state wildly varying length light`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+	},
+}
+
 export {
 	singleStateLight,
 	singleStateWithLabelLight,
@@ -242,4 +272,5 @@ export {
 	singleStateMobileLight,
 	singleStateWithIconMobileLight,
 	errorLight,
+	wildlyVaryingLengthLight,
 }

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -11,6 +11,8 @@ import {
 
 export const fieldset = css`
 	border: 0;
+	padding: 0;
+	margin: 0;
 `
 
 // TODO: This is currently applied to a div instead of the fieldset
@@ -134,7 +136,7 @@ export const choiceCard = ({
 
 	${from.mobileLandscape} {
 		flex-direction: column;
-		padding: ${space[2]}px ${space[3]}px;
+		padding: ${space[2]}px ${space[6]}px;
 		margin: 0 ${space[2]}px 0 0;
 		&:last-child {
 			margin: 0;
@@ -144,6 +146,7 @@ export const choiceCard = ({
 	& > * {
 		color: ${choiceCard.textLabel};
 		${textSans.medium({ fontWeight: "bold" })};
+		text-align: center;
 	}
 
 	& svg {

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -121,52 +121,60 @@ export const choiceCard = ({
 }: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
 	flex: 1;
 	display: flex;
-	flex-direction: row;
-	box-sizing: border-box;
+	justify-content: center;
 	/* TODO: let's talk about size! */
 	min-height: ${size.large}px;
 	margin: 0 0 ${space[2]}px 0;
-	align-items: center;
-	justify-content: center;
-	padding: ${space[2]}px ${space[5]}px;
 	box-shadow: inset 0 0 0 2px ${choiceCard.border};
 	border-radius: 4px;
 	position: relative;
 	cursor: pointer;
+	color: ${choiceCard.textLabel};
 
 	${from.mobileLandscape} {
-		flex-direction: column;
-		padding: ${space[2]}px ${space[6]}px;
 		margin: 0 ${space[2]}px 0 0;
+
 		&:last-child {
 			margin: 0;
 		}
 	}
 
+	&:hover {
+		box-shadow: inset 0 0 0 4px ${choiceCard.borderHover};
+		color: ${choiceCard.textHover};
+	}
+`
+
+export const contentWrapper = css`
+	flex: 0 1 auto;
+	display: flex;
+	flex-direction: row;
+	box-sizing: border-box;
+	align-items: center;
+	justify-content: center;
+	position: relative;
+
+	${from.mobileLandscape} {
+		flex-direction: column;
+		padding: ${space[2]}px ${space[6]}px;
+	}
+
 	& > * {
-		color: ${choiceCard.textLabel};
 		${textSans.medium({ fontWeight: "bold" })};
 		text-align: center;
 	}
 
 	& svg {
+		position: absolute;
 		/* TODO: 30px is a standard icon width, should probably exposed
 		as a size property */
 		width: 30px;
 		height: auto;
+		left: -34px; /* width + 4px "margin" */
 		fill: currentColor;
-		margin-right: ${space[1]}px;
 
 		${from.mobileLandscape} {
-			margin-right: 0;
-		}
-	}
-
-	&:hover {
-		box-shadow: inset 0 0 0 4px ${choiceCard.borderHover};
-
-		& > * {
-			color: ${choiceCard.textHover};
+			position: static;
 		}
 	}
 `

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -180,9 +180,9 @@ export const tick = ({
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	width: 6px;
-	height: 12px;
-	transform: rotate(45deg) translateX(-100%) translateY(-25%);
+	width: 7px;
+	height: 20px;
+	transform: rotate(45deg) translateX(-100%) translateY(-35%);
 	opacity: 0;
 
 	/* the checkmark ✓ */


### PR DESCRIPTION
## What is the purpose of this change?

Make choice cards look slightly nicer

## What does this change?

- ensure choice cards are always the same width regardless of text length
- increase horizontal padding inside choice cards
- increase the size of the tick
- center the text but not icons in mobile view

## Design

### Screenshots

**Mobile with icons**

<img width="372" alt="Screenshot 2020-03-19 at 12 20 24" src="https://user-images.githubusercontent.com/5931528/77066953-083a9500-69dc-11ea-946b-3a23e5e6ed54.png">

**Desktop with varying length text**

<img width="656" alt="Screenshot 2020-03-19 at 12 20 49" src="https://user-images.githubusercontent.com/5931528/77066981-17214780-69dc-11ea-92db-fa75bb9a3a54.png">



