### PR TITLE
include px unit in object style line-height

### DIFF
--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -24,7 +24,7 @@ export type TextSansSizes = "xsmall" | "small" | "medium" | "large" | "xlarge"
 export type TypographyStyles = {
 	fontFamily: string
 	fontSize: string | number
-	lineHeight: number
+	lineHeight: string | number
 	fontWeight?: number
 	fontStyle?: string
 }

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -19,7 +19,8 @@ export const fs: Fs = (
 			: `${fontSizeMapping[category][level] / 16}rem`
 	const lineHeightValue =
 		unit === "px"
-			? lineHeightMapping[lineHeight] * fontSizeMapping[category][level]
+			? `${lineHeightMapping[lineHeight] *
+					fontSizeMapping[category][level]}px`
 			: lineHeightMapping[lineHeight]
 	// TODO: consider logging an error in development if a requested
 	// font is unavailable

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -24,8 +24,7 @@ const titlepiece = Object.fromEntries(
 	Object.entries(titlepieceAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options: FontScaleArgs = {}) =>
-				objectStylesToString(func(options), options.unit),
+			(options?: FontScaleArgs) => objectStylesToString(func(options)),
 		]
 	}),
 )
@@ -33,8 +32,7 @@ const headline = Object.fromEntries(
 	Object.entries(headlineAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options: FontScaleArgs = {}) =>
-				objectStylesToString(func(options), options.unit),
+			(options?: FontScaleArgs) => objectStylesToString(func(options)),
 		]
 	}),
 )
@@ -42,8 +40,7 @@ const body = Object.fromEntries(
 	Object.entries(bodyAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options: FontScaleArgs = {}) =>
-				objectStylesToString(func(options), options.unit),
+			(options?: FontScaleArgs) => objectStylesToString(func(options)),
 		]
 	}),
 )
@@ -51,8 +48,7 @@ const textSans = Object.fromEntries(
 	Object.entries(textSansAsObj).map(([key, func]) => {
 		return [
 			key,
-			(options: FontScaleArgs = {}) =>
-				objectStylesToString(func(options), options.unit),
+			(options?: FontScaleArgs) => objectStylesToString(func(options)),
 		]
 	}),
 )

--- a/src/core/foundations/src/typography/obj/typography.obj.test.ts
+++ b/src/core/foundations/src/typography/obj/typography.obj.test.ts
@@ -44,7 +44,7 @@ it("should return styles containing the specified line height in px if requested
 	})
 
 	expect(mediumHeadlineStyles.lineHeight).toBe(
-		lineHeights.tight * headlineSizes.medium,
+		`${lineHeights.tight * headlineSizes.medium}px`,
 	)
 })
 

--- a/src/core/foundations/src/typography/object-styles-to-string.ts
+++ b/src/core/foundations/src/typography/object-styles-to-string.ts
@@ -1,18 +1,15 @@
-import { TypographyStyles, ScaleUnit } from "./data"
+import { TypographyStyles } from "./data"
 
-export const objectStylesToString = (
-	{
-		fontFamily,
-		fontSize,
-		lineHeight,
-		fontWeight,
-		fontStyle,
-	}: TypographyStyles,
-	unit?: ScaleUnit,
-) => `
+export const objectStylesToString = ({
+	fontFamily,
+	fontSize,
+	lineHeight,
+	fontWeight,
+	fontStyle,
+}: TypographyStyles) => `
 	font-family: ${fontFamily};
-	font-size: ${unit === "px" ? `${fontSize}px` : fontSize};
-	line-height: ${unit === "px" ? `${lineHeight}px` : lineHeight};
+	font-size: ${typeof fontSize === "number" ? `${fontSize}px` : fontSize};
+	line-height: ${lineHeight};
 	${fontWeight ? `font-weight: ${fontWeight}` : ""};
 	${fontStyle ? `font-style: ${fontStyle}` : ""};
 `


### PR DESCRIPTION
## What is the purpose of this change?

Line height must explicitly specify px, or unitless line height is applied by Emotion

## What does this change?

Explictly add `px` unit to line-height values when requested in object style
