### PR TITLE
Include dist dir in svgs package

### DIFF
--- a/src/core/svgs/package.json
+++ b/src/core/svgs/package.json
@@ -44,7 +44,8 @@
 		"minus.tsx",
 		"plus.tsx",
 		"paypal.tsx",
-		"*.d.ts"
+		"*.d.ts",
+		"dist/*.js"
 	],
 	"peerDependencies": {
 		"react": "^16.8.6"


### PR DESCRIPTION
## What is the purpose of this change?

fixes #328

## What does this change?

publishes all JS files in dist dir

