### PR TITLE
Refactor size

### DIFF
--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
 import { SvgCheckmark, SvgClose } from "@guardian/src-svgs"
-import { size, space } from "@guardian/src-foundations"
+import { space } from "@guardian/src-foundations"
 import { background } from "@guardian/src-foundations/palette"
 import {
 	Button,
@@ -89,7 +89,7 @@ const flexStart = css`
 	justify-content: flex-start;
 
 	> div {
-		margin-right: ${size.medium}px;
+		margin-right: ${space[9]}px;
 	}
 `
 

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -71,31 +71,20 @@ export const subdued = ({
 `
 
 export const defaultSize = css`
-	height: ${size.large}px;
-	min-height: ${size.large}px;
-	padding: 0 ${size.large / 2}px;
-	border-radius: ${size.large / 2}px;
-`
-
-export const smallSize = css`
 	height: ${size.medium}px;
 	min-height: ${size.medium}px;
 	padding: 0 ${size.medium / 2}px;
 	border-radius: ${size.medium / 2}px;
 `
 
-export const iconDefault = css`
-	svg {
-		flex: 0 0 auto;
-		display: block;
-		fill: currentColor;
-		position: relative;
-		width: ${size.large / 2}px;
-		height: auto;
-	}
+export const smallSize = css`
+	height: ${size.small}px;
+	min-height: ${size.small}px;
+	padding: 0 ${size.small / 2}px;
+	border-radius: ${size.small / 2}px;
 `
 
-export const iconSmall = css`
+export const iconDefault = css`
 	svg {
 		flex: 0 0 auto;
 		display: block;
@@ -106,26 +95,37 @@ export const iconSmall = css`
 	}
 `
 
+export const iconSmall = css`
+	svg {
+		flex: 0 0 auto;
+		display: block;
+		fill: currentColor;
+		position: relative;
+		width: ${size.small / 2}px;
+		height: auto;
+	}
+`
+
 export const iconRight = css`
 	svg {
-		margin: 0 ${-size.large / 8}px 0 ${size.large / 4}px;
+		margin: 0 ${-size.medium / 8}px 0 ${size.medium / 4}px;
 	}
 `
 
 export const iconLeft = css`
 	flex-direction: row-reverse;
 	svg {
-		margin: 0 ${size.large / 4}px 0 ${-size.large / 8}px;
+		margin: 0 ${size.medium / 4}px 0 ${-size.medium / 8}px;
 	}
 `
 
 export const iconOnlyDefault = css`
-	width: ${size.large}px;
+	width: ${size.medium}px;
 	justify-content: center;
 `
 
 export const iconOnlySmall = css`
-	width: ${size.medium}px;
+	width: ${size.small}px;
 	justify-content: center;
 `
 

--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -23,7 +23,7 @@ export const label = ({
 	display: flex;
 	align-items: center;
 	cursor: pointer;
-	min-height: ${size.large}px;
+	min-height: ${size.medium}px;
 
 	&:hover {
 		input {
@@ -45,8 +45,8 @@ export const checkbox = ({
 	display: inline-block;
 	z-index: 1;
 	cursor: pointer;
-	width: ${size.small}px;
-	height: ${size.small}px;
+	width: ${size.xsmall}px;
+	height: ${size.xsmall}px;
 	margin: 0 ${space[2]}px 0 0;
 
 	border: 2px solid currentColor;

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -123,7 +123,7 @@ export const choiceCard = ({
 	display: flex;
 	justify-content: center;
 	/* TODO: let's talk about size! */
-	min-height: ${size.large}px;
+	min-height: ${size.medium}px;
 	margin: 0 0 ${space[2]}px 0;
 	box-shadow: inset 0 0 0 2px ${choiceCard.border};
 	border-radius: 4px;

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -7,7 +7,7 @@ import {
 	SvgExternal,
 	SvgChevronLeftSingle,
 } from "@guardian/src-svgs"
-import { size } from "@guardian/src-foundations"
+import { space } from "@guardian/src-foundations"
 import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
 import { ThemeProvider } from "emotion-theming"
 
@@ -34,7 +34,7 @@ const flexStart = css`
 	justify-content: flex-start;
 
 	> * {
-		margin-right: ${size.medium}px;
+		margin-right: ${space[9]}px;
 	}
 `
 

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -51,7 +51,7 @@ export const icon = css`
 			- Wide: 30x20
 			Since width is constant, we'll hard code it here and allow height to scale
 		*/
-		width: ${size.medium / 2}px;
+		width: ${size.small / 2}px;
 		height: auto;
 	}
 `

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -14,7 +14,7 @@ export const label = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-	min-height: ${size.large}px;
+	min-height: ${size.medium}px;
 
 	&:hover {
 		input {
@@ -33,8 +33,8 @@ export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 	cursor: pointer;
 	box-sizing: border-box;
 	display: inline-block;
-	width: ${size.small}px;
-	height: ${size.small}px;
+	width: ${size.xsmall}px;
+	height: ${size.xsmall}px;
 	margin: 0 ${space[2]}px 0 0;
 
 	border: 2px solid currentColor;

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -17,7 +17,7 @@ export const errorInput = ({
 export const textInput = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
-	height: ${size.large}px;
+	height: ${size.medium}px;
 	${textSans.medium()};
 	color: ${textInput.textUserInput};
 	background-color: ${textInput.backgroundInput};

--- a/src/core/foundations/src/size.ts
+++ b/src/core/foundations/src/size.ts
@@ -1,9 +1,9 @@
 import { size as _size } from "./theme"
 
 const size = {
-	small: _size[0],
-	medium: _size[1],
-	large: _size[2],
+	xsmall: _size[0],
+	small: _size[1],
+	medium: _size[2],
 }
 
 export { size }

--- a/src/core/svgs/stories.tsx
+++ b/src/core/svgs/stories.tsx
@@ -38,7 +38,7 @@ const iconDefault = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.large / 2}px;
+		width: ${size.medium / 2}px;
 		height: auto;
 	}
 `
@@ -49,7 +49,7 @@ const iconSmall = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.medium / 2}px;
+		width: ${size.small / 2}px;
 		height: auto;
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

The sizing names are inconsistent with their usage within Source components, which is causing some confusion. `small` buttons use the `medium` size, default buttons use the `large` size.

We should make sizing names consistent with their usage. 

~We also need an `xxsmall` size for the dinky buttons. used in discussion-rendering (guardian/discussion-rendering#202).~ *We'll hold off on this for now.*

Follow-up PR to come to support an `xsmall` button in dotcom-rendering's immersive header (~not yet implemented~ guardian/dotcom-rendering#1400)

## What does this change?

- update the size names and refactor in components
- ~add xxsmall size (18px) to foundations~

