### PR TITLE
Improve publish of foundations

### DIFF
--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -18,11 +18,12 @@
 		"verbump:patch": "yarn version --patch --no-git-tag-version"
 	},
 	"files": [
-		"mq/*",
-		"accessibility/*",
-		"palette/*",
-		"themes/*",
-		"typography/*",
+		"mq/**",
+		"accessibility/**",
+		"palette/**",
+		"themes/**",
+		"typography/**",
+		"utils/**",
 		"*.d.ts",
 		"foundations.esm.js",
 		"src/animation.ts",
@@ -35,7 +36,7 @@
 		"src/mq/index.ts",
 		"src/palette/**",
 		"src/themes/**",
-		"src/typography/index.ts",
+		"src/typography/**",
 		"src/utils/**"
 	],
 	"devDependencies": {

--- a/src/core/foundations/rollup.config.js
+++ b/src/core/foundations/rollup.config.js
@@ -3,19 +3,33 @@ import resolve from "rollup-plugin-node-resolve"
 
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
-
 const folders = [
 	"accessibility",
 	"mq",
 	"palette",
 	"themes",
 	"typography",
+	"typography/obj",
 	"utils",
-].map(folder => ({
+]
+
+const esmFolders = folders.map(folder => ({
 	input: `src/${folder}/index.ts`,
 	output: [
 		{
 			file: `${folder}/index.js`,
+			format: "esm",
+		},
+	],
+	plugins,
+	external: ["@guardian/src-foundations"],
+}))
+
+const cjsFolders = folders.map(folder => ({
+	input: `src/${folder}/index.ts`,
+	output: [
+		{
+			file: `${folder}/cjs/index.js`,
 			format: "cjs",
 		},
 	],
@@ -38,5 +52,6 @@ module.exports = [
 		],
 		plugins,
 	},
-	...folders,
+	...esmFolders,
+	...cjsFolders,
 ]

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -13,13 +13,6 @@ import {
 	fontMapping,
 	fontWeightMapping,
 	lineHeightMapping,
-	Category,
-	LineHeight,
-	FontWeight,
-	TitlepieceSizes,
-	HeadlineSizes,
-	BodySizes,
-	TextSansSizes,
 	FontScaleArgs,
 } from "./data"
 
@@ -76,11 +69,4 @@ export {
 	fontMapping as fonts,
 	fontWeightMapping as fontWeights,
 	lineHeightMapping as lineHeights,
-	Category,
-	LineHeight,
-	FontWeight,
-	TitlepieceSizes,
-	HeadlineSizes,
-	BodySizes,
-	TextSansSizes,
 }

--- a/src/core/foundations/src/typography/obj/index.ts
+++ b/src/core/foundations/src/typography/obj/index.ts
@@ -7,14 +7,6 @@ import {
 	fontMapping,
 	fontWeightMapping,
 	lineHeightMapping,
-	TypographyStyles,
-	Category,
-	LineHeight,
-	FontWeight,
-	TitlepieceSizes,
-	HeadlineSizes,
-	BodySizes,
-	TextSansSizes,
 } from "../data"
 
 Object.freeze(titlepieceSizes)
@@ -37,12 +29,4 @@ export {
 	fontMapping as fonts,
 	fontWeightMapping as fontWeights,
 	lineHeightMapping as lineHeights,
-	TypographyStyles,
-	Category,
-	LineHeight,
-	FontWeight,
-	TitlepieceSizes,
-	HeadlineSizes,
-	BodySizes,
-	TextSansSizes,
 }

--- a/src/core/foundations/tsconfig.json
+++ b/src/core/foundations/tsconfig.json
@@ -1,9 +1,13 @@
 {
 	"compilerOptions": {
+		"rootDir": "./src",
 		"outDir": ".",
 		"declaration": true,
 		"emitDeclarationOnly": true,
-		"composite": true
+		"declarationDir": ".",
+		"composite": true,
+		"lib": ["es2019", "dom"],
+		"tsBuildInfoFile": "./tsconfig.tsbuildinfo"
 	},
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What is the purpose of this change?

The publish pipeline for foundations is a bit broken.

It's not possible to tree-shake foundations folders because they are published as CommonJS. We should provide ESM versions and make this the default (breaking change)

## What does this change?

- don't export types from entry files
- 💥 publish both esm (default) and cjs entry points for foundations folders
- emit types in the correct directories (broken in #275) 
