### PR TITLE
Downgrade Yarn to 1.19

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,1 @@
-yarnPath: .yarn/releases/yarn-1.21.1.js
+yarnPath: .yarn/releases/yarn-1.19.1.js


### PR DESCRIPTION
## What is the purpose of this change?

Since Yarn 1.19.2, there has been a bug preventing us from installing new packages in any workspace using `yarn add ...`

More info here:

- https://github.com/yarnpkg/yarn/issues/7807
- https://github.com/yarnpkg/yarn/issues/7734

Downgrading to 1.19.1 reesolves this issue, although it would be better to get back up to date again soon!

## What does this change?

-   Downgrade Yarn to 1.19.1
