### PR TITLE
Use ex instead of ch for better browser consistency

### DIFF
--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -43,16 +43,16 @@ export const widthFluid = css`
 `
 
 export const width30 = css`
-	width: 30ch;
+	width: 40ex;
 	max-width: 100%; /* prevent overflow on narrow viewports */
 `
 
 export const width10 = css`
-	width: 10ch;
+	width: 18ex;
 `
 
 export const width4 = css`
-	width: 4ch;
+	width: 9ex;
 `
 
 export const text = ({


### PR DESCRIPTION
## What is the purpose of this change?

Text input fields use the [`ch` unit](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#Relative_length_units) to set the width based on expected character length.

We have noticed that fields look narrower in IE11 due to the way IE11 calculates the width of `1ch`. According to [CanIUse](https://caniuse.com/#feat=ch-unit):

> IE supports the ch unit, but unlike other browsers its width is that specifically of the "0" glyph, not its surrounding space. As a result, 3ch for example is shorter than the width of the string "000" in IE.

The `ex` unit appears more consistent across browsers. Using this would mean we would not be able to map the expected character length to the actual width of the field.

GOV.UK [uses the `ex` unit](https://github.com/alphagov/govuk-design-system-backlog/issues/51#issuecomment-496411901) for their [fixed width text inputs](https://design-system.service.gov.uk/components/text-input/#fixed-width-inputs).

## What does this change?

- Use `ex` instead of `ch` to declare text input widths

## Screenshots

**Before IE11**

![Screenshot 2020-05-20 at 15 21 30](https://user-images.githubusercontent.com/5931528/82457832-d1513000-9aad-11ea-8e41-ad33059f671c.png)

**Before Safari**

![Screenshot 2020-05-20 at 15 22 25](https://user-images.githubusercontent.com/5931528/82457816-cc8c7c00-9aad-11ea-87bb-3393e615103e.png)

**After IE11**

![Screenshot 2020-05-20 at 15 20 45](https://user-images.githubusercontent.com/5931528/82457839-d4e4b700-9aad-11ea-84e0-dfa6de200069.png)

**After Safari**

![Screenshot 2020-05-20 at 15 21 47](https://user-images.githubusercontent.com/5931528/82457853-dd3cf200-9aad-11ea-827f-bec9b14e5231.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

