### PR TITLE
Shim Object.entries (and refactor some types) in typography

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -1,15 +1,16 @@
+import { TypographyStyles, FontScaleArgs } from "./data"
 import {
-	TypographyStyles,
-	FontScaleArgs,
 	TitlepieceSizes,
 	HeadlineSizes,
 	BodySizes,
 	TextSansSizes,
-} from "./data"
+} from "./types"
 import { fs } from "./fs"
 
 type TitlepieceFunctions = {
-	[key in TitlepieceSizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof TitlepieceSizes]: (
+		options?: FontScaleArgs,
+	) => TypographyStyles
 }
 
 const titlepieceDefaults = {
@@ -30,7 +31,7 @@ export const titlepiece: TitlepieceFunctions = {
 }
 
 type HeadlineFunctions = {
-	[key in HeadlineSizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof HeadlineSizes]: (options?: FontScaleArgs) => TypographyStyles
 }
 const headlineDefaults = {
 	lineHeight: "tight",
@@ -58,7 +59,7 @@ export const headline: HeadlineFunctions = {
 }
 
 type BodyFunctions = {
-	[key in BodySizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof BodySizes]: (options?: FontScaleArgs) => TypographyStyles
 }
 
 const bodyDefaults = {
@@ -77,7 +78,7 @@ export const body: BodyFunctions = {
 }
 
 type TextSansFunctions = {
-	[key in TextSansSizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof TextSansSizes]: (options?: FontScaleArgs) => TypographyStyles
 }
 
 const textSansDefaults = {

--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -3,15 +3,13 @@ import {
 	HeadlineSizes,
 	BodySizes,
 	TextSansSizes,
-	TypographyStyles,
 	FontScaleArgs,
+	FontScaleFunction,
 } from "./types"
 import { fs } from "./fs"
 
 type TitlepieceFunctions = {
-	[key in keyof TitlepieceSizes]: (
-		options?: FontScaleArgs,
-	) => TypographyStyles
+	[key in keyof TitlepieceSizes]: FontScaleFunction
 }
 
 const titlepieceDefaults = {
@@ -32,7 +30,7 @@ export const titlepiece: TitlepieceFunctions = {
 }
 
 type HeadlineFunctions = {
-	[key in keyof HeadlineSizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof HeadlineSizes]: FontScaleFunction
 }
 const headlineDefaults = {
 	lineHeight: "tight",
@@ -60,7 +58,7 @@ export const headline: HeadlineFunctions = {
 }
 
 type BodyFunctions = {
-	[key in keyof BodySizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof BodySizes]: FontScaleFunction
 }
 
 const bodyDefaults = {
@@ -79,7 +77,7 @@ export const body: BodyFunctions = {
 }
 
 type TextSansFunctions = {
-	[key in keyof TextSansSizes]: (options?: FontScaleArgs) => TypographyStyles
+	[key in keyof TextSansSizes]: FontScaleFunction
 }
 
 const textSansDefaults = {

--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -1,9 +1,10 @@
-import { TypographyStyles, FontScaleArgs } from "./data"
 import {
 	TitlepieceSizes,
 	HeadlineSizes,
 	BodySizes,
 	TextSansSizes,
+	TypographyStyles,
+	FontScaleArgs,
 } from "./types"
 import { fs } from "./fs"
 

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -1,25 +1,17 @@
 import { fontSizes, fonts, lineHeights, fontWeights } from "../theme"
+import {
+	TitlepieceSizes,
+	HeadlineSizes,
+	BodySizes,
+	TextSansSizes,
+	TypographySizes,
+} from "./types"
 
 export type ScaleUnit = "rem" | "px"
 export type Category = "titlepiece" | "headline" | "body" | "textSans"
 export type LineHeight = "tight" | "regular" | "loose"
 export type FontWeight = "light" | "regular" | "medium" | "bold"
 export type FontWeightDefinition = { hasItalic: boolean }
-
-export type TitlepieceSizes = "small" | "medium" | "large"
-
-export type HeadlineSizes =
-	| "xxxsmall"
-	| "xxsmall"
-	| "xsmall"
-	| "small"
-	| "medium"
-	| "large"
-	| "xlarge"
-
-export type BodySizes = "small" | "medium"
-
-export type TextSansSizes = "xsmall" | "small" | "medium" | "large" | "xlarge"
 
 export type TypographyStyles = {
 	fontFamily: string
@@ -53,13 +45,13 @@ export interface FontScaleArgs {
 	unit?: ScaleUnit
 }
 
-const titlepieceSizes: { [key in TitlepieceSizes]: number } = {
+const titlepieceSizes: TitlepieceSizes = {
 	small: fontSizes[7], //42px
 	medium: fontSizes[8], //50px
 	large: fontSizes[9], //70px
 }
 
-const headlineSizes: { [key in HeadlineSizes]: number } = {
+const headlineSizes: HeadlineSizes = {
 	xxxsmall: fontSizes[2], //17px
 	xxsmall: fontSizes[3], //20px
 	xsmall: fontSizes[4], //24px
@@ -69,12 +61,12 @@ const headlineSizes: { [key in HeadlineSizes]: number } = {
 	xlarge: fontSizes[8], //50px
 }
 
-const bodySizes: { [key in BodySizes]: number } = {
+const bodySizes: BodySizes = {
 	small: fontSizes[1], //15px
 	medium: fontSizes[2], //17px
 }
 
-const textSansSizes: { [key in TextSansSizes]: number } = {
+const textSansSizes: TextSansSizes = {
 	xsmall: fontSizes[0], //12px
 	small: fontSizes[1], //15px
 	medium: fontSizes[2], //17px
@@ -83,7 +75,7 @@ const textSansSizes: { [key in TextSansSizes]: number } = {
 }
 
 const fontSizeMapping: {
-	[cat in Category]: { [level in string]: number }
+	[cat in Category]: TypographySizes
 } = {
 	titlepiece: titlepieceSizes,
 	headline: headlineSizes,
@@ -93,13 +85,13 @@ const fontSizeMapping: {
 
 const remFontSizes = fontSizes.map(fontSize => fontSize / 16)
 
-const remTitlepieceSizes: { [key in TitlepieceSizes]: number } = {
+const remTitlepieceSizes: TitlepieceSizes = {
 	small: remFontSizes[7], //42px
 	medium: remFontSizes[8], //50px
 	large: remFontSizes[9], //70px
 }
 
-const remHeadlineSizes: { [key in HeadlineSizes]: number } = {
+const remHeadlineSizes: HeadlineSizes = {
 	xxxsmall: remFontSizes[2], //17px
 	xxsmall: remFontSizes[3], //20px
 	xsmall: remFontSizes[4], //24px
@@ -109,12 +101,12 @@ const remHeadlineSizes: { [key in HeadlineSizes]: number } = {
 	xlarge: remFontSizes[8], //50px
 }
 
-const remBodySizes: { [key in BodySizes]: number } = {
+const remBodySizes: BodySizes = {
 	small: remFontSizes[1], //15px
 	medium: remFontSizes[2], //17px
 }
 
-const remTextSansSizes: { [key in TextSansSizes]: number } = {
+const remTextSansSizes: TextSansSizes = {
 	xsmall: remFontSizes[0], //12px
 	small: remFontSizes[1], //15px
 	medium: remFontSizes[2], //17px
@@ -123,7 +115,7 @@ const remTextSansSizes: { [key in TextSansSizes]: number } = {
 }
 
 const remFontSizeMapping: {
-	[cat in Category]: { [level in string]: number }
+	[cat in Category]: TypographySizes
 } = {
 	titlepiece: remTitlepieceSizes,
 	headline: remHeadlineSizes,

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -1,49 +1,15 @@
 import { fontSizes, fonts, lineHeights, fontWeights } from "../theme"
 import {
+	Category,
+	LineHeight,
+	FontWeight,
+	FontWeightDefinition,
 	TitlepieceSizes,
 	HeadlineSizes,
 	BodySizes,
 	TextSansSizes,
 	TypographySizes,
 } from "./types"
-
-export type ScaleUnit = "rem" | "px"
-export type Category = "titlepiece" | "headline" | "body" | "textSans"
-export type LineHeight = "tight" | "regular" | "loose"
-export type FontWeight = "light" | "regular" | "medium" | "bold"
-export type FontWeightDefinition = { hasItalic: boolean }
-
-export type TypographyStyles = {
-	fontFamily: string
-	fontSize: string | number
-	lineHeight: string | number
-	fontWeight?: number
-	fontStyle?: string
-}
-
-export type Fs = (
-	category: Category,
-) => (
-	level: string,
-	{
-		lineHeight,
-		fontWeight,
-		italic,
-		unit,
-	}: {
-		lineHeight: LineHeight
-		fontWeight: FontWeight
-		italic: boolean
-		unit: ScaleUnit
-	},
-) => TypographyStyles
-
-export interface FontScaleArgs {
-	lineHeight?: LineHeight
-	fontWeight?: FontWeight
-	italic?: boolean
-	unit?: ScaleUnit
-}
 
 const titlepieceSizes: TitlepieceSizes = {
 	small: fontSizes[7], //42px

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -1,11 +1,11 @@
 import {
-	Fs,
 	fontMapping,
 	fontSizeMapping,
 	lineHeightMapping,
 	fontWeightMapping,
 	availableFonts,
 } from "./data"
+import { Fs } from "./types"
 
 export const fs: Fs = category => (
 	level,

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -19,8 +19,35 @@ import {
 	lineHeightMapping,
 	FontScaleArgs,
 } from "./data"
+import {
+	TitlepieceSizes,
+	HeadlineSizes,
+	BodySizes,
+	TextSansSizes,
+} from "./types"
 
-const titlepiece = Object.fromEntries(
+const fromEntries = <Sizes>(
+	entries: [keyof Sizes, (options?: FontScaleArgs) => string][],
+): {
+	[key in keyof Sizes]: (options?: FontScaleArgs) => string
+} =>
+	entries.reduce(
+		(
+			acc: {
+				[key in keyof Sizes]: (options?: FontScaleArgs) => string
+			},
+			[key, value],
+		) => {
+			acc[key] = value
+
+			return acc
+		},
+		{} as {
+			[key in keyof Sizes]: (options?: FontScaleArgs) => string
+		},
+	)
+
+const titlepiece = fromEntries<TitlepieceSizes>(
 	Object.entries(titlepieceAsObj).map(([key, func]) => {
 		return [
 			key,
@@ -28,7 +55,7 @@ const titlepiece = Object.fromEntries(
 		]
 	}),
 )
-const headline = Object.fromEntries(
+const headline = fromEntries<HeadlineSizes>(
 	Object.entries(headlineAsObj).map(([key, func]) => {
 		return [
 			key,
@@ -36,7 +63,7 @@ const headline = Object.fromEntries(
 		]
 	}),
 )
-const body = Object.fromEntries(
+const body = fromEntries<BodySizes>(
 	Object.entries(bodyAsObj).map(([key, func]) => {
 		return [
 			key,
@@ -44,7 +71,7 @@ const body = Object.fromEntries(
 		]
 	}),
 )
-const textSans = Object.fromEntries(
+const textSans = fromEntries<TextSansSizes>(
 	Object.entries(textSansAsObj).map(([key, func]) => {
 		return [
 			key,

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -24,17 +24,18 @@ import {
 	BodySizes,
 	TextSansSizes,
 	FontScaleArgs,
+	FontScaleFunctionStr,
 } from "./types"
 
 const fromEntries = <Sizes>(
-	entries: [keyof Sizes, (options?: FontScaleArgs) => string][],
+	entries: [keyof Sizes, FontScaleFunctionStr][],
 ): {
-	[key in keyof Sizes]: (options?: FontScaleArgs) => string
+	[key in keyof Sizes]: FontScaleFunctionStr
 } =>
 	entries.reduce(
 		(
 			acc: {
-				[key in keyof Sizes]: (options?: FontScaleArgs) => string
+				[key in keyof Sizes]: FontScaleFunctionStr
 			},
 			[key, value],
 		) => {
@@ -43,7 +44,7 @@ const fromEntries = <Sizes>(
 			return acc
 		},
 		{} as {
-			[key in keyof Sizes]: (options?: FontScaleArgs) => string
+			[key in keyof Sizes]: FontScaleFunctionStr
 		},
 	)
 

--- a/src/core/foundations/src/typography/index.ts
+++ b/src/core/foundations/src/typography/index.ts
@@ -17,13 +17,13 @@ import {
 	fontMapping,
 	fontWeightMapping,
 	lineHeightMapping,
-	FontScaleArgs,
 } from "./data"
 import {
 	TitlepieceSizes,
 	HeadlineSizes,
 	BodySizes,
 	TextSansSizes,
+	FontScaleArgs,
 } from "./types"
 
 const fromEntries = <Sizes>(

--- a/src/core/foundations/src/typography/object-styles-to-string.ts
+++ b/src/core/foundations/src/typography/object-styles-to-string.ts
@@ -1,4 +1,4 @@
-import { TypographyStyles } from "./data"
+import { TypographyStyles } from "./types"
 
 export const objectStylesToString = ({
 	fontFamily,

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -1,3 +1,16 @@
+export type ScaleUnit = "rem" | "px"
+export type Category = "titlepiece" | "headline" | "body" | "textSans"
+export type LineHeight = "tight" | "regular" | "loose"
+export type FontWeight = "light" | "regular" | "medium" | "bold"
+export type FontWeightDefinition = { hasItalic: boolean }
+
+export type TypographyStyles = {
+	fontFamily: string
+	fontSize: string | number
+	lineHeight: string | number
+	fontWeight?: number
+	fontStyle?: string
+}
 export type TypographySizes = {
 	[key in string]: number
 }
@@ -27,4 +40,28 @@ export interface TextSansSizes extends TypographySizes {
 	medium: number
 	large: number
 	xlarge: number
+}
+
+export type Fs = (
+	category: Category,
+) => (
+	level: string,
+	{
+		lineHeight,
+		fontWeight,
+		italic,
+		unit,
+	}: {
+		lineHeight: LineHeight
+		fontWeight: FontWeight
+		italic: boolean
+		unit: ScaleUnit
+	},
+) => TypographyStyles
+
+export interface FontScaleArgs {
+	lineHeight?: LineHeight
+	fontWeight?: FontWeight
+	italic?: boolean
+	unit?: ScaleUnit
 }

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -59,6 +59,11 @@ export type Fs = (
 	},
 ) => TypographyStyles
 
+export type FontScaleFunction = (options?: FontScaleArgs) => TypographyStyles
+
+// returns styles as a template literal
+export type FontScaleFunctionStr = (options?: FontScaleArgs) => string
+
 export interface FontScaleArgs {
 	lineHeight?: LineHeight
 	fontWeight?: FontWeight

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -1,0 +1,30 @@
+export type TypographySizes = {
+	[key in string]: number
+}
+
+export interface TitlepieceSizes extends TypographySizes {
+	small: number
+	medium: number
+	large: number
+}
+
+export interface HeadlineSizes extends TypographySizes {
+	xxxsmall: number
+	xxsmall: number
+	xsmall: number
+	small: number
+	medium: number
+	large: number
+	xlarge: number
+}
+export interface BodySizes extends TypographySizes {
+	small: number
+	medium: number
+}
+export interface TextSansSizes extends TypographySizes {
+	xsmall: number
+	small: number
+	medium: number
+	large: number
+	xlarge: number
+}


### PR DESCRIPTION
## What is the purpose of this change?

We're working with a lot of custom types for typography. We should use interfaces where possible as they are more indexable.

## What does this change?

- Use interfaces to define the available font sizes for each font family
- Move types to a new `types` module
- Replace use of Object.fromEntries with a shim