### PR TITLE
Externalise palette from foundations submodules

### DIFF
--- a/src/core/foundations/rollup.config.js
+++ b/src/core/foundations/rollup.config.js
@@ -22,7 +22,10 @@ const esmFolders = folders.map(folder => ({
 		},
 	],
 	plugins,
-	external: ["@guardian/src-foundations"],
+	external: [
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/palette",
+	],
 }))
 
 const cjsFolders = folders.map(folder => ({
@@ -34,7 +37,10 @@ const cjsFolders = folders.map(folder => ({
 		},
 	],
 	plugins,
-	external: ["@guardian/src-foundations"],
+	external: [
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/palette",
+	],
 }))
 
 module.exports = [

--- a/src/core/foundations/src/accessibility/index.ts
+++ b/src/core/foundations/src/accessibility/index.ts
@@ -1,4 +1,4 @@
-import { border } from "../index"
+import { border } from "@guardian/src-foundations/palette"
 
 const visuallyHidden = `
 	position: absolute;

--- a/src/core/foundations/src/themes/button.ts
+++ b/src/core/foundations/src/themes/button.ts
@@ -5,7 +5,7 @@ import {
 	brandBackground,
 	brandAltText,
 	brandAltBackground,
-} from "../index"
+} from "@guardian/src-foundations/palette"
 
 export type ButtonTheme = {
 	textPrimary: string

--- a/src/core/foundations/src/themes/checkbox.ts
+++ b/src/core/foundations/src/themes/checkbox.ts
@@ -5,7 +5,7 @@ import {
 	brandBorder,
 	brandBackground,
 	brandText,
-} from "../index"
+} from "@guardian/src-foundations/palette"
 import {
 	inlineErrorDefault,
 	inlineErrorBrand,

--- a/src/core/foundations/src/themes/choice-card.ts
+++ b/src/core/foundations/src/themes/choice-card.ts
@@ -1,4 +1,4 @@
-import { border, text, background } from "../index"
+import { border, text, background } from "@guardian/src-foundations/palette"
 import { InlineErrorTheme, inlineErrorDefault } from "./inline-error"
 
 export type ChoiceCardTheme = {

--- a/src/core/foundations/src/themes/inline-error.ts
+++ b/src/core/foundations/src/themes/inline-error.ts
@@ -1,4 +1,4 @@
-import { text, brandText } from "../index"
+import { text, brandText } from "@guardian/src-foundations/palette"
 
 export type InlineErrorTheme = {
 	text: string

--- a/src/core/foundations/src/themes/link.ts
+++ b/src/core/foundations/src/themes/link.ts
@@ -1,4 +1,8 @@
-import { text, brandText, brandAltText } from "../index"
+import {
+	text,
+	brandText,
+	brandAltText,
+} from "@guardian/src-foundations/palette"
 
 export type LinkTheme = {
 	textPrimary: string

--- a/src/core/foundations/src/themes/radio.ts
+++ b/src/core/foundations/src/themes/radio.ts
@@ -5,7 +5,7 @@ import {
 	brandBorder,
 	brandBackground,
 	brandText,
-} from "../index"
+} from "@guardian/src-foundations/palette"
 import {
 	inlineErrorLight,
 	inlineErrorBrand,

--- a/src/core/foundations/src/themes/text-input.ts
+++ b/src/core/foundations/src/themes/text-input.ts
@@ -1,4 +1,4 @@
-import { text, background, border } from "../index"
+import { text, background, border } from "@guardian/src-foundations/palette"
 import { inlineErrorDefault, InlineErrorTheme } from "./inline-error"
 
 export type TextInputTheme = {

--- a/src/core/foundations/tsconfig.json
+++ b/src/core/foundations/tsconfig.json
@@ -1,5 +1,9 @@
 {
 	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@guardian/src-foundations/palette": ["src/palette"]
+		},
 		"rootDir": "./src",
 		"outDir": ".",
 		"declaration": true,


### PR DESCRIPTION
## What is the purpose of this change?

The accessibility and themes submodules import the palette using a relative path. This ends up bringing most of the palette into the submodules' dist files.

By externalise the palette, the submodules assume `@guardian/src-foundations/palette` is already available in the consuming application (which it will be), and won't include the palette code in the dist file.

## What does this change?

-   externalise the palette in the config
-   externalise the palette in themes submodule
-   externalise the palette in accessibility submodule
