### PR TITLE
Simpler Headline Font Name

### DIFF
--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -27,7 +27,7 @@ const fontSizes = [12, 15, 17, 20, 24, 28, 34, 42, 50, 70]
 const fonts = {
 	titlepiece: "GT Guardian Titlepiece, Georgia, serif",
 	headlineSerif:
-		"GH Guardian Headline, Guardian Egyptian Web, Georgia, serif",
+		"Guardian Headline, GH Guardian Headline, Guardian Egyptian Web, Georgia, serif",
 	bodySerif:
 		"GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif",
 	bodySans:


### PR DESCRIPTION
## What is the purpose of this change?

I noticed a bug that we've introduced in apps-rendering since switching over to the design system typography APIs: our headline fonts are falling back to Georgia. It might be hard to spot this if your machine has the fonts installed locally, as that will mean it never attempts to load the webfonts. To observe this behaviour you can disable the Guardian fonts locally (in Font Book on macOS).

### Why?

Long story short, naming things is hard. We provide the headline font under the name "Guardian Headline" in our `@font-face` declarations, but the design system specifies "GH Guardian Headline" in `font-family` declarations. These don't match, therefore the browser falls back to the next font specified in `font-family`, in this case Georgia.

### Solution

There are a few ways to solve this:

1. Specify "GH Guardian Headline" in apps-rendering
2. Add "Guardian Headline" to the `font-family` declaration in the design system
3. Replace "GH Guardian Headline" with "Guardian Headline" in the `font-family` declaration in the design system

I've gone for (2) because it's less likely to introduce breaking changes for other projects than (3), although (3) would be my preferred option if possible. I haven't gone for (1) because I think the name should be "Guardian Headline". That said, I don't know why the "GH" prefix exists, so I may be wrong and the best solution is (1) because "GH Guardian Headline" is the correct name. @paperboyo what do you think?

cc @webb04 @gtrufitt 

## What does this change?

- Adds a new name for the headline font: "Guardian Headline".
