### PR TITLE
Font Style Normal

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -15,7 +15,7 @@ type TitlepieceFunctions = {
 const titlepieceDefaults = {
 	lineHeight: "tight",
 	fontWeight: "bold",
-	italic: false,
+	italic: undefined,
 	unit: "rem",
 }
 const titlepieceFs = fs("titlepiece")
@@ -35,7 +35,7 @@ type HeadlineFunctions = {
 const headlineDefaults = {
 	lineHeight: "tight",
 	fontWeight: "medium",
-	italic: false,
+	italic: undefined,
 	unit: "rem",
 }
 const headlineFs = fs("headline")
@@ -64,7 +64,7 @@ type BodyFunctions = {
 const bodyDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
-	italic: false,
+	italic: undefined,
 	unit: "rem",
 }
 const bodyFs = fs("body")
@@ -83,7 +83,7 @@ type TextSansFunctions = {
 const textSansDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
-	italic: false,
+	italic: undefined,
 	unit: "rem",
 }
 const textSansFs = fs("textSans")

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -41,7 +41,7 @@ export type Fs = (
 	}: {
 		lineHeight: LineHeight
 		fontWeight: FontWeight
-		italic: boolean
+		italic: boolean | undefined
 		unit: ScaleUnit
 	},
 ) => TypographyStyles

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -5,7 +5,23 @@ import {
 	lineHeightMapping,
 	fontWeightMapping,
 	availableFonts,
+	FontWeightDefinition,
 } from "./data"
+
+function fontStyle(
+	font: FontWeightDefinition | undefined,
+	italic: boolean | undefined,
+): string {
+	switch (italic) {
+		case true:
+			return font && font.hasItalic ? "italic" : ""
+		case false:
+			return "normal"
+		case undefined:
+		default:
+			return ""
+	}
+}
 
 export const fs: Fs = category => (
 	level,
@@ -25,8 +41,7 @@ export const fs: Fs = category => (
 	// font is unavailable
 	const requestedFont = availableFonts[category][fontWeight]
 	const fontWeightValue = requestedFont ? fontWeightMapping[fontWeight] : ""
-	const fontStyleValue =
-		italic && requestedFont && requestedFont.hasItalic ? "italic" : ""
+	const fontStyleValue = fontStyle(requestedFont, italic)
 
 	return Object.assign(
 		{

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -58,6 +58,18 @@ it("should return italic styles if specified", () => {
 	expect(mediumHeadlineStyles).toContain("font-style: italic;")
 })
 
+it("should return normal styles if specified", () => {
+	const mediumHeadlineStyles = headline.medium({ italic: false })
+
+	expect(mediumHeadlineStyles).toContain("font-style: normal;")
+})
+
+it("should not return font styles if unspecified", () => {
+	const mediumHeadlineStyles = headline.medium()
+
+	expect(mediumHeadlineStyles).not.toContain("font-style")
+})
+
 it("should not include italic font style if it is not available for requested font", () => {
 	const mediumHeadlineStyles = headline.medium({
 		fontWeight: "bold",


### PR DESCRIPTION
## What is the purpose of this change?

Introduced a way to get `font-style: normal;` by explicitly passing `false` to the `italic` property of font options. Fixes #292.

## What does this change?

- Made default fontStyle `undefined` for all fonts
- Updated 'italic' property to be `true | false | undefined`
- Created function to generate font style
- Added tests for font-style changes
