### PR TITLE
Accordion icon size

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -8,6 +8,7 @@ import {
 	toggleLabel,
 	chevronIconUp,
 	chevronIconDown,
+	toggleIconWithLabel,
 	expandedBody,
 	collapsedBody,
 } from "./styles"
@@ -51,7 +52,11 @@ const AccordionRow = ({
 			<button
 				aria-expanded={expanded}
 				onClick={expanded ? collapse : expand}
-				css={[button, expanded ? chevronIconUp : chevronIconDown]}
+				css={[
+					button,
+					expanded ? chevronIconUp : chevronIconDown,
+					!hideToggleLabel ? toggleIconWithLabel : "",
+				]}
 			>
 				<strong css={labelText}>{label}</strong>
 				<div css={toggle}>

--- a/src/core/components/accordion/stories.tsx
+++ b/src/core/components/accordion/stories.tsx
@@ -92,7 +92,7 @@ const hideToggleLabelLight = () => (
 )
 
 hideToggleLabelLight.story = {
-	name: `hide toggle label`,
+	name: `hide toggle label light`,
 }
 
 const defaultMobileLight = () => <div css={container}>{accordion}</div>
@@ -104,4 +104,19 @@ defaultMobileLight.story = {
 	},
 }
 
-export { defaultLight, defaultGrey, hideToggleLabelLight, defaultMobileLight }
+const hideToggleLabelMobileLight = () => <div css={container}>{accordion}</div>
+
+hideToggleLabelMobileLight.story = {
+	name: `hide toggle label light`,
+	parameters: {
+		viewport: { defaultViewport: "mobileMedium" },
+	},
+}
+
+export {
+	defaultLight,
+	defaultGrey,
+	hideToggleLabelLight,
+	defaultMobileLight,
+	hideToggleLabelMobileLight,
+}

--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -3,7 +3,7 @@ import { space, remSpace, transitions } from "@guardian/src-foundations"
 import { visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { text, border } from "@guardian/src-foundations/palette"
 import { headline, textSans } from "@guardian/src-foundations/typography"
-import { until } from "@guardian/src-foundations/mq"
+import { until, from } from "@guardian/src-foundations/mq"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
 export const accordion = css`
@@ -19,14 +19,13 @@ export const button = css`
 	display: flex;
 	justify-content: space-between;
 	padding: ${remSpace[2]} 0 ${remSpace[6]} 0;
-	align-items: baseline;
+	align-items: center;
 	color: ${text.primary};
 
 	/* user agent overrides */
 	background: none;
 	outline: none;
 	border: none;
-	/* padding: 0; */
 	cursor: pointer;
 	text-align: left;
 
@@ -80,12 +79,16 @@ export const toggleLabel = css`
 		${visuallyHidden}
 	}
 `
-
 const chevronIcon = css`
 	svg {
-		/* TODO: we need to tidy up size */
-		width: 15px;
-		height: 15px;
+		/* TODO: think about icon sizing */
+		width: 18px;
+		height: 18px;
+
+		${from.tablet} {
+			width: 26px;
+			height: 26px;
+		}
 		margin-left: ${remSpace[1]};
 		transition: ${transitions.short};
 	}
@@ -111,5 +114,12 @@ export const chevronIconUp = css`
 	svg {
 		transform: rotate(180deg);
 		transition: transform ${transitions.short};
+	}
+`
+
+export const toggleIconWithLabel = css`
+	svg {
+		width: 18px;
+		height: 18px;
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

The size of the icon should be:

- 18px if there is a show / hide label
- 26px if icon is alone

## What does this change?

- Adjust size of icon depending on presence of label text

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

![Screenshot 2020-05-07 at 11 24 09](https://user-images.githubusercontent.com/5931528/81283942-5cb1d680-9055-11ea-9e4d-71ba48817bf5.png)

![Screenshot 2020-05-07 at 11 24 18](https://user-images.githubusercontent.com/5931528/81283945-5d4a6d00-9055-11ea-8161-7afa11f65016.png)

**After**

![Screenshot 2020-05-07 at 11 24 25](https://user-images.githubusercontent.com/5931528/81283947-5d4a6d00-9055-11ea-9728-ba826f5efe24.png)

![Screenshot 2020-05-07 at 15 29 19](https://user-images.githubusercontent.com/5931528/81306594-91368a00-9077-11ea-8803-e7fc7b6e315f.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container
