### PR TITLE
Small fix for accordion styles to remove selector

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, ReactElement, ReactNode } from "react"
 import {
+	accordion,
 	accordionRow,
 	button,
 	labelText,
@@ -20,7 +21,7 @@ interface AccordionProps extends Props {
 }
 
 const Accordion = ({ children }: AccordionProps) => {
-	return <div>{children}</div>
+	return <div css={accordion}>{children}</div>
 }
 
 interface AccordionRowProps extends Props {

--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -4,12 +4,13 @@ import { text, border } from "@guardian/src-foundations/palette"
 import { headline, textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
+export const accordion = css`
+	border-bottom: 1px solid ${border.primary};
+`
+
 export const accordionRow = css`
 	padding: ${remSpace[2]};
 	border-top: 1px solid ${border.primary};
-	:last-of-type {
-		border-bottom: 1px solid ${border.primary};
-	}
 `
 
 export const button = css`


### PR DESCRIPTION
## What is the purpose of this change?
This is a tiny change to the styles of the accordion to remove a selector that *may* be breaking the static page render in `support-frontend`.

## What does this change?
It moves a style was was applied to the :last-of-type on the accordion rows and adds it to the bottom of the accordion itself. This is to provide the final line of the accordion.


### Screenshots

It looks the same!
