### PR TITLE
Sneaky any

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -18,7 +18,7 @@ const titlepieceDefaults = {
 	italic: false,
 	unit: "rem",
 }
-const titlepieceFs = fs.bind(null, "titlepiece")
+const titlepieceFs = fs("titlepiece")
 
 export const titlepiece: TitlepieceFunctions = {
 	small: (options?: FontScaleArgs) =>
@@ -38,7 +38,7 @@ const headlineDefaults = {
 	italic: false,
 	unit: "rem",
 }
-const headlineFs = fs.bind(null, "headline")
+const headlineFs = fs("headline")
 
 export const headline: HeadlineFunctions = {
 	xxxsmall: (options?: FontScaleArgs) =>
@@ -67,7 +67,7 @@ const bodyDefaults = {
 	italic: false,
 	unit: "rem",
 }
-const bodyFs = fs.bind(null, "body")
+const bodyFs = fs("body")
 
 export const body: BodyFunctions = {
 	small: (options?: FontScaleArgs) =>
@@ -86,7 +86,7 @@ const textSansDefaults = {
 	italic: false,
 	unit: "rem",
 }
-const textSansFs = fs.bind(null, "textSans")
+const textSansFs = fs("textSans")
 
 export const textSans: TextSansFunctions = {
 	xsmall: (options?: FontScaleArgs) =>

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -31,6 +31,7 @@ export type TypographyStyles = {
 
 export type Fs = (
 	category: Category,
+) => (
 	level: string,
 	{
 		lineHeight,

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -7,8 +7,7 @@ import {
 	availableFonts,
 } from "./data"
 
-export const fs: Fs = (
-	category,
+export const fs: Fs = category => (
 	level,
 	{ lineHeight, fontWeight, italic, unit },
 ) => {


### PR DESCRIPTION
## What is the purpose of this change?

Dealt with an any that had snuck through. `bind` returns `any`, so the type safety on `fs` was being lost.

## What does this change?

- Replaced `bind`, curried `fs` instead
