### PR TITLE
Add more items to PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,23 +12,55 @@ https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
 Give an overview of the changes you have made.
 -->
 
--   Change 1
--   Change 2
+- Change 1
+- Change 2
 
-## Design
+## Screenshots
 
 <!--
 If you are not making changes to the design, please delete this section.
 -->
 
-### Screenshots
-
 **Before**
 
 **After**
+
+## Checklist
 
 ### Accessibility
 
 -   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
 -   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
 -   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
+-   [ ] The component doesn't use only colour to convey meaning
+
+### Cross browser and device testing
+
+-   [ ] Tested with touch screen device
+
+### Responsiveness
+
+<!--
+If there are guidelines around how much content the
+component can support, or how wide its container
+may get, please specify them in the documentation section
+-->
+
+-   [ ] Tested at all breakpoints
+-   [ ] Tested with with long text, or stretched to fill a wide container
+
+### Documentation
+
+-   [ ] Full API surface area is documented in the README
+-   [ ] Examples in Storybook
+
+<!--
+If we need to make changes to the documentation website,
+please specify them here
+-->
+
+### Known issues
+
+<!--
+If there are known issues, please specify them here
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,7 +47,8 @@ may get, please specify them in the documentation section
 -->
 
 -   [ ] Tested at all breakpoints
--   [ ] Tested with with long text, or stretched to fill a wide container
+-   [ ] Tested with with long text
+-   [ ] Stretched to fill a wide container
 
 ### Documentation
 


### PR DESCRIPTION
## What is the purpose of this change?

It would be useful to prompt contributors to ensure changes to a component would mean the component still meets our [Acceptance Criteria](https://www.theguardian.design/2a1e5182b/p/11c92e-acceptance-criteria)

## What does this change?

- add acceptance criteria checklist to PR template
