### PR TITLE
Point CJS builds of components at CJS build of Foundations

### DIFF
--- a/src/core/components/accordion/package.json
+++ b/src/core/components/accordion/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/accordion.js",
 	"module": "dist/accordion.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/accordion/rollup.config.js
+++ b/src/core/components/accordion/rollup.config.js
@@ -10,6 +10,14 @@ module.exports = {
 		{
 			file: "dist/accordion.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/palette":
+					"@guardian/src-foundations/palette/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/accessibility":
+					"@guardian/src-foundations/accessibility/cjs",
+			},
 		},
 		{
 			file: "dist/accordion.esm.js",
@@ -21,7 +29,9 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
+		"@guardian/src-foundations/palette",
 		"@guardian/src-foundations/typography",
+		"@guardian/src-foundations/accessibility",
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/button.js",
 	"module": "dist/button.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/button/rollup.config.js
+++ b/src/core/components/button/rollup.config.js
@@ -10,6 +10,16 @@ module.exports = {
 		{
 			file: "dist/button.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/palette":
+					"@guardian/src-foundations/palette/cjs",
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/accessibility":
+					"@guardian/src-foundations/accessibility/cjs",
+			},
 		},
 		{
 			file: "dist/button.esm.js",

--- a/src/core/components/checkbox/package.json
+++ b/src/core/components/checkbox/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/checkbox.js",
 	"module": "dist/checkbox.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/checkbox/rollup.config.js
+++ b/src/core/components/checkbox/rollup.config.js
@@ -10,6 +10,14 @@ module.exports = {
 		{
 			file: "dist/checkbox.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/accessibility":
+					"@guardian/src-foundations/accessibility/cjs",
+			},
 		},
 		{
 			file: "dist/checkbox.esm.js",

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/choice-card.js",
 	"module": "dist/choice-card.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/choice-card/rollup.config.js
+++ b/src/core/components/choice-card/rollup.config.js
@@ -10,6 +10,14 @@ module.exports = {
 		{
 			file: "dist/choice-card.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/mq":
+					"@guardian/src-foundations/mq/cjs",
+			},
 		},
 		{
 			file: "dist/choice-card.esm.js",

--- a/src/core/components/grid/package.json
+++ b/src/core/components/grid/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/grid.js",
 	"module": "dist/grid.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"clean": "rm -rf dist *.d.ts",

--- a/src/core/components/grid/rollup.config.js
+++ b/src/core/components/grid/rollup.config.js
@@ -11,6 +11,10 @@ module.exports = {
 			file: "dist/grid.js",
 			format: "cjs",
 			sourceMap: true,
+			paths: {
+				"@guardian/src-foundations/mq":
+					"@guardian/src-foundations/mq/cjs",
+			},
 		},
 		{
 			file: "dist/grid.esm.js",

--- a/src/core/components/inline-error/package.json
+++ b/src/core/components/inline-error/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/inline-error.js",
 	"module": "dist/inline-error.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/inline-error/rollup.config.js
+++ b/src/core/components/inline-error/rollup.config.js
@@ -11,6 +11,12 @@ module.exports = {
 			file: "dist/inline-error.js",
 			format: "cjs",
 			sourceMap: true,
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+			},
 		},
 		{
 			file: "dist/inline-error.esm.js",

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/link.js",
 	"module": "dist/link.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/link/rollup.config.js
+++ b/src/core/components/link/rollup.config.js
@@ -10,6 +10,14 @@ module.exports = {
 		{
 			file: "dist/link.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/accessibility":
+					"@guardian/src-foundations/accessibility/cjs",
+			},
 		},
 		{
 			file: "dist/link.esm.js",

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/radio.js",
 	"module": "dist/radio.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/radio/rollup.config.js
+++ b/src/core/components/radio/rollup.config.js
@@ -10,6 +10,14 @@ module.exports = {
 		{
 			file: "dist/radio.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/accessibility":
+					"@guardian/src-foundations/accessibility/cjs",
+			},
 		},
 		{
 			file: "dist/radio.esm.js",

--- a/src/core/components/text-input/package.json
+++ b/src/core/components/text-input/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/text-input.js",
 	"module": "dist/text-input.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/core/components/text-input/rollup.config.js
+++ b/src/core/components/text-input/rollup.config.js
@@ -10,6 +10,14 @@ module.exports = {
 		{
 			file: "dist/text-input.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+				"@guardian/src-foundations/accessibility":
+					"@guardian/src-foundations/accessibility/cjs",
+			},
 		},
 		{
 			file: "dist/text-input.esm.js",

--- a/src/core/helpers/package.json
+++ b/src/core/helpers/package.json
@@ -4,7 +4,10 @@
 	"main": "dist/helpers.js",
 	"module": "dist/helpers.esm.js",
 	"types": "index.d.ts",
-	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"clean": "rm -rf dist *.d.ts tsconfig.tsbuildinfo",

--- a/src/core/helpers/rollup.config.js
+++ b/src/core/helpers/rollup.config.js
@@ -11,6 +11,10 @@ module.exports = {
 			file: "dist/helpers.js",
 			format: "cjs",
 			sourceMap: true,
+			paths: {
+				"@guardian/src-foundations/palette":
+					"@guardian/src-foundations/palette/cjs",
+			},
 		},
 		{
 			file: "dist/helpers.esm.js",

--- a/src/core/svgs/package.json
+++ b/src/core/svgs/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/index.js",
 	"module": "dist/index.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config",
 		"watch": "rollup --config --watch",

--- a/src/editorial/web/components/lines/package.json
+++ b/src/editorial/web/components/lines/package.json
@@ -3,6 +3,10 @@
 	"version": "0.18.0-rc.1",
 	"main": "dist/lines.js",
 	"module": "dist/lines.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
 	"scripts": {
 		"build": "yarn clean && rollup --config",
 		"clean": "rm -rf dist",

--- a/src/editorial/web/components/lines/rollup.config.js
+++ b/src/editorial/web/components/lines/rollup.config.js
@@ -10,6 +10,10 @@ module.exports = {
 		{
 			file: "dist/lines.js",
 			format: "cjs",
+			paths: {
+				"@guardian/src-foundations/palette":
+					"@guardian/src-foundations/palette/cjs",
+			},
 		},
 		{
 			file: "dist/lines.esm.js",


### PR DESCRIPTION
## What is the purpose of this change?

Currently the CommonJS builds of components are pointing at ESM build of foundations submodules. This is causing problems for projects that cannot use ESM files (i.e. Node-based projects).

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Implement path mapping that rewrites paths to foundations submodules to point to CJS builds
-   BONUS: add repository information to each component package.json
