### PR TITLE
Font-Style API - Specify Normal

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -15,7 +15,7 @@ type TitlepieceFunctions = {
 const titlepieceDefaults = {
 	lineHeight: "tight",
 	fontWeight: "bold",
-	italic: false,
+	fontStyle: null,
 	unit: "rem",
 }
 const titlepieceFs = fs("titlepiece")
@@ -35,7 +35,7 @@ type HeadlineFunctions = {
 const headlineDefaults = {
 	lineHeight: "tight",
 	fontWeight: "medium",
-	italic: false,
+	fontStyle: null,
 	unit: "rem",
 }
 const headlineFs = fs("headline")
@@ -64,7 +64,7 @@ type BodyFunctions = {
 const bodyDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
-	italic: false,
+	fontStyle: null,
 	unit: "rem",
 }
 const bodyFs = fs("body")
@@ -83,7 +83,7 @@ type TextSansFunctions = {
 const textSansDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
-	italic: false,
+	fontStyle: null,
 	unit: "rem",
 }
 const textSansFs = fs("textSans")

--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -15,6 +15,7 @@ type TitlepieceFunctions = {
 const titlepieceDefaults = {
 	lineHeight: "tight",
 	fontWeight: "bold",
+	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }
@@ -35,6 +36,7 @@ type HeadlineFunctions = {
 const headlineDefaults = {
 	lineHeight: "tight",
 	fontWeight: "medium",
+	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }
@@ -64,6 +66,7 @@ type BodyFunctions = {
 const bodyDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
+	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }
@@ -83,6 +86,7 @@ type TextSansFunctions = {
 const textSansDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
+	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -7,9 +7,17 @@ import {
 } from "./data"
 import { Fs, FontWeightDefinition, FontStyle, Option } from "./types"
 
+// Exists to support deprecated API, should be removed at some point
+const legacyItalic = (
+	font: FontWeightDefinition | undefined,
+	italic: boolean,
+): Option<FontStyle> =>
+	italic && font !== undefined && font.hasItalic ? "italic" : null
+
 function getFontStyle(
 	font: FontWeightDefinition | undefined,
 	fontStyle: Option<FontStyle>,
+	italic: boolean,
 ): Option<FontStyle> {
 	switch (fontStyle) {
 		case "italic":
@@ -18,13 +26,13 @@ function getFontStyle(
 			return "normal"
 		case null:
 		default:
-			return null
+			return legacyItalic(font, italic)
 	}
 }
 
 export const fs: Fs = category => (
 	level,
-	{ lineHeight, fontWeight, fontStyle, unit },
+	{ lineHeight, fontWeight, italic, fontStyle, unit },
 ) => {
 	const fontFamilyValue = fontMapping[category]
 	const fontSizeValue =
@@ -40,7 +48,7 @@ export const fs: Fs = category => (
 	// font is unavailable
 	const requestedFont = availableFonts[category][fontWeight]
 	const fontWeightValue = requestedFont ? fontWeightMapping[fontWeight] : ""
-	const fontStyleValue = getFontStyle(requestedFont, fontStyle)
+	const fontStyleValue = getFontStyle(requestedFont, fontStyle, italic)
 
 	return Object.assign(
 		{

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -5,11 +5,26 @@ import {
 	fontWeightMapping,
 	availableFonts,
 } from "./data"
-import { Fs } from "./types"
+import { Fs, FontWeightDefinition, FontStyle, Option } from "./types"
+
+function getFontStyle(
+	font: FontWeightDefinition | undefined,
+	fontStyle: Option<FontStyle>,
+): Option<FontStyle> {
+	switch (fontStyle) {
+		case "italic":
+			return font && font.hasItalic ? "italic" : null
+		case "normal":
+			return "normal"
+		case null:
+		default:
+			return null
+	}
+}
 
 export const fs: Fs = category => (
 	level,
-	{ lineHeight, fontWeight, italic, unit },
+	{ lineHeight, fontWeight, fontStyle, unit },
 ) => {
 	const fontFamilyValue = fontMapping[category]
 	const fontSizeValue =
@@ -25,8 +40,7 @@ export const fs: Fs = category => (
 	// font is unavailable
 	const requestedFont = availableFonts[category][fontWeight]
 	const fontWeightValue = requestedFont ? fontWeightMapping[fontWeight] : ""
-	const fontStyleValue =
-		italic && requestedFont && requestedFont.hasItalic ? "italic" : ""
+	const fontStyleValue = getFontStyle(requestedFont, fontStyle)
 
 	return Object.assign(
 		{

--- a/src/core/foundations/src/typography/obj/typography.obj.test.ts
+++ b/src/core/foundations/src/typography/obj/typography.obj.test.ts
@@ -49,7 +49,7 @@ it("should return styles containing the specified line height in px if requested
 })
 
 it("should return italic styles if specified", () => {
-	const mediumHeadlineStyles = headline.medium({ italic: true })
+	const mediumHeadlineStyles = headline.medium({ fontStyle: "italic" })
 
 	expect(mediumHeadlineStyles.fontStyle).toBe("italic")
 })
@@ -57,7 +57,7 @@ it("should return italic styles if specified", () => {
 it("should not include italic font style if it is not available for requested font", () => {
 	const mediumHeadlineStyles = headline.medium({
 		fontWeight: "bold",
-		italic: true,
+		fontStyle: "italic",
 	})
 
 	expect(mediumHeadlineStyles.fontStyle).toBeUndefined()

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -56,6 +56,7 @@ export type Fs = (
 	}: {
 		lineHeight: LineHeight
 		fontWeight: FontWeight
+		italic: boolean
 		fontStyle: Option<FontStyle>
 		unit: ScaleUnit
 	},
@@ -69,6 +70,7 @@ export type FontScaleFunctionStr = (options?: FontScaleArgs) => string
 export interface FontScaleArgs {
 	lineHeight?: LineHeight
 	fontWeight?: FontWeight
+	italic?: boolean
 	fontStyle?: FontStyle
 	unit?: ScaleUnit
 }

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -2,7 +2,9 @@ export type ScaleUnit = "rem" | "px"
 export type Category = "titlepiece" | "headline" | "body" | "textSans"
 export type LineHeight = "tight" | "regular" | "loose"
 export type FontWeight = "light" | "regular" | "medium" | "bold"
+export type FontStyle = "normal" | "italic"
 export type FontWeightDefinition = { hasItalic: boolean }
+export type Option<A> = A | null
 
 export type TypographyStyles = {
 	fontFamily: string
@@ -49,12 +51,12 @@ export type Fs = (
 	{
 		lineHeight,
 		fontWeight,
-		italic,
+		fontStyle,
 		unit,
 	}: {
 		lineHeight: LineHeight
 		fontWeight: FontWeight
-		italic: boolean
+		fontStyle: Option<FontStyle>
 		unit: ScaleUnit
 	},
 ) => TypographyStyles
@@ -67,6 +69,6 @@ export type FontScaleFunctionStr = (options?: FontScaleArgs) => string
 export interface FontScaleArgs {
 	lineHeight?: LineHeight
 	fontWeight?: FontWeight
-	italic?: boolean
+	fontStyle?: FontStyle
 	unit?: ScaleUnit
 }

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -51,6 +51,7 @@ export type Fs = (
 	{
 		lineHeight,
 		fontWeight,
+		italic,
 		fontStyle,
 		unit,
 	}: {

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -70,6 +70,22 @@ it("should not return font styles if unspecified", () => {
 	expect(mediumHeadlineStyles).not.toContain("font-style")
 })
 
+it("should support the legacy italic API", () => {
+	const mediumHeadlineStyles = headline.medium({ italic: true })
+
+	expect(mediumHeadlineStyles).toContain("font-style: italic;")
+})
+
+it("should prioritise the new font style API over the deprecated one", () => {
+	const mediumHeadlineStyles = headline.medium({
+		fontStyle: "normal",
+		italic: true,
+	})
+
+	expect(mediumHeadlineStyles).toContain("font-style: normal;")
+	expect(mediumHeadlineStyles).not.toContain("font-style: italic;")
+})
+
 it("should not include italic font style if it is not available for requested font", () => {
 	const mediumHeadlineStyles = headline.medium({
 		fontWeight: "bold",

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -53,15 +53,27 @@ it("should return styles containing the specified line height in px if requested
 })
 
 it("should return italic styles if specified", () => {
-	const mediumHeadlineStyles = headline.medium({ italic: true })
+	const mediumHeadlineStyles = headline.medium({ fontStyle: "italic" })
 
 	expect(mediumHeadlineStyles).toContain("font-style: italic;")
+})
+
+it("should return normal styles if specified", () => {
+	const mediumHeadlineStyles = headline.medium({ fontStyle: "normal" })
+
+	expect(mediumHeadlineStyles).toContain("font-style: normal;")
+})
+
+it("should not return font styles if unspecified", () => {
+	const mediumHeadlineStyles = headline.medium()
+
+	expect(mediumHeadlineStyles).not.toContain("font-style")
 })
 
 it("should not include italic font style if it is not available for requested font", () => {
 	const mediumHeadlineStyles = headline.medium({
 		fontWeight: "bold",
-		italic: true,
+		fontStyle: "italic",
 	})
 
 	expect(mediumHeadlineStyles).not.toContain("font-style: italic;")

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -92,5 +92,11 @@ it("should not include italic font style if it is not available for requested fo
 		fontStyle: "italic",
 	})
 
+	const largeHeadlineStyles = headline.large({
+		fontWeight: "bold",
+		italic: true,
+	})
+
 	expect(mediumHeadlineStyles).not.toContain("font-style: italic;")
+	expect(largeHeadlineStyles).not.toContain("font-style: italic;")
 })


### PR DESCRIPTION
## What is the purpose of this change?

Introduces a new API for `font-style` via a new `FontStyle` type. If specified, `FontStyle` can be `"normal"` or `"italic"`. If unspecified it won't be set in the resulting CSS.

Closes #292, and introduces a more explicit API than #297.

**Note:** I've added the `Option` type and put it in what I think is probably not the right place. If you would prefer not to create this new type, or would like it to exist in a different place at least, please let me know.

## What does this change?

- Migrated from specifying `italic` as a boolean to custom type `FontStyle`
- Added `Option` type
- Updated tests
