### PR TITLE
add xxlarge textsans

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -103,4 +103,6 @@ export const textSans: TextSansFunctions = {
 		textSansFs("large", Object.assign({}, textSansDefaults, options)),
 	xlarge: (options?: FontScaleArgs) =>
 		textSansFs("xlarge", Object.assign({}, textSansDefaults, options)),
+	xxlarge: (options?: FontScaleArgs) =>
+		textSansFs("xxlarge", Object.assign({}, textSansDefaults, options)),
 }

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -38,6 +38,7 @@ const textSansSizes: TextSansSizes = {
 	medium: fontSizes[2], //17px
 	large: fontSizes[3], //20px
 	xlarge: fontSizes[4], //24px
+	xxlarge: fontSizes[6], //34px
 }
 
 const fontSizeMapping: {
@@ -78,6 +79,7 @@ const remTextSansSizes: TextSansSizes = {
 	medium: remFontSizes[2], //17px
 	large: remFontSizes[3], //20px
 	xlarge: remFontSizes[4], //24px
+	xxlarge: remFontSizes[6], //34px
 }
 
 const remFontSizeMapping: {

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -42,6 +42,7 @@ export interface TextSansSizes extends TypographySizes {
 	medium: number
 	large: number
 	xlarge: number
+	xxlarge: number
 }
 
 export type Fs = (


### PR DESCRIPTION
## What is the purpose of this change?

Fixes #343

I was wondering if we needed to add `fontSizes[5]` too? Which would involve adding xxlarge textSans and xxxlargeTextSans?