### PR TITLE
Align icon to center for link

### DIFF
--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -16,6 +16,7 @@ const priorityLinks = [
 	<Link priority="secondary" href="#">
 		Secondary
 	</Link>,
+	<Link iconSide="left" icon={<SvgArrowRightStraight />} href="#">With icon</Link>,
 ]
 const subduedLinks = [
 	<Link subdued={true} href="#">

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
 import {
 	SvgArrowRightStraight,
+	SvgIndent,
 	SvgExternal,
 	SvgChevronLeftSingle,
 } from "@guardian/src-svgs"
@@ -103,12 +104,17 @@ export const textAndIcon = () => (
 				Terms and conditions
 			</Link>
 		</div>
-		<div css={flexStart}>
+		<div css={[flexStart, spacer]}>
 			<Link icon={<SvgChevronLeftSingle />} href="#">
 				Previous
 			</Link>
 			<Link iconSide="right" icon={<SvgArrowRightStraight />} href="#">
 				Next
+			</Link>
+		</div>
+		<div css={spacer}>
+			<Link iconSide="left" icon={<SvgIndent />} href="#">
+				Indent
 			</Link>
 		</div>
 	</>

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -16,7 +16,9 @@ const priorityLinks = [
 	<Link priority="secondary" href="#">
 		Secondary
 	</Link>,
-	<Link iconSide="left" icon={<SvgArrowRightStraight />} href="#">With icon</Link>,
+	<Link iconSide="left" icon={<SvgArrowRightStraight />} href="#">
+		With icon
+	</Link>,
 ]
 const subduedLinks = [
 	<Link subdued={true} href="#">

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -16,9 +16,6 @@ const priorityLinks = [
 	<Link priority="secondary" href="#">
 		Secondary
 	</Link>,
-	<Link iconSide="left" icon={<SvgArrowRightStraight />} href="#">
-		With icon
-	</Link>,
 ]
 const subduedLinks = [
 	<Link subdued={true} href="#">

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -9,6 +9,9 @@ export const link = css`
 	${textSans.medium()};
 	cursor: pointer;
 
+	display: flex;
+    align-items: center;
+
 	&:focus {
 		${focusHalo};
 	}
@@ -50,9 +53,6 @@ export const icon = css`
 		*/
 		width: ${size.medium / 2}px;
 		height: auto;
-
-		/* magic number to align the SVG to the text baseline*/
-		bottom: 4px;
 	}
 `
 

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -10,7 +10,7 @@ export const link = css`
 	cursor: pointer;
 
 	display: flex;
-    align-items: center;
+	align-items: center;
 
 	&:focus {
 		${focusHalo};


### PR DESCRIPTION
## What is the purpose of this change?

SVG icons should be centered to align with the text

## What does this change?

- Use flexbox `align-items: center;` to achieve the alignment.
- Remove `magic number`
- Add story for link with icon

### Screenshots

**Before**
<img width="115" alt="Screenshot 2020-04-16 at 14 35 37" src="https://user-images.githubusercontent.com/8831403/79462835-f3a7e780-7fef-11ea-9bba-3a2df043759a.png">


**After**
<img width="123" alt="Screenshot 2020-04-16 at 14 30 17" src="https://user-images.githubusercontent.com/8831403/79462848-f86c9b80-7fef-11ea-9f7f-7c00c0486a41.png">

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)

### Link to issue
https://github.com/guardian/source/issues/326

### Link to trello
https://trello.com/c/8VGqs2uU/1460-source-align-icon-to-the-center-of-component