### PR TITLE
Fix overflow issues with text input at narrow viewports

### DIFF
--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/core"
 import { ThemeProvider } from "emotion-theming"
 import { storybookBackgrounds, ThemeName } from "@guardian/src-helpers"
 import { space } from "@guardian/src-foundations"
+import { from } from "@guardian/src-foundations/mq"
 import { TextInput, textInputLight } from "./index"
 
 export default {
@@ -20,7 +21,10 @@ const themes: {
 ]
 
 const constrainedWith = css`
-	width: 30em;
+	width: 100%;
+	${from.phablet} {
+		width: 30em;
+	}
 `
 
 const [defaultLight] = themes.map(({ name, theme }) => {

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -17,6 +17,7 @@ export const errorInput = ({
 export const textInput = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
+	box-sizing: border-box;
 	height: ${size.medium}px;
 	${textSans.medium()};
 	color: ${textInput.textUserInput};
@@ -43,6 +44,7 @@ export const widthFluid = css`
 
 export const width30 = css`
 	width: 30ch;
+	max-width: 100%; /* prevent overflow on narrow viewports */
 `
 
 export const width10 = css`


### PR DESCRIPTION
## What is the purpose of this change?

The following cause horizontal scrolling on mobile viewports:

- fluid width
- 30-character width

The default story also has a horizontal scrollbar because the allocated width of 30em is wider than the viewport for mobile.

## What does this change?

- Use box-sizing: border-box to prevent overflow at fluid width
- Use max-width: 100% to prevent overflow at 30ch width
- Use `mq` to set viewport-appropriate container widths in stories

## Design

<!--
If you are not making changes to the design, please delete this section.
-->

### Screenshots

**Before: fluid**

![Screenshot 2020-05-04 at 16 24 37](https://user-images.githubusercontent.com/5931528/80982863-ca76bc00-8e23-11ea-85f4-c6dec60ab796.png)

**Before: widths**

![Screenshot 2020-05-04 at 16 24 45](https://user-images.githubusercontent.com/5931528/80982871-cba7e900-8e23-11ea-856e-cb1406f8022e.png)

**After: fluid**

![Screenshot 2020-05-04 at 16 23 36](https://user-images.githubusercontent.com/5931528/80982888-cfd40680-8e23-11ea-8a98-dce7b37994f5.png)

**After: widths**

![Screenshot 2020-05-04 at 16 23 27](https://user-images.githubusercontent.com/5931528/80982886-cfd40680-8e23-11ea-8bc5-6906f0c55a9f.png)

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
