### PR TITLE
IE11 fixes

### DIFF
--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -138,20 +138,24 @@ export const iconLeft = css`
 		margin: 0 ${size.medium / 4}px 0 ${-size.medium / 8}px;
 	}
 `
+const iconOnly = css`
+	justify-content: center;
+	padding: 0;
+`
 
 export const iconOnlyDefault = css`
+	${iconOnly};
 	width: ${size.medium}px;
-	justify-content: center;
 `
 
 export const iconOnlySmall = css`
+	${iconOnly};
 	width: ${size.small}px;
-	justify-content: center;
 `
 
 export const iconOnlyXsmall = css`
+	${iconOnly};
 	width: ${size.xsmall}px;
-	justify-content: center;
 `
 
 export const iconNudgeAnimation = css`

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -17,6 +17,7 @@ import {
 	tick,
 	errorChoiceCard,
 	contentWrapper,
+	contentWrapperLabelOnly,
 } from "./styles"
 import { InlineError } from "@guardian/src-inline-error"
 import { Props } from "@guardian/src-helpers"
@@ -147,7 +148,12 @@ const ChoiceCard = ({
 				]}
 				htmlFor={id}
 			>
-				<div css={contentWrapper}>
+				<div
+					css={[
+						contentWrapper,
+						!iconSvg ? contentWrapperLabelOnly : "",
+					]}
+				>
 					{iconSvg ? iconSvg : ""}
 					<div>{labelContent}</div>
 				</div>

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -169,7 +169,10 @@ export const contentWrapper = css`
 		/* TODO: 30px is a standard icon width, should probably exposed
 		as a size property */
 		width: 30px;
-		height: auto;
+		/* TODO: height is non-standard to support payment icons, which is
+		currently the only use case of the icon variant. We should find a way
+		to accommodate standard 30x30 icons too */
+		height: 20px;
 		left: -34px; /* width + 4px "margin" */
 		fill: currentColor;
 

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -149,10 +149,10 @@ export const contentWrapper = css`
 	flex: 0 1 auto;
 	display: flex;
 	flex-direction: row;
-	box-sizing: border-box;
 	align-items: center;
 	justify-content: center;
 	position: relative;
+	box-sizing: border-box;
 
 	${from.mobileLandscape} {
 		flex-direction: column;
@@ -178,6 +178,17 @@ export const contentWrapper = css`
 
 		${from.mobileLandscape} {
 			position: static;
+		}
+	}
+`
+
+/* We need to explicitly set the width of the content to support
+flex-direction: column in IE11 */
+export const contentWrapperLabelOnly = css`
+	width: 100%;
+	${from.mobileLandscape} {
+		& > div {
+			width: 100%;
 		}
 	}
 `

--- a/src/core/components/inline-error/styles.ts
+++ b/src/core/components/inline-error/styles.ts
@@ -18,5 +18,6 @@ export const inlineError = ({
 	svg {
 		fill: currentColor;
 		width: 30px;
+		height: 30px;
 	}
 `

--- a/src/core/svgs/stories.tsx
+++ b/src/core/svgs/stories.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { css } from "@emotion/core"
 
-import { size } from "@guardian/src-foundations"
 import { storybookBackgrounds } from "@guardian/src-helpers"
 
 import {
@@ -38,8 +37,15 @@ const iconDefault = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.medium / 2}px;
-		height: auto;
+		width: 30px;
+		height: 30px;
+	}
+`
+
+const paymentIconDefault = css`
+	svg {
+		height: 20px;
+		padding-bottom: 10px;
 	}
 `
 
@@ -49,8 +55,15 @@ const iconSmall = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.small / 2}px;
-		height: auto;
+		width: 15px;
+		height: 15px;
+	}
+`
+
+const paymentIconSmall = css`
+	svg {
+		height: 10px;
+		padding-bottom: 5px;
 	}
 `
 
@@ -58,35 +71,52 @@ const Small = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 	<div css={[iconSmall, whiteColor]}>{children}</div>
 )
 
+const SmallPayment = ({
+	children,
+}: {
+	children: JSX.Element | JSX.Element[]
+}) => <div css={[iconSmall, paymentIconSmall, whiteColor]}>{children}</div>
+
 const Default = ({ children }: { children: JSX.Element | JSX.Element[] }) => (
 	<div css={[iconDefault]}>{children}</div>
 )
+
+const DefaultPayment = ({
+	children,
+}: {
+	children: JSX.Element | JSX.Element[]
+}) => <div css={[iconDefault, paymentIconDefault]}>{children}</div>
 
 export default {
 	title: "Icons",
 }
 
 export const SmallIcons = () => (
-	<Small>
-		<SvgAlert />
-		<SvgArrowDownStraight />
-		<SvgArrowLeftStraight />
-		<SvgArrowRightStraight />
-		<SvgArrowUpStraight />
-		<SvgChevronDownSingle />
-		<SvgChevronLeftSingle />
-		<SvgChevronRightSingle />
-		<SvgChevronUpSingle />
-		<SvgCreditCard />
-		<SvgDirectDebit />
-		<SvgPayPal />
-		<SvgExternal />
-		<SvgCheckmark />
-		<SvgClose />
-		<SvgMinus />
-		<SvgPlus />
-		<SvgIndent />
-	</Small>
+	<>
+		<Small>
+			<SvgAlert />
+			<SvgArrowDownStraight />
+			<SvgArrowLeftStraight />
+			<SvgArrowRightStraight />
+			<SvgArrowUpStraight />
+			<SvgChevronDownSingle />
+			<SvgChevronLeftSingle />
+			<SvgChevronRightSingle />
+			<SvgChevronUpSingle />
+			<SvgExternal />
+			<SvgCheckmark />
+			<SvgClose />
+			<SvgMinus />
+			<SvgPlus />
+			<SvgIndent />
+		</Small>
+
+		<SmallPayment>
+			<SvgCreditCard />
+			<SvgDirectDebit />
+			<SvgPayPal />
+		</SmallPayment>
+	</>
 )
 SmallIcons.story = {
 	name: "small size",
@@ -98,26 +128,31 @@ SmallIcons.story = {
 }
 
 export const DefaultIcons = () => (
-	<Default>
-		<SvgAlert />
-		<SvgArrowDownStraight />
-		<SvgArrowLeftStraight />
-		<SvgArrowRightStraight />
-		<SvgArrowUpStraight />
-		<SvgChevronDownSingle />
-		<SvgChevronLeftSingle />
-		<SvgChevronRightSingle />
-		<SvgChevronUpSingle />
-		<SvgCreditCard />
-		<SvgDirectDebit />
-		<SvgPayPal />
-		<SvgExternal />
-		<SvgCheckmark />
-		<SvgClose />
-		<SvgMinus />
-		<SvgPlus />
-		<SvgIndent />
-	</Default>
+	<>
+		<Default>
+			<SvgAlert />
+			<SvgArrowDownStraight />
+			<SvgArrowLeftStraight />
+			<SvgArrowRightStraight />
+			<SvgArrowUpStraight />
+			<SvgChevronDownSingle />
+			<SvgChevronLeftSingle />
+			<SvgChevronRightSingle />
+			<SvgChevronUpSingle />
+			<SvgExternal />
+			<SvgCheckmark />
+			<SvgClose />
+			<SvgMinus />
+			<SvgPlus />
+			<SvgIndent />
+		</Default>
+
+		<DefaultPayment>
+			<SvgCreditCard />
+			<SvgDirectDebit />
+			<SvgPayPal />
+		</DefaultPayment>
+	</>
 )
 DefaultIcons.story = {
 	name: "default size",


### PR DESCRIPTION
## What is the purpose of this change?

There are a few IE11 issues across our components

- Poor alignment of icon-only buttons
- Inline errors look incredibly tall
- Icons in the icons story look incredibly tall
- Choice cards with icons look incredibly tall
- Very long text breaks out of container in choice cards

## What does this change?

- Various fixes add explicit icon height, as IE11 cannot calculate this as effectively as other browsers
- Remove unnecessary padding from icon only buttons to fix alignment issue
- Add explicit width to choice card content areas to fix issue with text not wrapping

## Screenshots

**Before**

![Screenshot 2020-05-20 at 14 51 01](https://user-images.githubusercontent.com/5931528/82454172-58e87000-9aa9-11ea-8ce7-08c32f60945b.png)

**After**

![Screenshot 2020-05-20 at 14 50 44](https://user-images.githubusercontent.com/5931528/82454168-584fd980-9aa9-11ea-9476-457c022acbc5.png)

**Before**

![Screenshot 2020-05-20 at 14 53 02](https://user-images.githubusercontent.com/5931528/82454422-a95fcd80-9aa9-11ea-9834-342fb9bfe2f3.png)

**After**

![Screenshot 2020-05-20 at 14 53 06](https://user-images.githubusercontent.com/5931528/82454423-a9f86400-9aa9-11ea-96e5-bf831084f479.png)

**Before**

![Screenshot 2020-05-20 at 14 54 14](https://user-images.githubusercontent.com/5931528/82454571-d14f3100-9aa9-11ea-9524-6c08f5e60fb2.png)

**After**

![Screenshot 2020-05-20 at 14 54 00](https://user-images.githubusercontent.com/5931528/82454565-d0b69a80-9aa9-11ea-86c7-2190e94e11b6.png)

**Before**

![Screenshot 2020-05-20 at 14 49 28](https://user-images.githubusercontent.com/5931528/82454001-2cccef00-9aa9-11ea-9a8b-9783e093fafe.png)

**After**

![Screenshot 2020-05-20 at 14 49 04](https://user-images.githubusercontent.com/5931528/82453998-2c345880-9aa9-11ea-8217-93bc6b6766fd.png)


**Before**

![Screenshot 2020-05-20 at 14 55 03](https://user-images.githubusercontent.com/5931528/82454682-f5127700-9aa9-11ea-82a0-2049ecd27543.png)

**After**

![Screenshot 2020-05-20 at 14 55 13](https://user-images.githubusercontent.com/5931528/82454685-f5ab0d80-9aa9-11ea-85cd-2ac2dd22d7a6.png)


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

