### PR TITLE
Subdued button

### DIFF
--- a/src/core/components/button/README.md
+++ b/src/core/components/button/README.md
@@ -63,7 +63,7 @@ Whether to show the arrow icon in this button
 
 ### `priority`
 
-**`"primary" | "secondary" | "tertiary"`** _= "primary"_
+**`"primary" | "secondary" | "subdued"`** _= "primary"_
 
 Informs users of how important an action is
 

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -12,6 +12,7 @@ import {
 	primary,
 	secondary,
 	tertiary,
+	subdued,
 	defaultSize,
 	smallSize,
 	iconDefault,
@@ -31,7 +32,7 @@ export {
 } from "@guardian/src-foundations/themes"
 export { buttonReaderRevenue, buttonReaderRevenueAlt } from "./themes"
 
-export type Priority = "primary" | "secondary" | "tertiary"
+export type Priority = "primary" | "secondary" | "tertiary" | "subdued"
 type IconSide = "left" | "right"
 type Size = "default" | "small"
 type LinkButtonPriority = Extract<"primary" | "secondary", Priority>
@@ -42,6 +43,7 @@ const priorities: {
 	primary,
 	secondary,
 	tertiary,
+	subdued,
 }
 
 const iconSides: {

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -25,7 +25,7 @@ const priorityButtons = [
 	>
 		Secondary
 	</Button>,
-	<Button priority="tertiary">Tertiary</Button>,
+	<Button priority="subdued">Subdued</Button>,
 ]
 const sizeButtons = [
 	<Button>Default</Button>,

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -46,12 +46,12 @@ export const secondary = ({
 	}
 `
 
-export const tertiary = ({
+export const subdued = ({
 	button,
 }: { button: ButtonTheme } = buttonDefault) => css`
 	padding: 0;
 	background-color: transparent;
-	color: ${button.textTertiary};
+	color: ${button.textSubdued};
 
 	&:hover {
 		text-decoration: underline;
@@ -61,6 +61,10 @@ export const tertiary = ({
 	   there is only text, it is more natural to show a rectangle for the focus halo */
 	border-radius: 0;
 `
+
+// TODO: 0.18
+// update this to apply "ghost button styling"
+export const tertiary = subdued
 
 export const defaultSize = css`
 	height: ${size.large}px;

--- a/src/core/foundations/src/themes/button.ts
+++ b/src/core/foundations/src/themes/button.ts
@@ -16,6 +16,7 @@ export type ButtonTheme = {
 	backgroundSecondaryHover: string
 	borderSecondary?: string
 	textTertiary?: string
+	textSubdued?: string
 }
 
 export const buttonDefault: { button: ButtonTheme } = {
@@ -27,6 +28,7 @@ export const buttonDefault: { button: ButtonTheme } = {
 		backgroundSecondary: background.ctaSecondary,
 		backgroundSecondaryHover: background.ctaSecondaryHover,
 		textTertiary: text.ctaSecondary,
+		textSubdued: text.ctaSecondary,
 	},
 }
 
@@ -39,6 +41,7 @@ export const buttonBrand: { button: ButtonTheme } = {
 		backgroundSecondary: brandBackground.ctaSecondary,
 		backgroundSecondaryHover: brandBackground.ctaSecondaryHover,
 		textTertiary: brandText.ctaSecondary,
+		textSubdued: brandText.ctaSecondary,
 	},
 }
 
@@ -51,6 +54,7 @@ export const buttonBrandAlt: { button: ButtonTheme } = {
 		backgroundSecondary: brandAltBackground.ctaSecondary,
 		backgroundSecondaryHover: brandAltBackground.ctaSecondaryHover,
 		textTertiary: brandAltText.ctaSecondary,
+		textSubdued: brandAltText.ctaSecondary,
 	},
 }
 


### PR DESCRIPTION
## What is the purpose of this change?

We are adding a fourth button priority, a "ghost button". We'd like to call it "tertiary" and switch the current tertiary button to be "subdued". This uses the same terminology as the Link component priority, and achieves a similar look and feel.

## What does this change?

-   Add subdued text colour to button theme
-   re-export tertiary button as "subdued"

We will continue to export the subdued styling as "tertiary" for now. This will be updated in a future version of the Button component.

## Screenshots

**Before**

![Screenshot 2020-04-08 at 11 11 12](https://user-images.githubusercontent.com/5931528/78772451-b1483000-7989-11ea-8ab9-e386c02b3e84.png)

**After** 

![Screenshot 2020-04-08 at 11 10 57](https://user-images.githubusercontent.com/5931528/78772448-b0af9980-7989-11ea-9501-ff958a637295.png)
