### PR TITLE
add blue border to text input when active

### DIFF
--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -24,6 +24,10 @@ export const textInput = ({
 	border: 2px solid ${textInput.border};
 	padding: 0 ${space[2]}px;
 
+	&:active {
+		border: 2px solid ${textInput.borderActive};
+	}
+
 	&:focus {
 		${focusHalo};
 	}

--- a/src/core/foundations/src/palette/border/default.ts
+++ b/src/core/foundations/src/palette/border/default.ts
@@ -14,5 +14,6 @@ export const border = {
 	input: neutral[60],
 	inputChecked: brand[500],
 	inputHover: brand[500],
+	inputActive: brand[500],
 	focusHalo: sport[500],
 }

--- a/src/core/foundations/src/themes/text-input.ts
+++ b/src/core/foundations/src/themes/text-input.ts
@@ -9,6 +9,7 @@ export type TextInputTheme = {
 	textError: string
 	backgroundInput: string
 	border: string
+	borderActive: string
 	borderError: string
 }
 
@@ -24,6 +25,7 @@ export const textInputDefault: {
 		textError: text.error,
 		backgroundInput: background.input,
 		border: border.input,
+		borderActive: border.inputActive,
 		borderError: border.error,
 	},
 	...inlineErrorDefault,


### PR DESCRIPTION
## What is the purpose of this change?
Add a blue border colour to text input when active. This shows when the input has been clicked/tapped.

Fixes: https://github.com/guardian/source/issues/281

### Screenshots

**Before**
<img width="513" alt="Screen Shot 2020-03-27 at 10 23 22" src="https://user-images.githubusercontent.com/11618797/77747087-ea8db100-7015-11ea-9901-354fa985f48c.png">

**After**
<img width="515" alt="Screen Shot 2020-03-27 at 10 22 42" src="https://user-images.githubusercontent.com/11618797/77747098-f11c2880-7015-11ea-89e0-e6e3d7ab71d5.png">
