### PR TITLE
Remove legacy italic API

### DIFF
--- a/src/core/foundations/src/typography/api.ts
+++ b/src/core/foundations/src/typography/api.ts
@@ -15,7 +15,6 @@ type TitlepieceFunctions = {
 const titlepieceDefaults = {
 	lineHeight: "tight",
 	fontWeight: "bold",
-	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }
@@ -36,7 +35,6 @@ type HeadlineFunctions = {
 const headlineDefaults = {
 	lineHeight: "tight",
 	fontWeight: "medium",
-	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }
@@ -66,7 +64,6 @@ type BodyFunctions = {
 const bodyDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
-	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }
@@ -86,7 +83,6 @@ type TextSansFunctions = {
 const textSansDefaults = {
 	lineHeight: "loose",
 	fontWeight: "regular",
-	italic: false, // Legacy property
 	fontStyle: null,
 	unit: "rem",
 }

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -7,17 +7,9 @@ import {
 } from "./data"
 import { Fs, FontWeightDefinition, FontStyle, Option } from "./types"
 
-// Exists to support deprecated API, should be removed at some point
-const legacyItalic = (
-	font: FontWeightDefinition | undefined,
-	italic: boolean,
-): Option<FontStyle> =>
-	italic && font !== undefined && font.hasItalic ? "italic" : null
-
 function getFontStyle(
 	font: FontWeightDefinition | undefined,
 	fontStyle: Option<FontStyle>,
-	italic: boolean,
 ): Option<FontStyle> {
 	switch (fontStyle) {
 		case "italic":
@@ -26,13 +18,13 @@ function getFontStyle(
 			return "normal"
 		case null:
 		default:
-			return legacyItalic(font, italic)
+			return null
 	}
 }
 
 export const fs: Fs = category => (
 	level,
-	{ lineHeight, fontWeight, italic, fontStyle, unit },
+	{ lineHeight, fontWeight, fontStyle, unit },
 ) => {
 	const fontFamilyValue = fontMapping[category]
 	const fontSizeValue =
@@ -48,7 +40,7 @@ export const fs: Fs = category => (
 	// font is unavailable
 	const requestedFont = availableFonts[category][fontWeight]
 	const fontWeightValue = requestedFont ? fontWeightMapping[fontWeight] : ""
-	const fontStyleValue = getFontStyle(requestedFont, fontStyle, italic)
+	const fontStyleValue = getFontStyle(requestedFont, fontStyle)
 
 	return Object.assign(
 		{

--- a/src/core/foundations/src/typography/types.ts
+++ b/src/core/foundations/src/typography/types.ts
@@ -53,13 +53,11 @@ export type Fs = (
 	{
 		lineHeight,
 		fontWeight,
-		italic,
 		fontStyle,
 		unit,
 	}: {
 		lineHeight: LineHeight
 		fontWeight: FontWeight
-		italic: boolean
 		fontStyle: Option<FontStyle>
 		unit: ScaleUnit
 	},
@@ -73,7 +71,6 @@ export type FontScaleFunctionStr = (options?: FontScaleArgs) => string
 export interface FontScaleArgs {
 	lineHeight?: LineHeight
 	fontWeight?: FontWeight
-	italic?: boolean
 	fontStyle?: FontStyle
 	unit?: ScaleUnit
 }

--- a/src/core/foundations/src/typography/typography.test.ts
+++ b/src/core/foundations/src/typography/typography.test.ts
@@ -70,22 +70,6 @@ it("should not return font styles if unspecified", () => {
 	expect(mediumHeadlineStyles).not.toContain("font-style")
 })
 
-it("should support the legacy italic API", () => {
-	const mediumHeadlineStyles = headline.medium({ italic: true })
-
-	expect(mediumHeadlineStyles).toContain("font-style: italic;")
-})
-
-it("should prioritise the new font style API over the deprecated one", () => {
-	const mediumHeadlineStyles = headline.medium({
-		fontStyle: "normal",
-		italic: true,
-	})
-
-	expect(mediumHeadlineStyles).toContain("font-style: normal;")
-	expect(mediumHeadlineStyles).not.toContain("font-style: italic;")
-})
-
 it("should not include italic font style if it is not available for requested font", () => {
 	const mediumHeadlineStyles = headline.medium({
 		fontWeight: "bold",
@@ -94,7 +78,7 @@ it("should not include italic font style if it is not available for requested fo
 
 	const largeHeadlineStyles = headline.large({
 		fontWeight: "bold",
-		italic: true,
+		fontStyle: "italic",
 	})
 
 	expect(mediumHeadlineStyles).not.toContain("font-style: italic;")


### PR DESCRIPTION
## What is the purpose of this change?

We changed our font stlye API in #303. We should now be safe to remove the legacy API that it replaces.

## What does this change?

- remove `italic: boolean` property from `fs` API
