### PR TITLE
Bring accordion font usage into line with design

### DIFF
--- a/src/core/components/accordion/package.json
+++ b/src/core/components/accordion/package.json
@@ -26,6 +26,7 @@
 		"@babel/preset-typescript": "^7.8.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^1.1.0-rc.0",
+		"@guardian/src-link": "^1.1.0-rc.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",

--- a/src/core/components/accordion/stories.tsx
+++ b/src/core/components/accordion/stories.tsx
@@ -2,55 +2,44 @@ import React from "react"
 import { css } from "@emotion/core"
 import { Accordion, AccordionRow } from "./index"
 import { background } from "@guardian/src-foundations/palette"
-import { textSans } from "@guardian/src-foundations/typography"
+import { body } from "@guardian/src-foundations/typography"
 import { from } from "@guardian/src-foundations/mq"
 import { space } from "@guardian/src-foundations"
+import { Link } from "@guardian/src-link"
+
+/* eslint-disable react/jsx-key */
+const accordionRows = [
+	<AccordionRow label="Collecting from multiple newsagents">
+		<p>
+			Present your card to a newsagent each time you collect the paper.
+			The newsagent will scan your card and will be reimbursed for each
+			transaction automatically.
+		</p>
+		<p>
+			<Link href="">Find your nearest participating retailer</Link>
+		</p>
+	</AccordionRow>,
+	<AccordionRow label="Delivery from your retailer">
+		<p>
+			Simply give your preferred store / retailer the barcode printed on
+			your subscription letter.
+		</p>
+		<p>
+			<Link href="">Find your nearest participating retailer</Link>
+		</p>
+	</AccordionRow>,
+]
+/* eslint-enable react/jsx-key */
 
 const accordion = (
 	<Accordion>
-		<AccordionRow label="Collecting from multiple newsagents">
-			<p>
-				Present your card to a newsagent each time you collect the
-				paper. The newsagent will scan your card and will be reimbursed
-				for each transaction automatically.
-			</p>
-			<p>
-				<a href="">Find your nearest participating retailer</a>
-			</p>
-		</AccordionRow>
-		<AccordionRow label="Delivery from your retailer">
-			<p>
-				Simply give your preferred store / retailer the barcode printed
-				on your subscription letter.
-			</p>
-			<p>
-				<a href="">Find your nearest participating retailer</a>
-			</p>
-		</AccordionRow>
+		{accordionRows.map((row, i) => React.cloneElement(row, { key: i }))}
 	</Accordion>
 )
 
 const accordionHideToggleLabel = (
 	<Accordion hideToggleLabel={true}>
-		<AccordionRow label="Collecting from multiple newsagents">
-			<p>
-				Present your card to a newsagent each time you collect the
-				paper. The newsagent will scan your card and will be reimbursed
-				for each transaction automatically.
-			</p>
-			<p>
-				<a href="">Find your nearest participating retailer</a>
-			</p>
-		</AccordionRow>
-		<AccordionRow label="Delivery from your retailer">
-			<p>
-				Simply give your preferred store / retailer the barcode printed
-				on your subscription letter.
-			</p>
-			<p>
-				<a href="">Find your nearest participating retailer</a>
-			</p>
-		</AccordionRow>
+		{accordionRows.map((row, i) => React.cloneElement(row, { key: i }))}
 	</Accordion>
 )
 
@@ -62,7 +51,7 @@ const container = css`
 	}
 
 	p {
-		${textSans.small()};
+		${body.medium({ lineHeight: "regular" })};
 		margin-bottom: ${space[3]}px;
 	}
 `

--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -35,7 +35,7 @@ export const button = css`
 `
 
 export const labelText = css`
-	${headline.xxxsmall()};
+	${headline.xxxsmall({ fontWeight: "bold" })};
 	margin-right: ${remSpace[4]};
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

The design uses a GH Guardian Headline bold for the accordion button label. We should update the code to use this.

The example in Figma uses Guardian Text Egyptian. We should update the code example to use this

## What does this change?

- Boldify label font
- Use Text Egyptian in stories instead of Text Sans
- BONUS: use Link component in stories instead of `a` tag

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**
![Screenshot 2020-05-12 at 10 13 56](https://user-images.githubusercontent.com/5931528/81666016-5ea2dd80-9439-11ea-85db-55d6f500e63c.png)

**After**
<img width="487" alt="Screenshot 2020-05-12 at 10 14 13" src="https://user-images.githubusercontent.com/5931528/81666025-61053780-9439-11ea-8b9a-e4a27938a939.png">

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

