### PR TITLE
Accordion refactors

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -1,99 +1,75 @@
 import React, { useState, ReactElement, ReactNode } from "react"
 import {
-	accordion,
+	accordionRow,
 	button,
 	labelText,
-	titleRow,
-	accordionRow,
-	showHide,
-	showHideText,
-	svgContainer,
-	showAccordionElement,
-	hideAccordionElement,
+	showHideLabel,
+	chevronIcon,
+	chevronIconUp,
+	chevronIconDown,
+	expandedBody,
+	collapsedBody,
 } from "./styles"
+import { css } from "@emotion/core"
+import { visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
-import { SvgChevronDownSingle, SvgChevronUpSingle } from "@guardian/src-svgs"
+import { SvgChevronUpSingle } from "@guardian/src-svgs"
 
 interface AccordionProps extends Props {
 	children: ReactElement[]
 }
 
 const Accordion = ({ children }: AccordionProps) => {
-	return (
-		<div css={accordion}>
-			{React.Children.map(
-				children,
-				(childElement: ReactElement, childIndex: number) => {
-					return React.cloneElement(
-						childElement,
-						Object.assign(
-							{},
-							childElement.props,
-							{ id: `accordion${childIndex + 1}` },
-							{ key: childIndex },
-						),
-					)
-				},
-			)}
-		</div>
-	)
+	return <div>{children}</div>
 }
 
 interface AccordionRowProps extends Props {
 	label: string
 	children: ReactNode
-	id?: string
 }
 
-const AccordionRow = ({ children, label, id }: AccordionRowProps) => {
-	const [accordionOpen, toggleAccordion] = useState(false)
-	const toggleToClosed = () => toggleAccordion(false)
-	const toggleToOpen = () => toggleAccordion(true)
+const AccordionRow = ({ children, label }: AccordionRowProps) => {
+	const [expanded, setExpanded] = useState(false)
+	const collapse = () => setExpanded(false)
+	const expand = () => setExpanded(true)
 
 	return (
 		<div css={accordionRow}>
 			<button
-				aria-expanded={accordionOpen}
-				onClick={accordionOpen ? toggleToClosed : toggleToOpen}
-				aria-controls={id}
-				css={[titleRow, button]}
+				aria-expanded={expanded}
+				onClick={expanded ? collapse : expand}
+				css={button}
 			>
 				<strong css={labelText}>{label}</strong>
-				<div css={showHide}>
-					<div
-						css={
-							accordionOpen
-								? showAccordionElement
-								: hideAccordionElement
-						}
-					>
-						<div css={showHideText}>Hide</div>
-						<div css={svgContainer}>
-							<SvgChevronUpSingle />
-						</div>
-					</div>
-					<div
-						css={
-							accordionOpen
-								? hideAccordionElement
-								: showAccordionElement
-						}
-					>
-						<div css={showHideText}>Show</div>
-						<div css={svgContainer}>
-							<SvgChevronDownSingle />
-						</div>
-					</div>
+				<div
+					css={[
+						showHideLabel,
+						chevronIcon,
+						expanded ? chevronIconUp : chevronIconDown,
+					]}
+				>
+					<span>
+						{expanded ? (
+							"Hide"
+						) : (
+							<>
+								Show
+								<span
+									css={css`
+										${visuallyHidden}
+									`}
+								>
+									{" "}
+									more
+								</span>
+							</>
+						)}
+					</span>
+					<SvgChevronUpSingle />
 				</div>
 			</button>
-			<div
-				id={id}
-				hidden={!accordionOpen}
-				css={
-					accordionOpen ? showAccordionElement : hideAccordionElement
-				}
-			>
-				{children}
+			<div css={expanded ? expandedBody : collapsedBody}>
+				<div hidden={!expanded}>{children}</div>
 			</div>
 		</div>
 	)

--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -1,84 +1,96 @@
 import { css } from "@emotion/core"
-import { border } from "@guardian/src-foundations/palette"
+import { remSpace, transitions } from "@guardian/src-foundations"
+import { text, border } from "@guardian/src-foundations/palette"
 import { headline, textSans } from "@guardian/src-foundations/typography"
-import { space } from "@guardian/src-foundations"
-
-export const accordion = css`
-	background-color: transparent;
-`
+import { focusHalo } from "@guardian/src-foundations/accessibility"
 
 export const accordionRow = css`
+	padding: ${remSpace[2]};
 	border-top: 1px solid ${border.primary};
 	:last-of-type {
 		border-bottom: 1px solid ${border.primary};
 	}
-	padding: ${space[2]}px 0 ${space[4]}px ${space[2]}px;
 `
 
 export const button = css`
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: ${remSpace[3]};
+	align-items: baseline;
+	color: ${text.primary};
+
+	/* user agent overrides */
 	background: none;
 	outline: none;
 	border: none;
 	padding: 0;
 	cursor: pointer;
 	text-align: left;
+
+	&:focus div {
+		${focusHalo};
+	}
 `
 
 export const labelText = css`
 	${headline.xxxsmall()};
-	margin-right: ${space[4]}px;
+	margin-right: ${remSpace[4]};
 `
 
-export const titleRow = css`
-	width: 100%;
-	display: flex;
-	justify-content: space-between;
-	margin-bottom: ${space[3]}px;
-	align-items: baseline;
-`
-
-export const showHide = css`
-	div {
-		display: flex;
-	}
-`
-
-export const showHideText = css`
-	${textSans.small({ fontWeight: "bold" })};
-	margin-right: ${space[2]}px;
-`
-
-export const svgContainer = css`
-	height: 22px;
-	width: 15px;
-	svg {
-		height: auto;
-		width: 100%;
-	}
-`
-
-export const showAccordionElement = css`
-	max-height: auto;
-	overflow: visible;
-	transition: max-height 400ms;
-	margin-right: ${space[2]}px;
-
-	> * {
-		transition: opacity 300ms 200ms;
-		opacity: 1;
-	}
-`
-
-export const hideAccordionElement = css`
-	max-height: 0;
-	height: 0;
-	width: 0;
+export const expandedBody = css`
+	/*
+	TODO:
+	Hardcoded max-height because auto is invalid.
+	If content is longer, we'll need to set overflow: auto
+	but only after max-height has been reached.
+	Otherwise, for short content we'll always see a flash
+	of a scrollbar as the row height is transitioning
+	*/
+	max-height: 500px;
+	transition: max-height ${transitions.medium};
 	overflow: hidden;
-	transition: max-height 400ms;
+	height: auto;
+`
 
-	> * {
-		opacity: 0;
-		transition: opacity 400ms;
-		margin: 0;
+export const collapsedBody = css`
+	max-height: 0;
+	/*
+	TODO:
+	This transition is being ignored as the hidden
+	attribute is applied immediately
+
+	transition: max-height ${transitions.short};
+	*/
+	overflow: hidden;
+`
+
+export const showHideLabel = css`
+	width: auto;
+	display: flex;
+	align-items: center;
+	${textSans.small({ fontWeight: "bold" })};
+`
+
+export const chevronIcon = css`
+	svg {
+		/* TODO: we need to tidy up size */
+		width: 15px;
+		height: 15px;
+		margin-left: ${remSpace[1]};
+	}
+`
+
+export const chevronIconUp = css`
+	svg {
+		transform: rotate(0);
+		transition: transform ${transitions.short};
+	}
+`
+
+export const chevronIconDown = css`
+	svg {
+		transform: rotate(180deg);
+		transition: transform ${transitions.short};
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

Restructure the HTML and CSS, rework animations slightly to make them more Source-y and rename a bunch of things

## What does this change?

- Condense Hide / Show buttons into a single control
- Rework animations to use `src-foundations` transitions
- Made the chevron spin dramatically through 180 degrees
- Rename a bunch of style variables and state hooks
- Set focus halo on show/hide button
- Add optional `id` prop to accordion, which gets suffixed and passed to accordion rows
- Use `remSpace` instead of `space`
- [Removed `aria-controls`](https://heydonworks.com/article/aria-controls-is-poop/) because it's needlessly complex and 💩 

## Todo

- [Further design tweaks](https://www.figma.com/file/VpSDf7YlEUbeFCbiXaWD1I/Accordion?node-id=1%3A2)?

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

![Apr-17-2020 15-16-26](https://user-images.githubusercontent.com/5931528/79578683-739c8300-80be-11ea-98dd-368bd8a4d972.gif)

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
