### PR TITLE
Add reader revenue light theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "source",
 	"version": "0.17.0",
 	"scripts": {
-		"storybook": "yarn watch:foundations & yarn watch:svgs & yarn & start-storybook",
+		"storybook": "yarn watch:foundations & yarn watch:svgs & start-storybook",
 		"lint:styles": "stylelint src/core/**/styles.ts",
 		"lint:js": "eslint . --ext .ts,.tsx,.js",
 		"lint": "yarn lint:js && yarn lint:styles",

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -30,7 +30,11 @@ export {
 	buttonBrand,
 	buttonBrandAlt,
 } from "@guardian/src-foundations/themes"
-export { buttonReaderRevenue, buttonReaderRevenueAlt } from "./themes"
+export {
+	buttonReaderRevenue,
+	buttonReaderRevenueAlt,
+	buttonReaderRevenueLight,
+} from "./themes"
 
 export type Priority = "primary" | "secondary" | "tertiary" | "subdued"
 type IconSide = "left" | "right"

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -11,6 +11,7 @@ import {
 	buttonBrand,
 	buttonReaderRevenue,
 	buttonReaderRevenueAlt,
+	buttonReaderRevenueLight,
 } from "./index"
 import { ThemeProvider } from "emotion-theming"
 
@@ -174,6 +175,24 @@ priorityReaderRevenueYellow.story = {
 	parameters: {
 		backgrounds: [
 			Object.assign({}, { default: true }, storybookBackgrounds.brandAlt),
+		],
+	},
+}
+
+export const priorityReaderRevenueLight = () => (
+	<ThemeProvider theme={buttonReaderRevenueLight}>
+		<div css={flexStart}>
+			{priorityButtons.slice(0, 2).map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+	</ThemeProvider>
+)
+priorityReaderRevenueLight.story = {
+	name: "priority reader revenue light",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
 		],
 	},
 }

--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -19,7 +19,7 @@ const background = {
 	readerRevenue: {
 		primary: brand[400],
 		ctaPrimary: brandAlt[400],
-		ctaPrimaryHover: brandAlt[200],
+		ctaPrimaryHover: "#FFD213",
 		ctaSecondary: brand[400],
 		ctaSecondaryHover: "#234B8A",
 	},

--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -14,6 +14,12 @@ const text = {
 		ctaPrimary: neutral[100],
 		ctaSecondary: neutral[7],
 	},
+	readerRevenueLight: {
+		primary: brand[400],
+		secondary: brand[400],
+		ctaPrimary: brand[400],
+		ctaSecondary: brand[400],
+	},
 }
 const background = {
 	readerRevenue: {
@@ -30,6 +36,12 @@ const background = {
 		ctaSecondary: brandAlt[400],
 		ctaSecondaryHover: brandAlt[200],
 	},
+	readerRevenueLight: {
+		ctaPrimary: brandAlt[400],
+		ctaPrimaryHover: "#FFD213",
+		ctaSecondary: neutral[100],
+		ctaSecondaryHover: "#E5E5E5",
+	},
 }
 const border = {
 	readerRevenue: {
@@ -37,6 +49,9 @@ const border = {
 	},
 	readerRevenueAlt: {
 		ctaSecondary: neutral[7],
+	},
+	readerRevenueLight: {
+		ctaSecondary: brand[400],
 	},
 }
 
@@ -61,5 +76,18 @@ export const buttonReaderRevenueAlt: { button: ButtonTheme } = {
 		backgroundSecondary: background.readerRevenueAlt.ctaSecondary,
 		backgroundSecondaryHover: background.readerRevenueAlt.ctaSecondaryHover,
 		borderSecondary: border.readerRevenueAlt.ctaSecondary,
+	},
+}
+
+export const buttonReaderRevenueLight: { button: ButtonTheme } = {
+	button: {
+		textPrimary: text.readerRevenueLight.ctaPrimary,
+		backgroundPrimary: background.readerRevenueLight.ctaPrimary,
+		backgroundPrimaryHover: background.readerRevenueLight.ctaPrimaryHover,
+		textSecondary: text.readerRevenueLight.ctaSecondary,
+		backgroundSecondary: background.readerRevenueLight.ctaSecondary,
+		backgroundSecondaryHover:
+			background.readerRevenueLight.ctaSecondaryHover,
+		borderSecondary: border.readerRevenueLight.ctaSecondary,
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

We have noticed reader revenue-related buttons appearing on lighter backgrounds. The purpose of this theme is to encourage consolidation around a common set of colours for these backgrounds.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Add reader revenue buttons for light background
-   Update hover colour of primary reader reveneu brand button
-   BONUS: Remove erroneous call to `yarn` in storybook script

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Screenshot 2020-04-08 at 16 30 24](https://user-images.githubusercontent.com/5931528/78803131-86280580-79b6-11ea-8559-409db48d9211.png)


### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
