### PR TITLE
Strict Foundations

### DIFF
--- a/src/core/foundations/tsconfig.json
+++ b/src/core/foundations/tsconfig.json
@@ -6,6 +6,7 @@
 		"emitDeclarationOnly": true,
 		"declarationDir": ".",
 		"composite": true,
+		"strict": true,
 		"lib": ["es2019", "dom"],
 		"tsBuildInfoFile": "./tsconfig.tsbuildinfo"
 	},


### PR DESCRIPTION
## What is the purpose of this change?

Applies the [`strict` flag](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to the TS compiler. It's a useful option to make the type checker do more work for you. The principle reason I'm enabling it here is to get `strictNullChecks`, which prevents `null` and `undefined` being part of every type.

## What does this change?

- Added `strict` to the `tsconfig.json` for foundations
