### PR TITLE
update positional properties for unlabelled checkbox tick

### DIFF
--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -111,11 +111,15 @@ export const tick = ({
 	@supports (appearance: none) {
 		/* overall positional properties */
 		position: absolute;
-		top: 13px;
-		left: 17px;
 		width: 6px;
 		height: 12px;
 		transform: rotate(45deg);
+		/*
+			these properties are very sensitive and are overridden
+			if the checkbox has a label or supporting text
+		*/
+		top: 14px;
+		left: 9px;
 
 		/* the checkmark ✓ */
 		&:after,


### PR DESCRIPTION
## What is the purpose of this change?

The checkbox tick is positioned incorrectly if it has no label or supporting text

## What does this change?

-   correct the top and left values for unlabelled checkbox without supporting text

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before**

![Screenshot 2020-04-08 at 10 09 37](https://user-images.githubusercontent.com/5931528/78766555-501c5e80-7981-11ea-928a-1d21ab3fbcd9.png)


**After**

![Screenshot 2020-04-08 at 10 09 21](https://user-images.githubusercontent.com/5931528/78766566-53174f00-7981-11ea-8358-f17e05d663d7.png)

