### PR TITLE
make text input label bold by default

### DIFF
--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -52,7 +52,7 @@ export const width4 = css`
 export const text = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
-	${textSans.medium()};
+	${textSans.medium({ fontWeight: "bold" })};
 	color: ${textInput.textLabel};
 	margin-bottom: ${space[1]}px;
 `


### PR DESCRIPTION
## What is the purpose of this change?

Designs for the `TextInput` label are bold by default. It stands out next to optional and error messages.

## What does this change?

Set the font weight to bold for `TextInput` labels

### Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/77569030-7510cc00-6ec1-11ea-9bb6-af6c60dbb41a.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/77569045-7d690700-6ec1-11ea-9419-8d6a6ea59dbd.png" width="300"/> |
| <img src="https://user-images.githubusercontent.com/11618797/77569068-86f26f00-6ec1-11ea-8472-5d4b03dec2b8.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/77569093-8f4aaa00-6ec1-11ea-9def-d739335f9bee.png" width="300"/> |
| <img src="https://user-images.githubusercontent.com/11618797/77569122-97a2e500-6ec1-11ea-8e0c-2169484f5b6f.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/77569136-9ec9f300-6ec1-11ea-8890-5ee98675ce6d.png" width="300"/> |
| <img src="https://user-images.githubusercontent.com/11618797/77569159-a7222e00-6ec1-11ea-9d9c-7085d668ffa2.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/77569203-bd2fee80-6ec1-11ea-9e3d-a8b81c41c7c0.png" width="300"/> |
| <img src="https://user-images.githubusercontent.com/11618797/77569221-c456fc80-6ec1-11ea-980f-b62781f02c3b.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/77569229-cb7e0a80-6ec1-11ea-90fa-4f1ddc9e909f.png" width="300"/> |
| <img src="https://user-images.githubusercontent.com/11618797/77569247-d173eb80-6ec1-11ea-8ecf-9fc11df9dc9e.png" width="300"/> | <img src="https://user-images.githubusercontent.com/11618797/77569265-d9339000-6ec1-11ea-9a32-3afd5bb95c01.png" width="300"/> |

