### PR TITLE
Add nudge animation to toggle icon on hover

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -6,7 +6,6 @@ import {
 	labelText,
 	toggle,
 	toggleLabel,
-	chevronIcon,
 	chevronIconUp,
 	chevronIconDown,
 	expandedBody,
@@ -15,7 +14,7 @@ import {
 import { css } from "@emotion/core"
 import { visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
-import { SvgChevronUpSingle } from "@guardian/src-svgs"
+import { SvgChevronDownSingle } from "@guardian/src-svgs"
 
 interface AccordionProps extends Props {
 	hideToggleLabel?: boolean
@@ -52,16 +51,10 @@ const AccordionRow = ({
 			<button
 				aria-expanded={expanded}
 				onClick={expanded ? collapse : expand}
-				css={button}
+				css={[button, expanded ? chevronIconUp : chevronIconDown]}
 			>
 				<strong css={labelText}>{label}</strong>
-				<div
-					css={[
-						toggle,
-						chevronIcon,
-						expanded ? chevronIconUp : chevronIconDown,
-					]}
-				>
+				<div css={toggle}>
 					{hideToggleLabel ? (
 						<span
 							css={css`
@@ -89,7 +82,7 @@ const AccordionRow = ({
 							)}
 						</span>
 					)}
-					<SvgChevronUpSingle />
+					<SvgChevronDownSingle />
 				</div>
 			</button>
 			<div css={expanded ? expandedBody : collapsedBody}>

--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core"
-import { remSpace, transitions } from "@guardian/src-foundations"
+import { space, remSpace, transitions } from "@guardian/src-foundations"
 import { visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { text, border } from "@guardian/src-foundations/palette"
 import { headline, textSans } from "@guardian/src-foundations/typography"
@@ -81,23 +81,33 @@ export const toggleLabel = css`
 	}
 `
 
-export const chevronIcon = css`
+const chevronIcon = css`
 	svg {
 		/* TODO: we need to tidy up size */
 		width: 15px;
 		height: 15px;
 		margin-left: ${remSpace[1]};
-	}
-`
-
-export const chevronIconUp = css`
-	svg {
-		transform: rotate(0);
-		transition: transform ${transitions.short};
+		transition: ${transitions.short};
 	}
 `
 
 export const chevronIconDown = css`
+	${chevronIcon};
+	svg {
+		transform: translate(0, 0);
+		transition: transform ${transitions.short};
+	}
+
+	&:hover,
+	&:focus {
+		svg {
+			transform: translate(0, ${space[1] / 2}px);
+		}
+	}
+`
+
+export const chevronIconUp = css`
+	${chevronIcon};
 	svg {
 		transform: rotate(180deg);
 		transition: transform ${transitions.short};


### PR DESCRIPTION
## What is the purpose of this change?

We should add more feedback for a user when they hover over the accordion control, to indivcate that it is interactive.

We decided to nudge the icon down when the cursor hovers and the accordion is collapsed. This is consistent with the LinkButton's nudge animation (#127)

## What does this change?

- Add nudge animation to icon on hover

## Screenshots

![2020-05-07 10 40 47](https://user-images.githubusercontent.com/5931528/81279635-4ef95280-904f-11ea-91bc-d9969515c5fa.gif)


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook
