### PR TITLE
Support px font sizes in typography API

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -16,6 +16,7 @@ const titlepieceDefaults = {
 	lineHeight: "tight",
 	fontWeight: "bold",
 	italic: false,
+	unit: "rem",
 }
 const titlepieceFs = fs.bind(null, "titlepiece")
 
@@ -35,6 +36,7 @@ const headlineDefaults = {
 	lineHeight: "tight",
 	fontWeight: "medium",
 	italic: false,
+	unit: "rem",
 }
 const headlineFs = fs.bind(null, "headline")
 
@@ -63,6 +65,7 @@ const bodyDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
 	italic: false,
+	unit: "rem",
 }
 const bodyFs = fs.bind(null, "body")
 
@@ -81,6 +84,7 @@ const textSansDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
 	italic: false,
+	unit: "rem",
 }
 const textSansFs = fs.bind(null, "textSans")
 

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -1,5 +1,6 @@
 import { fontSizes, fonts, lineHeights, fontWeights } from "../theme"
 
+export type ScaleUnit = "rem" | "px"
 export type Category = "titlepiece" | "headline" | "body" | "textSans"
 export type LineHeight = "tight" | "regular" | "loose"
 export type FontWeight = "light" | "regular" | "medium" | "bold"
@@ -22,7 +23,7 @@ export type TextSansSizes = "xsmall" | "small" | "medium" | "large" | "xlarge"
 
 export type TypographyStyles = {
 	fontFamily: string
-	fontSize: string
+	fontSize: string | number
 	lineHeight: number
 	fontWeight?: number
 	fontStyle?: string
@@ -35,10 +36,12 @@ export type Fs = (
 		lineHeight,
 		fontWeight,
 		italic,
+		unit,
 	}: {
 		lineHeight: LineHeight
 		fontWeight: FontWeight
 		italic: boolean
+		unit: ScaleUnit
 	},
 ) => TypographyStyles
 
@@ -46,6 +49,7 @@ export interface FontScaleArgs {
 	lineHeight?: LineHeight
 	fontWeight?: FontWeight
 	italic?: boolean
+	unit?: ScaleUnit
 }
 
 const titlepieceSizes: { [key in TitlepieceSizes]: number } = {

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -1,15 +1,22 @@
 import {
 	Fs,
 	fontMapping,
-	remFontSizeMapping,
+	fontSizeMapping,
 	lineHeightMapping,
 	fontWeightMapping,
 	availableFonts,
 } from "./data"
 
-export const fs: Fs = (category, level, { lineHeight, fontWeight, italic }) => {
+export const fs: Fs = (
+	category,
+	level,
+	{ lineHeight, fontWeight, italic, unit },
+) => {
 	const fontFamilyValue = fontMapping[category]
-	const fontSizeValue = remFontSizeMapping[category][level]
+	const fontSizeValue =
+		unit === "px"
+			? fontSizeMapping[category][level]
+			: `${fontSizeMapping[category][level] / 16}rem`
 	const lineHeightValue = lineHeightMapping[lineHeight]
 	// TODO: consider logging an error in development if a requested
 	// font is unavailable
@@ -21,7 +28,7 @@ export const fs: Fs = (category, level, { lineHeight, fontWeight, italic }) => {
 	return Object.assign(
 		{
 			fontFamily: fontFamilyValue,
-			fontSize: `${fontSizeValue}rem`,
+			fontSize: fontSizeValue,
 			lineHeight: lineHeightValue,
 		},
 		fontWeightValue ? { fontWeight: fontWeightValue } : {},

--- a/src/core/foundations/src/typography/obj/typography.obj.test.ts
+++ b/src/core/foundations/src/typography/obj/typography.obj.test.ts
@@ -1,6 +1,7 @@
 import {
 	headline,
 	fonts,
+	headlineSizes,
 	remHeadlineSizes,
 	fontWeights,
 	lineHeights,
@@ -16,6 +17,12 @@ it("should return styles containing the specified font size", () => {
 	const mediumHeadlineStyles = headline.medium()
 
 	expect(mediumHeadlineStyles.fontSize).toBe(`${remHeadlineSizes.medium}rem`)
+})
+
+it("should return styles containing the specified font size in px if requested", () => {
+	const mediumHeadlineStyles = headline.medium({ unit: "px" })
+
+	expect(mediumHeadlineStyles.fontSize).toBe(headlineSizes.medium)
 })
 
 it("should return styles containing the specified font weight", () => {

--- a/src/core/foundations/src/typography/object-styles-to-string.ts
+++ b/src/core/foundations/src/typography/object-styles-to-string.ts
@@ -8,7 +8,7 @@ export const objectStylesToString = ({
 	fontStyle,
 }: TypographyStyles) => `
 	font-family: ${fontFamily};
-	font-size: ${fontSize};
+	font-size: ${typeof fontSize === "number" ? `${fontSize}px` : fontSize};
 	line-height: ${lineHeight};
 	${fontWeight ? `font-weight: ${fontWeight}` : ""};
 	${fontStyle ? `font-style: ${fontStyle}` : ""};

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -1,6 +1,7 @@
 import {
 	headline,
 	fonts,
+	headlineSizes,
 	remHeadlineSizes,
 	fontWeights,
 	lineHeights,
@@ -17,6 +18,14 @@ it("should return styles containing the specified font size", () => {
 
 	expect(mediumHeadlineStyles).toContain(
 		`font-size: ${remHeadlineSizes.medium}rem;`,
+	)
+})
+
+it("should return styles containing the specified font size in px if requested", () => {
+	const mediumHeadlineStyles = headline.medium({ unit: "px" })
+
+	expect(mediumHeadlineStyles).toContain(
+		`font-size: ${headlineSizes.medium}px;`,
 	)
 })
 


### PR DESCRIPTION
## What is the purpose of this change?

For Editions, and perhaps other use cases, it would be useful for users to be able to specify the unit for typography properties. 


## What does this change?

In this change, we start with providing font size as `px` if the user passes `{ unit: 'px' }` as a configuration option to the typography API. 
