### PR TITLE
Support px line heights in typography API

### DIFF
--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -17,7 +17,10 @@ export const fs: Fs = (
 		unit === "px"
 			? fontSizeMapping[category][level]
 			: `${fontSizeMapping[category][level] / 16}rem`
-	const lineHeightValue = lineHeightMapping[lineHeight]
+	const lineHeightValue =
+		unit === "px"
+			? lineHeightMapping[lineHeight] * fontSizeMapping[category][level]
+			: lineHeightMapping[lineHeight]
 	// TODO: consider logging an error in development if a requested
 	// font is unavailable
 	const requestedFont = availableFonts[category][fontWeight]

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -24,7 +24,8 @@ const titlepiece = Object.fromEntries(
 	Object.entries(titlepieceAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options?: FontScaleArgs) => objectStylesToString(func(options)),
+			(options: FontScaleArgs = {}) =>
+				objectStylesToString(func(options), options.unit),
 		]
 	}),
 )
@@ -32,7 +33,8 @@ const headline = Object.fromEntries(
 	Object.entries(headlineAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options?: FontScaleArgs) => objectStylesToString(func(options)),
+			(options: FontScaleArgs = {}) =>
+				objectStylesToString(func(options), options.unit),
 		]
 	}),
 )
@@ -40,7 +42,8 @@ const body = Object.fromEntries(
 	Object.entries(bodyAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options?: FontScaleArgs) => objectStylesToString(func(options)),
+			(options: FontScaleArgs = {}) =>
+				objectStylesToString(func(options), options.unit),
 		]
 	}),
 )
@@ -48,7 +51,8 @@ const textSans = Object.fromEntries(
 	Object.entries(textSansAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options?: FontScaleArgs) => objectStylesToString(func(options)),
+			(options: FontScaleArgs = {}) =>
+				objectStylesToString(func(options), options.unit),
 		]
 	}),
 )

--- a/src/core/foundations/src/typography/obj/typography.obj.test.ts
+++ b/src/core/foundations/src/typography/obj/typography.obj.test.ts
@@ -37,6 +37,17 @@ it("should return styles containing the specified line height", () => {
 	expect(mediumHeadlineStyles.lineHeight).toBe(lineHeights.tight)
 })
 
+it("should return styles containing the specified line height in px if requested", () => {
+	const mediumHeadlineStyles = headline.medium({
+		lineHeight: "tight",
+		unit: "px",
+	})
+
+	expect(mediumHeadlineStyles.lineHeight).toBe(
+		lineHeights.tight * headlineSizes.medium,
+	)
+})
+
 it("should return italic styles if specified", () => {
 	const mediumHeadlineStyles = headline.medium({ italic: true })
 

--- a/src/core/foundations/src/typography/object-styles-to-string.ts
+++ b/src/core/foundations/src/typography/object-styles-to-string.ts
@@ -1,15 +1,18 @@
-import { TypographyStyles } from "./data"
+import { TypographyStyles, ScaleUnit } from "./data"
 
-export const objectStylesToString = ({
-	fontFamily,
-	fontSize,
-	lineHeight,
-	fontWeight,
-	fontStyle,
-}: TypographyStyles) => `
+export const objectStylesToString = (
+	{
+		fontFamily,
+		fontSize,
+		lineHeight,
+		fontWeight,
+		fontStyle,
+	}: TypographyStyles,
+	unit?: ScaleUnit,
+) => `
 	font-family: ${fontFamily};
-	font-size: ${typeof fontSize === "number" ? `${fontSize}px` : fontSize};
-	line-height: ${lineHeight};
+	font-size: ${unit === "px" ? `${fontSize}px` : fontSize};
+	line-height: ${unit === "px" ? `${lineHeight}px` : lineHeight};
 	${fontWeight ? `font-weight: ${fontWeight}` : ""};
 	${fontStyle ? `font-style: ${fontStyle}` : ""};
 `

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -41,6 +41,17 @@ it("should return styles containing the specified line height", () => {
 	expect(mediumHeadlineStyles).toContain(`line-height: ${lineHeights.tight};`)
 })
 
+it("should return styles containing the specified line height in px if requested", () => {
+	const mediumHeadlineStyles = headline.medium({
+		lineHeight: "tight",
+		unit: "px",
+	})
+
+	expect(mediumHeadlineStyles).toContain(
+		`line-height: ${lineHeights.tight * headlineSizes.medium}px;`,
+	)
+})
+
 it("should return italic styles if specified", () => {
 	const mediumHeadlineStyles = headline.medium({ italic: true })
 


### PR DESCRIPTION
## What is the purpose of this change?

Follow on from #288 

## What does this change?

Convert specified line height to px if requested
