### PR TITLE
add aria-required attribute based on optional prop

### DIFF
--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -73,6 +73,7 @@ const TextInput = ({
 					error ? errorInput(theme.textInput && theme) : "",
 					cssOverrides,
 				]}
+				aria-required={!optional}
 				{...props}
 			/>
 		</label>


### PR DESCRIPTION
## What is the purpose of this change?

Sighted users can viually scan a form to determine which fields are optional (marked with an optional label) and which are required (implied by the omission of this label). 

However for screen reader users, if the first field they encounter is required, it's not obvious that this is the case. We should therefore set the `aria-required` to true if the `optional` prop is not passed or is set to `false`.

This stops short of setting the `required` attribute to true. I propose that we recommend never to pass the `required` attribute as it means fields are automatically invalid and receive error styling as soon as they are rendered. This is a poor user experience.

## What does this change?

-   set the `aria-required` to true if the `optional` prop is not passed or is set to `false`

## Design

### Screenshots

**Before**

![Screenshot 2020-04-07 at 11 10 43](https://user-images.githubusercontent.com/5931528/78657289-75956380-78c0-11ea-999f-69ca28d1f0b2.png)


**After**

![Screenshot 2020-04-07 at 11 09 35](https://user-images.githubusercontent.com/5931528/78657300-78905400-78c0-11ea-8009-d8d58ff3a967.png)

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
