### PR TITLE
Add no-JS support to accordion

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -18,7 +18,7 @@ import { css } from "@emotion/core"
 import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
 import { SvgChevronDownSingle } from "@guardian/src-svgs"
-export { AccordionTheme } from "@guardian/src-foundations/themes"
+export { accordionDefault } from "@guardian/src-foundations/themes"
 
 const visuallyHidden = css`
 	${_visuallyHidden}

--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactElement, ReactNode } from "react"
+import React, { useState, useEffect, ReactElement, ReactNode } from "react"
 import {
 	accordion,
 	accordionRow,
@@ -11,12 +11,18 @@ import {
 	toggleIconWithLabel,
 	expandedBody,
 	collapsedBody,
+	noJsInput,
+	noJsButton,
 } from "./styles"
 import { css } from "@emotion/core"
-import { visuallyHidden } from "@guardian/src-foundations/accessibility"
+import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
 import { SvgChevronDownSingle } from "@guardian/src-svgs"
 export { AccordionTheme } from "@guardian/src-foundations/themes"
+
+const visuallyHidden = css`
+	${_visuallyHidden}
+`
 
 interface AccordionProps extends Props {
 	hideToggleLabel?: boolean
@@ -39,6 +45,67 @@ interface AccordionRowProps extends Props {
 	children: ReactNode
 }
 
+const NoJsRow = ({
+	label,
+	hideToggleLabel = false,
+	children,
+}: AccordionRowProps) => {
+	return (
+		<div css={theme => accordionRow(theme.accordion && theme)}>
+			<label>
+				<input type="checkbox" css={noJsInput} role="button" />
+				<div
+					css={theme => noJsButton(theme.accordion && theme)}
+					data-target="label"
+				>
+					<strong css={labelText}>{label}</strong>
+					<div data-target="toggle">
+						<div
+							css={[
+								toggle,
+								chevronIconDown,
+								!hideToggleLabel ? toggleIconWithLabel : "",
+							]}
+							data-target="toggle-label-show"
+						>
+							<span
+								css={[
+									toggleLabel,
+									hideToggleLabel ? visuallyHidden : "",
+								]}
+							>
+								Show<span css={visuallyHidden}> more</span>
+							</span>
+							<SvgChevronDownSingle />
+						</div>
+						<div
+							css={[
+								toggle,
+								chevronIconUp,
+								!hideToggleLabel ? toggleIconWithLabel : "",
+							]}
+							data-target="toggle-label-hide"
+						>
+							<span
+								css={[
+									toggleLabel,
+									hideToggleLabel ? visuallyHidden : "",
+								]}
+							>
+								Hide
+							</span>
+							<SvgChevronDownSingle />
+						</div>
+					</div>
+				</div>
+				<div css={collapsedBody} data-target="body">
+					<div>{children}</div>
+				</div>
+			</label>
+		</div>
+	)
+}
+
 const AccordionRow = ({
 	label,
 	hideToggleLabel = false,
@@ -47,55 +114,57 @@ const AccordionRow = ({
 	const [expanded, setExpanded] = useState(false)
 	const collapse = () => setExpanded(false)
 	const expand = () => setExpanded(true)
+	const [isBrowser, setIsBrowser] = useState(false)
 
-	return (
-		<div css={theme => accordionRow(theme.accordion && theme)}>
-			<button
-				aria-expanded={expanded}
-				onClick={expanded ? collapse : expand}
-				css={theme => [
-					button(theme.accordion && theme),
-					expanded ? chevronIconUp : chevronIconDown,
-					!hideToggleLabel ? toggleIconWithLabel : "",
-				]}
-			>
-				<strong css={labelText}>{label}</strong>
-				<div css={toggle}>
-					{hideToggleLabel ? (
-						<span
-							css={css`
-								${visuallyHidden}
-							`}
-						>
-							{expanded ? "Hide" : "Show more"}
-						</span>
-					) : (
-						<span css={toggleLabel}>
-							{expanded ? (
-								"Hide"
-							) : (
-								<>
-									Show
-									<span
-										css={css`
-											${visuallyHidden}
-										`}
-									>
-										{" "}
-										more
-									</span>
-								</>
-							)}
-						</span>
-					)}
-					<SvgChevronDownSingle />
+	useEffect(() => {
+		setIsBrowser(true)
+	})
+
+	if (isBrowser) {
+		return (
+			<div css={theme => accordionRow(theme.accordion && theme)}>
+				<button
+					aria-expanded={expanded}
+					onClick={expanded ? collapse : expand}
+					css={theme => [
+						button(theme.accordion && theme),
+						expanded ? chevronIconUp : chevronIconDown,
+						!hideToggleLabel ? toggleIconWithLabel : "",
+					]}
+				>
+					<strong css={labelText}>{label}</strong>
+					<div css={toggle}>
+						{hideToggleLabel ? (
+							<span css={visuallyHidden}>
+								{expanded ? "Hide" : "Show more"}
+							</span>
+						) : (
+							<span css={toggleLabel}>
+								{expanded ? (
+									"Hide"
+								) : (
+									<>
+										Show
+										<span css={visuallyHidden}> more</span>
+									</>
+								)}
+							</span>
+						)}
+						<SvgChevronDownSingle />
+					</div>
+				</button>
+				<div css={expanded ? expandedBody : collapsedBody}>
+					<div hidden={!expanded}>{children}</div>
 				</div>
-			</button>
-			<div css={expanded ? expandedBody : collapsedBody}>
-				<div hidden={!expanded}>{children}</div>
 			</div>
-		</div>
-	)
+		)
+	}
+
+	return NoJsRow({
+		label,
+		hideToggleLabel,
+		children,
+	})
 }
 
 export { Accordion, AccordionRow }

--- a/src/core/components/accordion/styles.ts
+++ b/src/core/components/accordion/styles.ts
@@ -21,21 +21,25 @@ export const accordionRow = ({
 	border-top: 1px solid ${accordion.borderPrimary};
 `
 
-export const button = ({
-	accordion,
-}: { accordion: AccordionTheme } = accordionDefault) => css`
+const buttonStyles = css`
 	width: 100%;
 	display: flex;
 	justify-content: space-between;
-	padding: ${remSpace[2]} 0 ${remSpace[6]} 0;
 	align-items: center;
+	padding: ${remSpace[2]} 0 ${remSpace[6]} 0;
+	cursor: pointer;
+`
+
+export const button = ({
+	accordion,
+}: { accordion: AccordionTheme } = accordionDefault) => css`
+	${buttonStyles};
 	color: ${accordion.textPrimary};
 
 	/* user agent overrides */
 	background: none;
 	outline: none;
 	border: none;
-	cursor: pointer;
 	text-align: left;
 
 	&:focus div {
@@ -43,12 +47,19 @@ export const button = ({
 	}
 `
 
+export const noJsButton = ({
+	accordion,
+}: { accordion: AccordionTheme } = accordionDefault) => css`
+	${buttonStyles};
+	color: ${accordion.textPrimary};
+`
+
 export const labelText = css`
 	${headline.xxxsmall({ fontWeight: "bold" })};
 	margin-right: ${remSpace[4]};
 `
 
-export const expandedBody = css`
+const expandedBodyStyles = css`
 	/*
 	TODO:
 	Hardcoded max-height because auto is invalid.
@@ -63,7 +74,11 @@ export const expandedBody = css`
 	height: auto;
 `
 
-export const collapsedBody = css`
+export const expandedBody = css`
+	${expandedBodyStyles};
+`
+
+export const collapsedBodyStyles = css`
 	max-height: 0;
 	/*
 	TODO:
@@ -73,6 +88,34 @@ export const collapsedBody = css`
 	transition: max-height ${transitions.short};
 	*/
 	overflow: hidden;
+`
+export const collapsedBody = css`
+	${collapsedBodyStyles};
+`
+
+export const noJsInput = css`
+	${visuallyHidden};
+
+	&:focus + [data-target="label"] > [data-target="toggle"] {
+		${focusHalo};
+	}
+
+	&:not(:checked) ~ [data-target="body"] {
+		${collapsedBodyStyles};
+		display: none;
+	}
+
+	&:checked ~ [data-target="body"] {
+		${expandedBodyStyles};
+	}
+
+	&:not(:checked) + [data-target="label"] [data-target="toggle-label-hide"] {
+		display: none;
+	}
+
+	&:checked + [data-target="label"] [data-target="toggle-label-show"] {
+		display: none;
+	}
 `
 
 export const toggle = css`


### PR DESCRIPTION
## What is the purpose of this change?

Our [Acceptance criteria](https://www.theguardian.design/2a1e5182b/p/11c92e-acceptance-criteria/t/7967c4) require all components to function without JavaScript. This change adds no-JS support.

## What does this change?


- Provide no-JavaScript alternative markup using a hidden checkbox
- BONUS: fix type issue with AccordionTheme

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Known issues

Without JavaScript, the component is not as accessible. We're using a label that controls a hidden checkbox to determine the state of an accordion row. The checkbox element doesn't respond to an `Enter` keystroke, only a `Space` keystroke, which may prove tricky for keyboard users with JS disabled.