### PR TITLE
Add dependency bumping script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"verbump:major:all": "ts-node ./scripts/verbump-major-all",
 		"verbump:minor:all": "ts-node ./scripts/verbump-minor-all",
 		"verbump:patch:all": "ts-node ./scripts/verbump-patch-all",
-		"verbump:prerelease:all": "ts-node ./scripts/verbump-prerelease-all"
+		"verbump:prerelease:all": "ts-node ./scripts/verbump-prerelease-all",
+		"verbump:deps:all": "ts-node ./scripts/verbump-src-deps-all"
 	},
 	"private": true,
 	"workspaces": [

--- a/scripts/verbump-src-deps-all.ts
+++ b/scripts/verbump-src-deps-all.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from "fs"
+import { version } from "../package.json"
+import { paths, getComponentPaths } from "./paths"
+
+const verbump = (dir: string) => {
+	return fs.readFile(`${dir}/package.json`, "utf8").then(contents => {
+		// perfectly safe find and replace that definitely, _definitely_ won't go wrong ever
+		const regex = /"@guardian\/src-(\w+)": ".*"/g
+		const replaceString = `"@guardian\/src-$1": "^${version}"`
+		const bumpedContents = contents.replace(regex, replaceString)
+
+		return fs.writeFile(`${dir}/package.json`, bumpedContents)
+	})
+}
+
+const { root, foundations, svgs, helpers } = paths
+
+const packages = getComponentPaths().then(paths =>
+	paths.concat([foundations, svgs, root, helpers]),
+)
+
+packages.then(ps => {
+	ps.forEach(dir => {
+		if (!dir) return
+
+		verbump(dir).catch(err => console.log("Error bumping packages:", err))
+	})
+})


### PR DESCRIPTION
## What is the purpose of this change?

To speed up releases, we need a script that will bump dependencies, peerDependencies and devDependencies which begin with `@guardian/src-*` in every src-* package to the latest version.
 
## What does this change?

- Add a dependency-bumping script
