### PR TITLE
Add typography tests

### DIFF
--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -247,6 +247,9 @@ Object.freeze(titlepieceSizes)
 Object.freeze(headlineSizes)
 Object.freeze(bodySizes)
 Object.freeze(textSansSizes)
+Object.freeze(fontMapping)
+Object.freeze(fontWeightMapping)
+Object.freeze(lineHeightMapping)
 
 export {
 	titlepiece,
@@ -257,6 +260,9 @@ export {
 	headlineSizes,
 	bodySizes,
 	textSansSizes,
+	fontMapping as fonts,
+	fontWeightMapping as fontWeights,
+	lineHeightMapping as lineHeights,
 	Category,
 	LineHeight,
 	FontWeight,

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -1,0 +1,48 @@
+import {
+	headline,
+	fonts,
+	headlineSizes,
+	fontWeights,
+	lineHeights,
+} from "./index"
+
+it("should return styles containing the specified font family", () => {
+	const mediumHeadlineStyles = headline.medium()
+
+	expect(mediumHeadlineStyles).toContain(`font-family: ${fonts.headline};`)
+})
+
+it("should return styles containing the specified font size", () => {
+	const mediumHeadlineStyles = headline.medium()
+
+	expect(mediumHeadlineStyles).toContain(
+		`font-size: ${headlineSizes.medium}rem;`,
+	)
+})
+
+it("should return styles containing the specified font weight", () => {
+	const mediumHeadlineStyles = headline.medium({ fontWeight: "bold" })
+
+	expect(mediumHeadlineStyles).toContain(`font-weight: ${fontWeights.bold};`)
+})
+
+it("should return styles containing the specified line height", () => {
+	const mediumHeadlineStyles = headline.medium({ lineHeight: "tight" })
+
+	expect(mediumHeadlineStyles).toContain(`line-height: ${lineHeights.tight};`)
+})
+
+it("should return italic styles if specified", () => {
+	const mediumHeadlineStyles = headline.medium({ italic: true })
+
+	expect(mediumHeadlineStyles).toContain("font-style: italic;")
+})
+
+it("should not include italic font style if it is not available for requested font", () => {
+	const mediumHeadlineStyles = headline.medium({
+		fontWeight: "bold",
+		italic: true,
+	})
+
+	expect(mediumHeadlineStyles).not.toContain("font-style: italic;")
+})


### PR DESCRIPTION
## What is the purpose of this change?

We are looking to bring in object styles to support a wider range of applications. It will be useful to have a few tests to draw on as we refactor.

## What does this change?

- add typography tests
- export some useful mapping objects
