### PR TITLE
add secondary background colour to default theme

### DIFF
--- a/src/core/foundations/src/palette/background/default.ts
+++ b/src/core/foundations/src/palette/background/default.ts
@@ -2,6 +2,7 @@ import { neutral, brand } from "../global"
 
 export const background = {
 	primary: neutral[100],
+	secondary: neutral[97],
 	inverse: neutral[10],
 	ctaPrimary: brand[400],
 	ctaPrimaryHover: "#234B8A",


### PR DESCRIPTION
## What is the purpose of this change?

Some components (accordions, the epic) use an off-white background colour. This change makes this colour a canonical background colour.

## What does this change?

- Create `background.secondary` (`#f6f6f6`)
