### PR TITLE
Resize indent svg to be 30x30

### DIFF
--- a/src/core/svgs/indent.tsx
+++ b/src/core/svgs/indent.tsx
@@ -2,11 +2,11 @@ import React from "react"
 
 export const SvgIndent = () => {
 	return (
-		<svg viewBox="0 0 30 20" xmlns="http://www.w3.org/2000/svg">
+		<svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
 			<path
 				fillRule="evenodd"
 				clipRule="evenodd"
-				d="M8.02499 9.49998V5H6V10.45L7.025 11.475H20.7499L18 15.05L18.85 15.95L23.9999 10.825V10.15L18.9 5.025L18 5.9L20.7499 9.49998H8.02499Z"
+				d="M8.02499 14.5V10H6V15.45L7.025 16.475H20.7499L18 20.05L18.85 20.95L23.9999 15.825V15.15L18.9 10.025L18 10.9L20.7499 14.5H8.02499Z"
 			/>
 		</svg>
 	)


### PR DESCRIPTION
## What is the purpose of this change?

All our UI icons are 30x30 with the exception of Indent, which is 30x20. We should add the Indent icon to a 30x30 viewbox to make it consistent.

## What does this change?

- Add indent icon to 30x30 viewbox

## Screenshots

**Before**

![Screenshot 2020-05-20 at 15 46 58](https://user-images.githubusercontent.com/5931528/82460512-293d6600-9ab1-11ea-83a3-b6b24415589c.png)

**After**

![Screenshot 2020-05-20 at 15 45 54](https://user-images.githubusercontent.com/5931528/82460535-335f6480-9ab1-11ea-851c-bdd10d691bf1.png)
