### PR TITLE
Add xsmall button

### DIFF
--- a/src/core/components/button/README.md
+++ b/src/core/components/button/README.md
@@ -49,7 +49,7 @@ Informs users of how important an action is
 
 ### `size`
 
-**`"default" | "small"`** _= "default"_
+**`"default" | "small" | "xsmall"`** _= "default"_
 
 Reflects the prominance of the action
 
@@ -69,7 +69,7 @@ Informs users of how important an action is
 
 ### `size`
 
-**`"default" | "small"`** _= "default"_
+**`"default" | "small" | "xsmall"`** _= "default"_
 
 Reflects the prominance of the action
 

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -15,12 +15,15 @@ import {
 	subdued,
 	defaultSize,
 	smallSize,
+	xsmallSize,
 	iconDefault,
 	iconSmall,
+	iconXsmall,
 	iconLeft,
 	iconRight,
 	iconOnlyDefault,
 	iconOnlySmall,
+	iconOnlyXsmall,
 	iconNudgeAnimation,
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
@@ -38,7 +41,7 @@ export {
 
 export type Priority = "primary" | "secondary" | "tertiary" | "subdued"
 type IconSide = "left" | "right"
-type Size = "default" | "small"
+type Size = "default" | "small" | "xsmall"
 type LinkButtonPriority = Extract<
 	"primary" | "secondary" | "tertiary",
 	Priority
@@ -64,18 +67,21 @@ const sizes: {
 } = {
 	default: defaultSize,
 	small: smallSize,
+	xsmall: xsmallSize,
 }
 const iconSizes: {
 	[key in Size]: SerializedStyles
 } = {
 	default: iconDefault,
 	small: iconSmall,
+	xsmall: iconXsmall,
 }
 const iconOnlySizes: {
 	[key in Size]: SerializedStyles
 } = {
 	default: iconOnlyDefault,
 	small: iconOnlySmall,
+	xsmall: iconOnlyXsmall,
 }
 
 interface ButtonProps extends Props, ButtonHTMLAttributes<HTMLButtonElement> {

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -40,9 +40,21 @@ const priorityButtons = [
 		Subdued
 	</Button>,
 ]
-const sizeButtons = [
-	<Button>Default</Button>,
-	<Button size="small">Small</Button>,
+const defaultSizeButtons = [
+	<Button>Default primary</Button>,
+	<Button priority="subdued">Default subdued</Button>,
+]
+const smallSizeButtons = [
+	<Button size="small">Small primary</Button>,
+	<Button priority="subdued" size="small">
+		Small subdued
+	</Button>,
+]
+const xsmallSizeButtons = [
+	<Button size="xsmall">Extra small primary</Button>,
+	<Button priority="subdued" size="xsmall">
+		Extra small subdued
+	</Button>,
 ]
 const textIconButtons = [
 	<Button icon={<SvgCheckmark />}>Icon to the left</Button>,
@@ -53,11 +65,40 @@ const textIconButtons = [
 		Link button with an arrow icon
 	</LinkButton>,
 ]
+
+const textIconButtonsSmall = [
+	<Button icon={<SvgCheckmark />} size="small">
+		Small: to the left
+	</Button>,
+	<Button iconSide="right" icon={<SvgCheckmark />} size="small">
+		Small: to the right
+	</Button>,
+	<LinkButton href="#" showIcon={true} size="small">
+		Small: Link button
+	</LinkButton>,
+]
+
+const textIconButtonsXsmall = [
+	<Button icon={<SvgCheckmark />} size="xsmall">
+		Extra small: to the left
+	</Button>,
+	<Button iconSide="right" icon={<SvgCheckmark />} size="xsmall">
+		Extra small: to the right
+	</Button>,
+	<LinkButton href="#" showIcon={true} size="xsmall">
+		Extra small: Link button
+	</LinkButton>,
+]
 const iconButtons = [
 	<Button icon={<SvgClose />} aria-label="Dismiss the subscribe banner" />,
 	<Button
 		icon={<SvgClose />}
 		size="small"
+		aria-label="Dismiss the subscribe banner"
+	/>,
+	<Button
+		icon={<SvgClose />}
+		size="xsmall"
 		aria-label="Dismiss the subscribe banner"
 	/>,
 ]
@@ -91,6 +132,10 @@ const flexStart = css`
 	> div {
 		margin-right: ${space[9]}px;
 	}
+`
+
+const bottomSpacer = css`
+	margin-bottom: ${space[9]}px;
 `
 
 export default {
@@ -220,10 +265,22 @@ priorityReaderRevenueYellow.story = {
 }
 
 export const sizes = () => (
-	<div css={flexStart}>
-		{sizeButtons.map((button, index) => (
-			<div key={index}>{button}</div>
-		))}
+	<div>
+		<div css={[flexStart, bottomSpacer]}>
+			{defaultSizeButtons.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+		<div css={[flexStart, bottomSpacer]}>
+			{smallSizeButtons.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+		<div css={[flexStart, bottomSpacer]}>
+			{xsmallSizeButtons.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
 	</div>
 )
 sizes.story = {
@@ -231,10 +288,22 @@ sizes.story = {
 }
 
 export const textAndIcon = () => (
-	<div css={flexStart}>
-		{textIconButtons.map((button, index) => (
-			<div key={index}>{button}</div>
-		))}
+	<div>
+		<div css={[flexStart, bottomSpacer]}>
+			{textIconButtons.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+		<div css={[flexStart, bottomSpacer]}>
+			{textIconButtonsSmall.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
+		<div css={[flexStart, bottomSpacer]}>
+			{textIconButtonsXsmall.map((button, index) => (
+				<div key={index}>{button}</div>
+			))}
+		</div>
 	</div>
 )
 textAndIcon.story = {

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -8,7 +8,6 @@ export const button = css`
 	display: inline-flex;
 	justify-content: space-between;
 	align-items: center;
-	${textSans.medium({ fontWeight: "bold" })};
 	box-sizing: border-box;
 	border: none;
 	background: transparent;
@@ -71,6 +70,7 @@ export const subdued = ({
 `
 
 export const defaultSize = css`
+	${textSans.medium({ fontWeight: "bold" })};
 	height: ${size.medium}px;
 	min-height: ${size.medium}px;
 	padding: 0 ${size.medium / 2}px;
@@ -78,10 +78,19 @@ export const defaultSize = css`
 `
 
 export const smallSize = css`
+	${textSans.medium({ fontWeight: "bold" })};
 	height: ${size.small}px;
 	min-height: ${size.small}px;
 	padding: 0 ${size.small / 2}px;
 	border-radius: ${size.small / 2}px;
+`
+
+export const xsmallSize = css`
+	${textSans.small({ fontWeight: "bold" })};
+	height: ${size.xsmall}px;
+	min-height: ${size.xsmall}px;
+	padding: 0 ${size.xsmall / 2}px;
+	border-radius: ${size.xsmall / 2}px;
 `
 
 export const iconDefault = css`
@@ -106,6 +115,17 @@ export const iconSmall = css`
 	}
 `
 
+export const iconXsmall = css`
+	svg {
+		flex: 0 0 auto;
+		display: block;
+		fill: currentColor;
+		position: relative;
+		width: ${size.xsmall / 2}px;
+		height: auto;
+	}
+`
+
 export const iconRight = css`
 	svg {
 		margin: 0 ${-size.medium / 8}px 0 ${size.medium / 4}px;
@@ -126,6 +146,11 @@ export const iconOnlyDefault = css`
 
 export const iconOnlySmall = css`
 	width: ${size.small}px;
+	justify-content: center;
+`
+
+export const iconOnlyXsmall = css`
+	width: ${size.xsmall}px;
 	justify-content: center;
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

A few places require smaller buttons than we currently provide:

- immersive header (subscribe)
- discussion (reply and share)
- discussion  (view more replies)

This change adds an `xsmall` button with a 24px height.

## What does this change?

- Add xsmall button

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Text only**

![Screenshot 2020-05-01 at 17 16 47](https://user-images.githubusercontent.com/5931528/80820843-8ee3b400-8bcf-11ea-8350-cc16c1decfd4.png)

**Text with icon**

![Screenshot 2020-05-01 at 17 17 06](https://user-images.githubusercontent.com/5931528/80820871-9acf7600-8bcf-11ea-9beb-7caa2f153c51.png)

**Icon only**

![Screenshot 2020-05-01 at 17 17 24](https://user-images.githubusercontent.com/5931528/80820896-a458de00-8bcf-11ea-9a97-035017640df3.png)


### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
