### PR TITLE
Increase row header hit area

### DIFF
--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -9,7 +9,6 @@ export const accordion = css`
 `
 
 export const accordionRow = css`
-	padding: ${remSpace[2]};
 	border-top: 1px solid ${border.primary};
 `
 
@@ -17,7 +16,7 @@ export const button = css`
 	width: 100%;
 	display: flex;
 	justify-content: space-between;
-	margin-bottom: ${remSpace[3]};
+	padding: ${remSpace[2]} 0 ${remSpace[6]} 0;
 	align-items: baseline;
 	color: ${text.primary};
 
@@ -25,7 +24,7 @@ export const button = css`
 	background: none;
 	outline: none;
 	border: none;
-	padding: 0;
+	/* padding: 0; */
 	cursor: pointer;
 	text-align: left;
 


### PR DESCRIPTION
## What is the purpose of this change?

The accordion row is not easily clickable/tappable

## What does this change?

- Increase the hit area by making the button fill all available space in the accordion row header

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook
