### PR TITLE
Explicit rem font size exports

### DIFF
--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -1,6 +1,9 @@
 import { css } from "@emotion/core"
 import { linkLight, LinkTheme } from "@guardian/src-foundations/themes"
-import { textSans, textSansSizes } from "@guardian/src-foundations/typography"
+import {
+	textSans,
+	remTextSansSizes,
+} from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
 export const link = css`
@@ -41,7 +44,7 @@ export const icon = css`
 	svg {
 		fill: currentColor;
 		position: absolute;
-		height: ${textSansSizes.medium}rem;
+		height: ${remTextSansSizes.medium}rem;
 		width: auto;
 
 		/* magic number to align the SVG to the text baseline*/

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -48,15 +48,53 @@ export interface FontScaleArgs {
 	italic?: boolean
 }
 
-export const remFontSizes = fontSizes.map(fontSize => fontSize / 16)
+const titlepieceSizes: { [key in TitlepieceSizes]: number } = {
+	small: fontSizes[7], //42px
+	medium: fontSizes[8], //50px
+	large: fontSizes[9], //70px
+}
 
-export const remTitlepieceSizes: { [key in TitlepieceSizes]: number } = {
+const headlineSizes: { [key in HeadlineSizes]: number } = {
+	xxxsmall: fontSizes[2], //17px
+	xxsmall: fontSizes[3], //20px
+	xsmall: fontSizes[4], //24px
+	small: fontSizes[5], //28px
+	medium: fontSizes[6], //34px
+	large: fontSizes[7], //42px
+	xlarge: fontSizes[8], //50px
+}
+
+const bodySizes: { [key in BodySizes]: number } = {
+	small: fontSizes[1], //15px
+	medium: fontSizes[2], //17px
+}
+
+const textSansSizes: { [key in TextSansSizes]: number } = {
+	xsmall: fontSizes[0], //12px
+	small: fontSizes[1], //15px
+	medium: fontSizes[2], //17px
+	large: fontSizes[3], //20px
+	xlarge: fontSizes[4], //24px
+}
+
+const fontSizeMapping: {
+	[cat in Category]: { [level in string]: number }
+} = {
+	titlepiece: titlepieceSizes,
+	headline: headlineSizes,
+	body: bodySizes,
+	textSans: textSansSizes,
+}
+
+const remFontSizes = fontSizes.map(fontSize => fontSize / 16)
+
+const remTitlepieceSizes: { [key in TitlepieceSizes]: number } = {
 	small: remFontSizes[7], //42px
 	medium: remFontSizes[8], //50px
 	large: remFontSizes[9], //70px
 }
 
-export const remHeadlineSizes: { [key in HeadlineSizes]: number } = {
+const remHeadlineSizes: { [key in HeadlineSizes]: number } = {
 	xxxsmall: remFontSizes[2], //17px
 	xxsmall: remFontSizes[3], //20px
 	xsmall: remFontSizes[4], //24px
@@ -66,12 +104,12 @@ export const remHeadlineSizes: { [key in HeadlineSizes]: number } = {
 	xlarge: remFontSizes[8], //50px
 }
 
-export const remBodySizes: { [key in BodySizes]: number } = {
+const remBodySizes: { [key in BodySizes]: number } = {
 	small: remFontSizes[1], //15px
 	medium: remFontSizes[2], //17px
 }
 
-export const remTextSansSizes: { [key in TextSansSizes]: number } = {
+const remTextSansSizes: { [key in TextSansSizes]: number } = {
 	xsmall: remFontSizes[0], //12px
 	small: remFontSizes[1], //15px
 	medium: remFontSizes[2], //17px
@@ -79,7 +117,7 @@ export const remTextSansSizes: { [key in TextSansSizes]: number } = {
 	xlarge: remFontSizes[4], //24px
 }
 
-export const remFontSizeMapping: {
+const remFontSizeMapping: {
 	[cat in Category]: { [level in string]: number }
 } = {
 	titlepiece: remTitlepieceSizes,
@@ -88,27 +126,27 @@ export const remFontSizeMapping: {
 	textSans: remTextSansSizes,
 }
 
-export const fontMapping: { [cat in Category]: string } = {
+const fontMapping: { [cat in Category]: string } = {
 	titlepiece: fonts.titlepiece,
 	headline: fonts.headlineSerif,
 	body: fonts.bodySerif,
 	textSans: fonts.bodySans,
 }
 
-export const lineHeightMapping: { [lineHight in LineHeight]: number } = {
+const lineHeightMapping: { [lineHight in LineHeight]: number } = {
 	tight: lineHeights[0],
 	regular: lineHeights[1],
 	loose: lineHeights[2],
 }
 
-export const fontWeightMapping: { [fontWeight in FontWeight]: number } = {
+const fontWeightMapping: { [fontWeight in FontWeight]: number } = {
 	light: fontWeights[0],
 	regular: fontWeights[1],
 	medium: fontWeights[2],
 	bold: fontWeights[3],
 }
 
-export const availableFonts: {
+const availableFonts: {
 	[cat in Category]: {
 		[fontWeight in FontWeight]?: FontWeightDefinition
 	}
@@ -145,4 +183,36 @@ export const availableFonts: {
 			hasItalic: false,
 		},
 	},
+}
+
+Object.freeze(titlepieceSizes)
+Object.freeze(headlineSizes)
+Object.freeze(bodySizes)
+Object.freeze(textSansSizes)
+Object.freeze(remTitlepieceSizes)
+Object.freeze(remHeadlineSizes)
+Object.freeze(remBodySizes)
+Object.freeze(remTextSansSizes)
+Object.freeze(fontMapping)
+Object.freeze(fontSizeMapping)
+Object.freeze(fontWeightMapping)
+Object.freeze(lineHeightMapping)
+Object.freeze(availableFonts)
+
+export {
+	titlepieceSizes,
+	headlineSizes,
+	bodySizes,
+	textSansSizes,
+	remFontSizes,
+	remTitlepieceSizes,
+	remHeadlineSizes,
+	remBodySizes,
+	remTextSansSizes,
+	remFontSizeMapping,
+	fontMapping,
+	fontSizeMapping,
+	lineHeightMapping,
+	fontWeightMapping,
+	availableFonts,
 }

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -48,44 +48,44 @@ export interface FontScaleArgs {
 	italic?: boolean
 }
 
-export const fontSizesRem = fontSizes.map(fontSize => fontSize / 16)
+export const remFontSizes = fontSizes.map(fontSize => fontSize / 16)
 
-export const titlepieceSizes: { [key in TitlepieceSizes]: number } = {
-	small: fontSizesRem[7], //42px
-	medium: fontSizesRem[8], //50px
-	large: fontSizesRem[9], //70px
+export const remTitlepieceSizes: { [key in TitlepieceSizes]: number } = {
+	small: remFontSizes[7], //42px
+	medium: remFontSizes[8], //50px
+	large: remFontSizes[9], //70px
 }
 
-export const headlineSizes: { [key in HeadlineSizes]: number } = {
-	xxxsmall: fontSizesRem[2], //17px
-	xxsmall: fontSizesRem[3], //20px
-	xsmall: fontSizesRem[4], //24px
-	small: fontSizesRem[5], //28px
-	medium: fontSizesRem[6], //34px
-	large: fontSizesRem[7], //42px
-	xlarge: fontSizesRem[8], //50px
+export const remHeadlineSizes: { [key in HeadlineSizes]: number } = {
+	xxxsmall: remFontSizes[2], //17px
+	xxsmall: remFontSizes[3], //20px
+	xsmall: remFontSizes[4], //24px
+	small: remFontSizes[5], //28px
+	medium: remFontSizes[6], //34px
+	large: remFontSizes[7], //42px
+	xlarge: remFontSizes[8], //50px
 }
 
-export const bodySizes: { [key in BodySizes]: number } = {
-	small: fontSizesRem[1], //15px
-	medium: fontSizesRem[2], //17px
+export const remBodySizes: { [key in BodySizes]: number } = {
+	small: remFontSizes[1], //15px
+	medium: remFontSizes[2], //17px
 }
 
-export const textSansSizes: { [key in TextSansSizes]: number } = {
-	xsmall: fontSizesRem[0], //12px
-	small: fontSizesRem[1], //15px
-	medium: fontSizesRem[2], //17px
-	large: fontSizesRem[3], //20px
-	xlarge: fontSizesRem[4], //24px
+export const remTextSansSizes: { [key in TextSansSizes]: number } = {
+	xsmall: remFontSizes[0], //12px
+	small: remFontSizes[1], //15px
+	medium: remFontSizes[2], //17px
+	large: remFontSizes[3], //20px
+	xlarge: remFontSizes[4], //24px
 }
 
-export const fontSizeMapping: {
+export const remFontSizeMapping: {
 	[cat in Category]: { [level in string]: number }
 } = {
-	titlepiece: titlepieceSizes,
-	headline: headlineSizes,
-	body: bodySizes,
-	textSans: textSansSizes,
+	titlepiece: remTitlepieceSizes,
+	headline: remHeadlineSizes,
+	body: remBodySizes,
+	textSans: remTextSansSizes,
 }
 
 export const fontMapping: { [cat in Category]: string } = {

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -1,7 +1,7 @@
 import {
 	Fs,
 	fontMapping,
-	fontSizeMapping,
+	remFontSizeMapping,
 	lineHeightMapping,
 	fontWeightMapping,
 	availableFonts,
@@ -9,7 +9,7 @@ import {
 
 export const fs: Fs = (category, level, { lineHeight, fontWeight, italic }) => {
 	const fontFamilyValue = fontMapping[category]
-	const fontSizeValue = fontSizeMapping[category][level]
+	const fontSizeValue = remFontSizeMapping[category][level]
 	const lineHeightValue = lineHeightMapping[lineHeight]
 	// TODO: consider logging an error in development if a requested
 	// font is unavailable

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -6,10 +6,10 @@ import {
 } from "./api"
 import { objectStylesToString } from "./object-styles-to-string"
 import {
-	titlepieceSizes,
-	headlineSizes,
-	bodySizes,
-	textSansSizes,
+	remTitlepieceSizes,
+	remHeadlineSizes,
+	remBodySizes,
+	remTextSansSizes,
 	fontMapping,
 	fontWeightMapping,
 	lineHeightMapping,
@@ -49,10 +49,10 @@ const textSans = Object.fromEntries(
 	}),
 )
 
-Object.freeze(titlepieceSizes)
-Object.freeze(headlineSizes)
-Object.freeze(bodySizes)
-Object.freeze(textSansSizes)
+Object.freeze(remTitlepieceSizes)
+Object.freeze(remHeadlineSizes)
+Object.freeze(remBodySizes)
+Object.freeze(remTextSansSizes)
 Object.freeze(fontMapping)
 Object.freeze(fontWeightMapping)
 Object.freeze(lineHeightMapping)
@@ -62,10 +62,10 @@ export {
 	headline,
 	body,
 	textSans,
-	titlepieceSizes,
-	headlineSizes,
-	bodySizes,
-	textSansSizes,
+	remTitlepieceSizes,
+	remHeadlineSizes,
+	remBodySizes,
+	remTextSansSizes,
 	fontMapping as fonts,
 	fontWeightMapping as fontWeights,
 	lineHeightMapping as lineHeights,

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -6,6 +6,10 @@ import {
 } from "./api"
 import { objectStylesToString } from "./object-styles-to-string"
 import {
+	titlepieceSizes,
+	headlineSizes,
+	bodySizes,
+	textSansSizes,
 	remTitlepieceSizes,
 	remHeadlineSizes,
 	remBodySizes,
@@ -49,19 +53,15 @@ const textSans = Object.fromEntries(
 	}),
 )
 
-Object.freeze(remTitlepieceSizes)
-Object.freeze(remHeadlineSizes)
-Object.freeze(remBodySizes)
-Object.freeze(remTextSansSizes)
-Object.freeze(fontMapping)
-Object.freeze(fontWeightMapping)
-Object.freeze(lineHeightMapping)
-
 export {
 	titlepiece,
 	headline,
 	body,
 	textSans,
+	titlepieceSizes,
+	headlineSizes,
+	bodySizes,
+	textSansSizes,
 	remTitlepieceSizes,
 	remHeadlineSizes,
 	remBodySizes,

--- a/src/core/foundations/src/typography/obj/index.ts
+++ b/src/core/foundations/src/typography/obj/index.ts
@@ -1,18 +1,18 @@
 import { titlepiece, headline, body, textSans } from "../api"
 import {
-	titlepieceSizes,
-	headlineSizes,
-	bodySizes,
-	textSansSizes,
+	remTitlepieceSizes,
+	remHeadlineSizes,
+	remBodySizes,
+	remTextSansSizes,
 	fontMapping,
 	fontWeightMapping,
 	lineHeightMapping,
 } from "../data"
 
-Object.freeze(titlepieceSizes)
-Object.freeze(headlineSizes)
-Object.freeze(bodySizes)
-Object.freeze(textSansSizes)
+Object.freeze(remTitlepieceSizes)
+Object.freeze(remHeadlineSizes)
+Object.freeze(remBodySizes)
+Object.freeze(remTextSansSizes)
 Object.freeze(fontMapping)
 Object.freeze(fontWeightMapping)
 Object.freeze(lineHeightMapping)
@@ -22,10 +22,10 @@ export {
 	headline,
 	body,
 	textSans,
-	titlepieceSizes,
-	headlineSizes,
-	bodySizes,
-	textSansSizes,
+	remTitlepieceSizes,
+	remHeadlineSizes,
+	remBodySizes,
+	remTextSansSizes,
 	fontMapping as fonts,
 	fontWeightMapping as fontWeights,
 	lineHeightMapping as lineHeights,

--- a/src/core/foundations/src/typography/obj/index.ts
+++ b/src/core/foundations/src/typography/obj/index.ts
@@ -1,5 +1,9 @@
 import { titlepiece, headline, body, textSans } from "../api"
 import {
+	titlepieceSizes,
+	headlineSizes,
+	bodySizes,
+	textSansSizes,
 	remTitlepieceSizes,
 	remHeadlineSizes,
 	remBodySizes,
@@ -9,19 +13,15 @@ import {
 	lineHeightMapping,
 } from "../data"
 
-Object.freeze(remTitlepieceSizes)
-Object.freeze(remHeadlineSizes)
-Object.freeze(remBodySizes)
-Object.freeze(remTextSansSizes)
-Object.freeze(fontMapping)
-Object.freeze(fontWeightMapping)
-Object.freeze(lineHeightMapping)
-
 export {
 	titlepiece,
 	headline,
 	body,
 	textSans,
+	titlepieceSizes,
+	headlineSizes,
+	bodySizes,
+	textSansSizes,
 	remTitlepieceSizes,
 	remHeadlineSizes,
 	remBodySizes,

--- a/src/core/foundations/src/typography/obj/typography.obj.test.ts
+++ b/src/core/foundations/src/typography/obj/typography.obj.test.ts
@@ -1,7 +1,7 @@
 import {
 	headline,
 	fonts,
-	headlineSizes,
+	remHeadlineSizes,
 	fontWeights,
 	lineHeights,
 } from "./index"
@@ -15,7 +15,7 @@ it("should return styles containing the specified font family", () => {
 it("should return styles containing the specified font size", () => {
 	const mediumHeadlineStyles = headline.medium()
 
-	expect(mediumHeadlineStyles.fontSize).toBe(`${headlineSizes.medium}rem`)
+	expect(mediumHeadlineStyles.fontSize).toBe(`${remHeadlineSizes.medium}rem`)
 })
 
 it("should return styles containing the specified font weight", () => {

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -1,7 +1,7 @@
 import {
 	headline,
 	fonts,
-	headlineSizes,
+	remHeadlineSizes,
 	fontWeights,
 	lineHeights,
 } from "./index"
@@ -16,7 +16,7 @@ it("should return styles containing the specified font size", () => {
 	const mediumHeadlineStyles = headline.medium()
 
 	expect(mediumHeadlineStyles).toContain(
-		`font-size: ${headlineSizes.medium}rem;`,
+		`font-size: ${remHeadlineSizes.medium}rem;`,
 	)
 })
 


### PR DESCRIPTION
## What is the purpose of this change?

It should be possible to request font sizes in `rem` or `px`

The typography folder exports a number of font size and line height values. These should be treated as `px` values for consistency with other foundations.

We should also export `rem` values, with more explicit naming.

This is to unlock support for Editions and other codebases / use cases that require px values.

## What does this change?

- :boom: use explicit names for rem font size exports
- expose px font sizes and mappings
- update link styles to use new font size naming