### PR TITLE
Hardcode icon width, allow height to scale

### DIFF
--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -1,9 +1,7 @@
 import { css } from "@emotion/core"
+import { size } from "@guardian/src-foundations"
 import { linkLight, LinkTheme } from "@guardian/src-foundations/themes"
-import {
-	textSans,
-	remTextSansSizes,
-} from "@guardian/src-foundations/typography"
+import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
 export const link = css`
@@ -44,8 +42,14 @@ export const icon = css`
 	svg {
 		fill: currentColor;
 		position: absolute;
-		height: ${remTextSansSizes.medium}rem;
-		width: auto;
+		/*
+			We support two SVG sizes:
+			- Square: 30x30
+			- Wide: 30x20
+			Since width is constant, we'll hard code it here and allow height to scale
+		*/
+		width: ${size.medium / 2}px;
+		height: auto;
 
 		/* magic number to align the SVG to the text baseline*/
 		bottom: 4px;


### PR DESCRIPTION
## What is the purpose of this change?

We now support 2 SVG sizes:

- Square: 30px x 30px
- Wide: 30px x 20px

We need to ensure both sizes look great when used within the `Link`  component.

## What does this change?

Since both sizes share a constant width, we should explicitly set the width in the Link styles and allow the height to scale.

-   Explicitly set icon width. Make height auto

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before**

![Screenshot 2020-04-06 at 16 31 49](https://user-images.githubusercontent.com/5931528/78576106-239f0000-7824-11ea-9cb5-734a8fd3abae.png)

**After**

![Screenshot 2020-04-06 at 16 31 55](https://user-images.githubusercontent.com/5931528/78576111-26015a00-7824-11ea-8353-f55e3fbb388e.png)
