### PR TITLE
Rework tertiary priority buttons

### DIFF
--- a/src/core/components/button/README.md
+++ b/src/core/components/button/README.md
@@ -43,7 +43,7 @@ const Form = () => (
 
 ### `priority`
 
-**`"primary" | "secondary"`** _= "primary"_
+**`"primary" | "secondary" | "tertiary"`** _= "primary"_
 
 Informs users of how important an action is
 
@@ -63,7 +63,7 @@ Whether to show the arrow icon in this button
 
 ### `priority`
 
-**`"primary" | "secondary" | "subdued"`** _= "primary"_
+**`"primary" | "secondary" | "tertiary" | "subdued"`** _= "primary"_
 
 Informs users of how important an action is
 
@@ -96,4 +96,5 @@ The side of the button on which the icon appears
 ### Custom
 
 -   `readerRevenue`
--   `readerRevenueAlt`
+-   `readerRevenueBrand`
+-   `readerRevenueBrandAlt`

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -39,7 +39,10 @@ export {
 export type Priority = "primary" | "secondary" | "tertiary" | "subdued"
 type IconSide = "left" | "right"
 type Size = "default" | "small"
-type LinkButtonPriority = Extract<"primary" | "secondary", Priority>
+type LinkButtonPriority = Extract<
+	"primary" | "secondary" | "tertiary",
+	Priority
+>
 
 const priorities: {
 	[key in Priority]: ({ button }: { button: ButtonTheme }) => SerializedStyles

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -157,10 +157,12 @@ priorityYellow.story = {
 	},
 }
 
+const readerRevenueButtons = [priorityButtons[0], priorityButtons[2]]
+
 export const priorityReaderRevenueLight = () => (
 	<ThemeProvider theme={buttonReaderRevenue}>
 		<div css={flexStart}>
-			{priorityButtons.slice(0, 2).map((button, index) => (
+			{readerRevenueButtons.map((button, index) => (
 				<div key={index}>{button}</div>
 			))}
 		</div>
@@ -178,7 +180,7 @@ priorityReaderRevenueLight.story = {
 export const priorityReaderRevenueBlue = () => (
 	<ThemeProvider theme={buttonReaderRevenueBrand}>
 		<div css={flexStart}>
-			{priorityButtons.slice(0, 2).map((button, index) => (
+			{readerRevenueButtons.map((button, index) => (
 				<div key={index}>{button}</div>
 			))}
 		</div>
@@ -196,7 +198,7 @@ priorityReaderRevenueBlue.story = {
 export const priorityReaderRevenueYellow = () => (
 	<ThemeProvider theme={buttonReaderRevenueBrandAlt}>
 		<div css={flexStart}>
-			{priorityButtons.slice(0, 2).map((button, index) => (
+			{readerRevenueButtons.map((button, index) => (
 				<div key={index}>{button}</div>
 			))}
 		</div>

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -22,12 +22,23 @@ const priorityButtons = [
 		Primary
 	</Button>,
 	<Button
-		onClick={() => console.log("Secondary clicked")}
+		onClick={e => console.log("Secondary clicked:", e.target)}
 		priority="secondary"
 	>
 		Secondary
 	</Button>,
-	<Button priority="subdued">Subdued</Button>,
+	<Button
+		onClick={e => console.log("Tertiary clicked", e.target)}
+		priority="tertiary"
+	>
+		Tertiary
+	</Button>,
+	<Button
+		priority="subdued"
+		onClick={e => console.log("Subdued clicked", e.target)}
+	>
+		Subdued
+	</Button>,
 ]
 const sizeButtons = [
 	<Button>Default</Button>,

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -66,6 +66,9 @@ const linkButtons = [
 	<LinkButton href="#" priority="secondary">
 		Secondary
 	</LinkButton>,
+	<LinkButton href="#" priority="tertiary">
+		Tertiary
+	</LinkButton>,
 ]
 const iconLinkButtons = [
 	<LinkButton href="#" showIcon={true}>
@@ -73,6 +76,9 @@ const iconLinkButtons = [
 	</LinkButton>,
 	<LinkButton href="#" showIcon={true} priority="secondary">
 		Secondary
+	</LinkButton>,
+	<LinkButton href="#" showIcon={true} priority="tertiary">
+		Tertiary
 	</LinkButton>,
 ]
 /* eslint-enable react/jsx-key */

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -37,12 +37,20 @@ export const secondary = ({
 }: { button: ButtonTheme } = buttonDefault) => css`
 	background-color: ${button.backgroundSecondary};
 	color: ${button.textSecondary};
-	${button.borderSecondary
-		? `border: 1px solid ${button.borderSecondary};`
-		: ""}
 
 	&:hover {
 		background-color: ${button.backgroundSecondaryHover};
+	}
+`
+
+export const tertiary = ({
+	button,
+}: { button: ButtonTheme } = buttonDefault) => css`
+	color: ${button.textTertiary};
+	border: 1px solid ${button.borderTertiary};
+
+	&:hover {
+		background-color: ${button.backgroundTertiaryHover};
 	}
 `
 
@@ -61,10 +69,6 @@ export const subdued = ({
 	   there is only text, it is more natural to show a rectangle for the focus halo */
 	border-radius: 0;
 `
-
-// TODO: 0.18
-// update this to apply "ghost button styling"
-export const tertiary = subdued
 
 export const defaultSize = css`
 	height: ${size.large}px;

--- a/src/core/components/button/themes.ts
+++ b/src/core/components/button/themes.ts
@@ -4,46 +4,43 @@ import { ButtonTheme } from "@guardian/src-foundations/themes"
 const text = {
 	readerRevenue: {
 		ctaPrimary: brand[400],
-		ctaSecondary: brand[400],
+		ctaTertiary: brand[400],
 	},
 	readerRevenueBrand: {
 		ctaPrimary: brand[400],
-		ctaSecondary: brandAlt[400],
+		ctaTertiary: brandAlt[400],
 	},
 	readerRevenueBrandAlt: {
 		ctaPrimary: neutral[100],
-		ctaSecondary: neutral[7],
+		ctaTertiary: neutral[7],
 	},
 }
 const background = {
 	readerRevenue: {
 		ctaPrimary: brandAlt[400],
 		ctaPrimaryHover: "#FFD213",
-		ctaSecondary: neutral[100],
-		ctaSecondaryHover: "#E5E5E5",
+		ctaTertiaryHover: "#E5E5E5",
 	},
 	readerRevenueBrand: {
 		ctaPrimary: brandAlt[400],
 		ctaPrimaryHover: "#FFD213",
-		ctaSecondary: brand[400],
-		ctaSecondaryHover: "#234B8A",
+		ctaTertiaryHover: brand[300],
 	},
 	readerRevenueBrandAlt: {
 		ctaPrimary: neutral[7],
 		ctaPrimaryHover: "#454545",
-		ctaSecondary: brandAlt[400],
-		ctaSecondaryHover: brandAlt[200],
+		ctaTertiaryHover: "#FFD213",
 	},
 }
 const border = {
 	readerRevenue: {
-		ctaSecondary: brand[400],
+		ctaTertiary: brand[400],
 	},
 	readerRevenueBrand: {
-		ctaSecondary: brandAlt[400],
+		ctaTertiary: brandAlt[400],
 	},
 	readerRevenueBrandAlt: {
-		ctaSecondary: neutral[7],
+		ctaTertiary: neutral[7],
 	},
 }
 
@@ -52,10 +49,9 @@ export const buttonReaderRevenue: { button: ButtonTheme } = {
 		textPrimary: text.readerRevenue.ctaPrimary,
 		backgroundPrimary: background.readerRevenue.ctaPrimary,
 		backgroundPrimaryHover: background.readerRevenue.ctaPrimaryHover,
-		textSecondary: text.readerRevenue.ctaSecondary,
-		backgroundSecondary: background.readerRevenue.ctaSecondary,
-		backgroundSecondaryHover: background.readerRevenue.ctaSecondaryHover,
-		borderSecondary: border.readerRevenue.ctaSecondary,
+		textTertiary: text.readerRevenue.ctaTertiary,
+		backgroundTertiaryHover: background.readerRevenue.ctaTertiaryHover,
+		borderTertiary: border.readerRevenue.ctaTertiary,
 	},
 }
 export const buttonReaderRevenueBrand: { button: ButtonTheme } = {
@@ -63,11 +59,9 @@ export const buttonReaderRevenueBrand: { button: ButtonTheme } = {
 		textPrimary: text.readerRevenueBrand.ctaPrimary,
 		backgroundPrimary: background.readerRevenueBrand.ctaPrimary,
 		backgroundPrimaryHover: background.readerRevenueBrand.ctaPrimaryHover,
-		textSecondary: text.readerRevenueBrand.ctaSecondary,
-		backgroundSecondary: background.readerRevenueBrand.ctaSecondary,
-		backgroundSecondaryHover:
-			background.readerRevenueBrand.ctaSecondaryHover,
-		borderSecondary: border.readerRevenueBrand.ctaSecondary,
+		textTertiary: text.readerRevenueBrand.ctaTertiary,
+		backgroundTertiaryHover: background.readerRevenueBrand.ctaTertiaryHover,
+		borderTertiary: border.readerRevenueBrand.ctaTertiary,
 	},
 }
 
@@ -77,10 +71,9 @@ export const buttonReaderRevenueBrandAlt: { button: ButtonTheme } = {
 		backgroundPrimary: background.readerRevenueBrandAlt.ctaPrimary,
 		backgroundPrimaryHover:
 			background.readerRevenueBrandAlt.ctaPrimaryHover,
-		textSecondary: text.readerRevenueBrandAlt.ctaSecondary,
-		backgroundSecondary: background.readerRevenueBrandAlt.ctaSecondary,
-		backgroundSecondaryHover:
-			background.readerRevenueBrandAlt.ctaSecondaryHover,
-		borderSecondary: border.readerRevenueBrandAlt.ctaSecondary,
+		textTertiary: text.readerRevenueBrandAlt.ctaTertiary,
+		backgroundTertiaryHover:
+			background.readerRevenueBrandAlt.ctaTertiaryHover,
+		borderTertiary: border.readerRevenueBrandAlt.ctaTertiary,
 	},
 }

--- a/src/core/foundations/src/index.ts
+++ b/src/core/foundations/src/index.ts
@@ -26,6 +26,7 @@ import {
 	brandLine,
 	brandText,
 	brandAltBackground,
+	brandAltBorder,
 	brandAltLine,
 	brandAltText,
 	brand,
@@ -55,6 +56,7 @@ export const palette = {
 	brandText,
 	// functional colours (brandAlt)
 	brandAltBackground,
+	brandAltBorder,
 	brandAltLine,
 	brandAltText,
 	// global colours

--- a/src/core/foundations/src/palette/background/brand-alt.ts
+++ b/src/core/foundations/src/palette/background/brand-alt.ts
@@ -6,4 +6,5 @@ export const brandAltBackground = {
 	ctaPrimaryHover: "#454545",
 	ctaSecondary: brandAlt[200],
 	ctaSecondaryHover: "#F2AE00",
+	ctaTertiaryHover: "#FFD213",
 }

--- a/src/core/foundations/src/palette/background/brand.ts
+++ b/src/core/foundations/src/palette/background/brand.ts
@@ -7,4 +7,5 @@ export const brandBackground = {
 	ctaPrimaryHover: "#E0E0E0",
 	ctaSecondary: brand[600],
 	ctaSecondaryHover: "#234B8A",
+	ctaTertiaryHover: brand[300],
 }

--- a/src/core/foundations/src/palette/background/default.ts
+++ b/src/core/foundations/src/palette/background/default.ts
@@ -8,6 +8,7 @@ export const background = {
 	ctaPrimaryHover: "#234B8A",
 	ctaSecondary: brand[800],
 	ctaSecondaryHover: "#ACC9F7",
+	ctaTertiaryHover: "#E5E5E5",
 	input: neutral[100],
 	inputChecked: brand[500],
 }

--- a/src/core/foundations/src/palette/border/brand-alt.ts
+++ b/src/core/foundations/src/palette/border/brand-alt.ts
@@ -1,0 +1,5 @@
+import { neutral } from "../global"
+
+export const brandAltBorder = {
+	ctaTertiary: neutral[7],
+}

--- a/src/core/foundations/src/palette/border/brand.ts
+++ b/src/core/foundations/src/palette/border/brand.ts
@@ -4,6 +4,7 @@ export const brandBorder = {
 	primary: brand[800],
 	success: _success[400],
 	error: _error[500],
+	ctaTertiary: neutral[100],
 	input: brand[800],
 	inputChecked: neutral[100],
 	inputHover: neutral[100],

--- a/src/core/foundations/src/palette/border/default.ts
+++ b/src/core/foundations/src/palette/border/default.ts
@@ -11,6 +11,7 @@ export const border = {
 	secondary: neutral[86],
 	success: _success[400],
 	error: _error[400],
+	ctaTertiary: brand[400],
 	input: neutral[60],
 	inputChecked: brand[500],
 	inputHover: brand[500],

--- a/src/core/foundations/src/palette/border/index.ts
+++ b/src/core/foundations/src/palette/border/index.ts
@@ -1,2 +1,3 @@
 export { border } from "./default"
 export { brandBorder } from "./brand"
+export { brandAltBorder } from "./brand-alt"

--- a/src/core/foundations/src/palette/index.ts
+++ b/src/core/foundations/src/palette/index.ts
@@ -13,6 +13,6 @@ export {
 	labs,
 } from "./global"
 export { background, brandBackground, brandAltBackground } from "./background"
-export { border, brandBorder } from "./border"
+export { border, brandBorder, brandAltBorder } from "./border"
 export { line, brandLine, brandAltLine } from "./line"
 export { text, brandText, brandAltText } from "./text"

--- a/src/core/foundations/src/palette/text/brand-alt.ts
+++ b/src/core/foundations/src/palette/text/brand-alt.ts
@@ -5,5 +5,6 @@ export const brandAltText = {
 	supporting: neutral[60],
 	ctaPrimary: neutral[100],
 	ctaSecondary: neutral[7],
+	ctaTertiary: neutral[7],
 	anchorPrimary: neutral[7],
 }

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -7,6 +7,7 @@ export const brandText = {
 	error: _error[500],
 	ctaPrimary: brand[400],
 	ctaSecondary: neutral[100],
+	ctaTertiary: neutral[100],
 	anchorPrimary: neutral[100],
 	userInput: neutral[100],
 	inputLabel: neutral[100],

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -7,6 +7,7 @@ export const text = {
 	error: _error[400],
 	ctaPrimary: neutral[100],
 	ctaSecondary: brand[400],
+	ctaTertiary: brand[400],
 	anchorPrimary: brand[500],
 	anchorSecondary: neutral[7],
 	userInput: neutral[7],

--- a/src/core/foundations/src/themes/button.ts
+++ b/src/core/foundations/src/themes/button.ts
@@ -1,21 +1,25 @@
 import {
 	text,
+	border,
 	background,
 	brandText,
 	brandBackground,
+	brandBorder,
 	brandAltText,
 	brandAltBackground,
+	brandAltBorder,
 } from "@guardian/src-foundations/palette"
 
 export type ButtonTheme = {
 	textPrimary: string
 	backgroundPrimary: string
 	backgroundPrimaryHover: string
-	textSecondary: string
-	backgroundSecondary: string
-	backgroundSecondaryHover: string
-	borderSecondary?: string
+	textSecondary?: string
+	backgroundSecondary?: string
+	backgroundSecondaryHover?: string
 	textTertiary?: string
+	backgroundTertiaryHover?: string
+	borderTertiary?: string
 	textSubdued?: string
 }
 
@@ -27,7 +31,9 @@ export const buttonDefault: { button: ButtonTheme } = {
 		textSecondary: text.ctaSecondary,
 		backgroundSecondary: background.ctaSecondary,
 		backgroundSecondaryHover: background.ctaSecondaryHover,
-		textTertiary: text.ctaSecondary,
+		textTertiary: text.ctaTertiary,
+		backgroundTertiaryHover: background.ctaTertiaryHover,
+		borderTertiary: border.ctaTertiary,
 		textSubdued: text.ctaSecondary,
 	},
 }
@@ -40,7 +46,9 @@ export const buttonBrand: { button: ButtonTheme } = {
 		textSecondary: brandText.ctaSecondary,
 		backgroundSecondary: brandBackground.ctaSecondary,
 		backgroundSecondaryHover: brandBackground.ctaSecondaryHover,
-		textTertiary: brandText.ctaSecondary,
+		textTertiary: brandText.ctaTertiary,
+		backgroundTertiaryHover: brandBackground.ctaTertiaryHover,
+		borderTertiary: brandBorder.ctaTertiary,
 		textSubdued: brandText.ctaSecondary,
 	},
 }
@@ -53,7 +61,9 @@ export const buttonBrandAlt: { button: ButtonTheme } = {
 		textSecondary: brandAltText.ctaSecondary,
 		backgroundSecondary: brandAltBackground.ctaSecondary,
 		backgroundSecondaryHover: brandAltBackground.ctaSecondaryHover,
-		textTertiary: brandAltText.ctaSecondary,
+		textTertiary: brandAltText.ctaTertiary,
+		backgroundTertiaryHover: brandAltBackground.ctaTertiaryHover,
+		borderTertiary: brandAltBorder.ctaTertiary,
 		textSubdued: brandAltText.ctaSecondary,
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

Following on from #315, tertiary priority buttons have been reworked as "Ghost buttons" (i.e. transparent background and a thin border)

## What does this change?

- Add new CTA colours to palette
- Point to new CTA colours from theme
- BONUS: make colours for nearly all priorities optional to support future themes that don't need secondary or tertiary colours
- Rework tertiary button styles
- Rework tertiary styles in reader revenue theme
- Add tertiary styles to link buttons
- Update readme with new priority option

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Default**

<img width="537" alt="Screenshot 2020-04-22 at 20 42 56" src="https://user-images.githubusercontent.com/5931528/80026461-1481a880-84da-11ea-8c5c-95e73d4bfc92.png">

**Brand**

<img width="538" alt="Screenshot 2020-04-22 at 20 43 14" src="https://user-images.githubusercontent.com/5931528/80026465-151a3f00-84da-11ea-8e70-910d2ca9be5c.png">

**brandAlt**

<img width="537" alt="Screenshot 2020-04-22 at 20 43 21" src="https://user-images.githubusercontent.com/5931528/80026470-164b6c00-84da-11ea-8b2c-c7c02e52d08b.png">

**readerRevenue**

<img width="263" alt="Screenshot 2020-04-22 at 20 43 28" src="https://user-images.githubusercontent.com/5931528/80026472-16e40280-84da-11ea-9c9e-82e3e3687be3.png">

**readerRevenueBrand**

<img width="266" alt="Screenshot 2020-04-22 at 20 43 36" src="https://user-images.githubusercontent.com/5931528/80026474-18152f80-84da-11ea-878f-56dcf5aed153.png">

**readerRevenueBrandAlt**

<img width="275" alt="Screenshot 2020-04-22 at 20 43 43" src="https://user-images.githubusercontent.com/5931528/80026477-19465c80-84da-11ea-9395-754351fd5fe5.png">



### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
