### PR TITLE
Better background in stories

### DIFF
--- a/src/core/components/accordion/stories.tsx
+++ b/src/core/components/accordion/stories.tsx
@@ -1,19 +1,41 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { Accordion, AccordionRow } from "./index"
-import { neutral } from "@guardian/src-foundations/palette"
+import { background } from "@guardian/src-foundations/palette"
 import { textSans } from "@guardian/src-foundations/typography"
+import { from } from "@guardian/src-foundations/mq"
 import { space } from "@guardian/src-foundations"
 
-const main = css`
-	display: flex;
-	justify-content: center;
-	width: 100%;
-`
+const accordion = (
+	<Accordion>
+		<AccordionRow label="Collecting from multiple newsagents">
+			<p>
+				Present your card to a newsagent each time you collect the
+				paper. The newsagent will scan your card and will be reimbursed
+				for each transaction automatically.
+			</p>
+			<p>
+				<a href="">Find your nearest participating retailer</a>
+			</p>
+		</AccordionRow>
+		<AccordionRow label="Delivery from your retailer">
+			<p>
+				Simply give your preferred store / retailer the barcode printed
+				on your subscription letter.
+			</p>
+			<p>
+				<a href="">Find your nearest participating retailer</a>
+			</p>
+		</AccordionRow>
+	</Accordion>
+)
 
 const container = css`
-	background-color: ${neutral["97"]};
-	width: 320px;
+	width: 100%;
+
+	${from.tablet} {
+		width: 30em;
+	}
 
 	p {
 		${textSans.small()};
@@ -21,41 +43,24 @@ const container = css`
 	}
 `
 
+const lightGrey = css`
+	background-color: ${background.secondary};
+`
+
 export default {
 	title: "Accordion",
 	component: Accordion,
 }
 
-const defaultLight = () => (
-	<div css={main}>
-		<div css={container}>
-			<Accordion>
-				<AccordionRow label="Collecting from multiple newsagents">
-					<p>
-						Present your card to a newsagent each time you collect
-						the paper. The newsagent will scan your card and will be
-						reimbursed for each transaction automatically.
-					</p>
-					<p>
-						<a href="">Find your nearest participating retailer</a>
-					</p>
-				</AccordionRow>
-				<AccordionRow label="Delivery from your retailer">
-					<p>
-						Simply give your preferred store / retailer the barcode
-						printed on your subscription letter.
-					</p>
-					<p>
-						<a href="">Find your nearest participating retailer</a>
-					</p>
-				</AccordionRow>
-			</Accordion>
-		</div>
-	</div>
-)
+const defaultLight = () => <div css={container}>{accordion}</div>
 
 defaultLight.story = {
 	name: `default light`,
 }
+const defaultGrey = () => <div css={[container, lightGrey]}>{accordion}</div>
 
-export { defaultLight }
+defaultGrey.story = {
+	name: `default grey`,
+}
+
+export { defaultLight, defaultGrey }

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
 import { SvgCheckmark, SvgClose } from "@guardian/src-svgs"
 import { size, space } from "@guardian/src-foundations"
+import { background } from "@guardian/src-foundations/palette"
 import {
 	Button,
 	LinkButton,
@@ -110,7 +111,7 @@ priorityBlue.story = {
 }
 
 export const priorityGrey = () => (
-	<ThemeProvider theme={buttonBrand}>
+	<ThemeProvider theme={buttonDefault}>
 		<div css={flexStart}>
 			{priorityButtons.map((button, index) => (
 				<div key={index}>{button}</div>
@@ -121,7 +122,9 @@ export const priorityGrey = () => (
 priorityGrey.story = {
 	name: "priority grey",
 	parameters: {
-		backgrounds: [{ name: "grey", value: "lightgrey", default: true }],
+		backgrounds: [
+			{ name: "grey", value: background.secondary, default: true },
+		],
 	},
 }
 


### PR DESCRIPTION
## What is the purpose of this change?

A couple of our stories use arbitrary greys for backgrounds. Let's tighten that up and make them more accessible

## What does this change?

-   Use background.secondary for background in grey accordion story
-   Refactor container sizes in accordion stories
-   Add a light background accordion story
-   Use background.secondary for background in grey button story
-   Use default theme for buttons in grey button story
