### PR TITLE
Rename reader revenue button themes

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -32,8 +32,8 @@ export {
 } from "@guardian/src-foundations/themes"
 export {
 	buttonReaderRevenue,
-	buttonReaderRevenueAlt,
-	buttonReaderRevenueLight,
+	buttonReaderRevenueBrand,
+	buttonReaderRevenueBrandAlt,
 } from "./themes"
 
 export type Priority = "primary" | "secondary" | "tertiary" | "subdued"

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -10,8 +10,8 @@ import {
 	buttonBrandAlt,
 	buttonBrand,
 	buttonReaderRevenue,
-	buttonReaderRevenueAlt,
-	buttonReaderRevenueLight,
+	buttonReaderRevenueBrand,
+	buttonReaderRevenueBrandAlt,
 } from "./index"
 import { ThemeProvider } from "emotion-theming"
 
@@ -143,8 +143,26 @@ priorityYellow.story = {
 	},
 }
 
-export const priorityReaderRevenueBlue = () => (
+export const priorityReaderRevenueLight = () => (
 	<ThemeProvider theme={buttonReaderRevenue}>
+		<div css={flexStart}>
+			{priorityButtons.slice(0, 2).map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+	</ThemeProvider>
+)
+priorityReaderRevenueLight.story = {
+	name: "priority reader revenue light",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.default),
+		],
+	},
+}
+
+export const priorityReaderRevenueBlue = () => (
+	<ThemeProvider theme={buttonReaderRevenueBrand}>
 		<div css={flexStart}>
 			{priorityButtons.slice(0, 2).map((button, index) => (
 				<div key={index}>{button}</div>
@@ -162,7 +180,7 @@ priorityReaderRevenueBlue.story = {
 }
 
 export const priorityReaderRevenueYellow = () => (
-	<ThemeProvider theme={buttonReaderRevenueAlt}>
+	<ThemeProvider theme={buttonReaderRevenueBrandAlt}>
 		<div css={flexStart}>
 			{priorityButtons.slice(0, 2).map((button, index) => (
 				<div key={index}>{button}</div>
@@ -175,24 +193,6 @@ priorityReaderRevenueYellow.story = {
 	parameters: {
 		backgrounds: [
 			Object.assign({}, { default: true }, storybookBackgrounds.brandAlt),
-		],
-	},
-}
-
-export const priorityReaderRevenueLight = () => (
-	<ThemeProvider theme={buttonReaderRevenueLight}>
-		<div css={flexStart}>
-			{priorityButtons.slice(0, 2).map((button, index) => (
-				<div key={index}>{button}</div>
-			))}
-		</div>
-	</ThemeProvider>
-)
-priorityReaderRevenueLight.story = {
-	name: "priority reader revenue light",
-	parameters: {
-		backgrounds: [
-			Object.assign({}, { default: true }, storybookBackgrounds.default),
 		],
 	},
 }

--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -4,46 +4,46 @@ import { ButtonTheme } from "@guardian/src-foundations/themes"
 const text = {
 	readerRevenue: {
 		ctaPrimary: brand[400],
+		ctaSecondary: brand[400],
+	},
+	readerRevenueBrand: {
+		ctaPrimary: brand[400],
 		ctaSecondary: brandAlt[400],
 	},
-	readerRevenueAlt: {
+	readerRevenueBrandAlt: {
 		ctaPrimary: neutral[100],
 		ctaSecondary: neutral[7],
-	},
-	readerRevenueLight: {
-		ctaPrimary: brand[400],
-		ctaSecondary: brand[400],
 	},
 }
 const background = {
 	readerRevenue: {
 		ctaPrimary: brandAlt[400],
 		ctaPrimaryHover: "#FFD213",
+		ctaSecondary: neutral[100],
+		ctaSecondaryHover: "#E5E5E5",
+	},
+	readerRevenueBrand: {
+		ctaPrimary: brandAlt[400],
+		ctaPrimaryHover: "#FFD213",
 		ctaSecondary: brand[400],
 		ctaSecondaryHover: "#234B8A",
 	},
-	readerRevenueAlt: {
+	readerRevenueBrandAlt: {
 		ctaPrimary: neutral[7],
 		ctaPrimaryHover: "#454545",
 		ctaSecondary: brandAlt[400],
 		ctaSecondaryHover: brandAlt[200],
 	},
-	readerRevenueLight: {
-		ctaPrimary: brandAlt[400],
-		ctaPrimaryHover: "#FFD213",
-		ctaSecondary: neutral[100],
-		ctaSecondaryHover: "#E5E5E5",
-	},
 }
 const border = {
 	readerRevenue: {
+		ctaSecondary: brand[400],
+	},
+	readerRevenueBrand: {
 		ctaSecondary: brandAlt[400],
 	},
-	readerRevenueAlt: {
+	readerRevenueBrandAlt: {
 		ctaSecondary: neutral[7],
-	},
-	readerRevenueLight: {
-		ctaSecondary: brand[400],
 	},
 }
 
@@ -58,28 +58,29 @@ export const buttonReaderRevenue: { button: ButtonTheme } = {
 		borderSecondary: border.readerRevenue.ctaSecondary,
 	},
 }
-
-export const buttonReaderRevenueAlt: { button: ButtonTheme } = {
+export const buttonReaderRevenueBrand: { button: ButtonTheme } = {
 	button: {
-		textPrimary: text.readerRevenueAlt.ctaPrimary,
-		backgroundPrimary: background.readerRevenueAlt.ctaPrimary,
-		backgroundPrimaryHover: background.readerRevenueAlt.ctaPrimaryHover,
-		textSecondary: text.readerRevenueAlt.ctaSecondary,
-		backgroundSecondary: background.readerRevenueAlt.ctaSecondary,
-		backgroundSecondaryHover: background.readerRevenueAlt.ctaSecondaryHover,
-		borderSecondary: border.readerRevenueAlt.ctaSecondary,
+		textPrimary: text.readerRevenueBrand.ctaPrimary,
+		backgroundPrimary: background.readerRevenueBrand.ctaPrimary,
+		backgroundPrimaryHover: background.readerRevenueBrand.ctaPrimaryHover,
+		textSecondary: text.readerRevenueBrand.ctaSecondary,
+		backgroundSecondary: background.readerRevenueBrand.ctaSecondary,
+		backgroundSecondaryHover:
+			background.readerRevenueBrand.ctaSecondaryHover,
+		borderSecondary: border.readerRevenueBrand.ctaSecondary,
 	},
 }
 
-export const buttonReaderRevenueLight: { button: ButtonTheme } = {
+export const buttonReaderRevenueBrandAlt: { button: ButtonTheme } = {
 	button: {
-		textPrimary: text.readerRevenueLight.ctaPrimary,
-		backgroundPrimary: background.readerRevenueLight.ctaPrimary,
-		backgroundPrimaryHover: background.readerRevenueLight.ctaPrimaryHover,
-		textSecondary: text.readerRevenueLight.ctaSecondary,
-		backgroundSecondary: background.readerRevenueLight.ctaSecondary,
+		textPrimary: text.readerRevenueBrandAlt.ctaPrimary,
+		backgroundPrimary: background.readerRevenueBrandAlt.ctaPrimary,
+		backgroundPrimaryHover:
+			background.readerRevenueBrandAlt.ctaPrimaryHover,
+		textSecondary: text.readerRevenueBrandAlt.ctaSecondary,
+		backgroundSecondary: background.readerRevenueBrandAlt.ctaSecondary,
 		backgroundSecondaryHover:
-			background.readerRevenueLight.ctaSecondaryHover,
-		borderSecondary: border.readerRevenueLight.ctaSecondary,
+			background.readerRevenueBrandAlt.ctaSecondaryHover,
+		borderSecondary: border.readerRevenueBrandAlt.ctaSecondary,
 	},
 }

--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -3,34 +3,26 @@ import { ButtonTheme } from "@guardian/src-foundations/themes"
 
 const text = {
 	readerRevenue: {
-		primary: neutral[100],
-		secondary: neutral[60],
 		ctaPrimary: brand[400],
 		ctaSecondary: brandAlt[400],
 	},
 	readerRevenueAlt: {
-		primary: neutral[7],
-		secondary: neutral[60],
 		ctaPrimary: neutral[100],
 		ctaSecondary: neutral[7],
 	},
 	readerRevenueLight: {
-		primary: brand[400],
-		secondary: brand[400],
 		ctaPrimary: brand[400],
 		ctaSecondary: brand[400],
 	},
 }
 const background = {
 	readerRevenue: {
-		primary: brand[400],
 		ctaPrimary: brandAlt[400],
 		ctaPrimaryHover: "#FFD213",
 		ctaSecondary: brand[400],
 		ctaSecondaryHover: "#234B8A",
 	},
 	readerRevenueAlt: {
-		primary: brandAlt[400],
 		ctaPrimary: neutral[7],
 		ctaPrimaryHover: "#454545",
 		ctaSecondary: brandAlt[400],


### PR DESCRIPTION
## What is the purpose of this change?

With the introduction of the light reader revenue theme in #317, the naming of the reader revenue themes is potentially confusing.

## What does this change?

Renamed:

- buttonReaderRevenueLight -> buttonReaderRevenue
- buttonReaderRevenue -> buttonReaderRevenueBrand
- buttonReaderRevenueAlt -> buttonReaderRevenueBrandAlt

In addition, this change deletes a few unused colours

