### PR TITLE
CI Excludes master And gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 on:
     push:
-        branches:
-            - "*"
+        branches-ignore:
+            - 'master'
+            - 'gh-pages'
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What is the purpose of this change?

Added `master` and `gh-pages` to ignored CI branches. CI will run on all other branches. From the docs [here](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags). Should fix #304.

## What does this change?

- Removes the `branches` positive match
- Adds the `branches-ignore` negative match for `master` and `gh-pages`
