### PR TITLE
Add new size endpoint to foundations

### DIFF
--- a/src/core/foundations/.gitignore
+++ b/src/core/foundations/.gitignore
@@ -2,6 +2,7 @@
 mq/
 accessibility/
 palette/
+size/
 themes/
 typography/
 utils/
@@ -15,6 +16,7 @@ tsconfig.tsbuildinfo
 !src/mq/
 !src/accessibility/
 !src/palette
+!src/size
 !src/themes/
 !src/typography/
 !src/utils/

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"build": "yarn clean && tsc && rollup --config && yarn copy:types",
 		"watch": "yarn clean && tsc && rollup --config --watch",
-		"clean": "rm -rf accessibility mq palette themes typography utils foundations.js foundations.esm.js *.d.ts tsconfig.tsbuildinfo src/*.d.ts",
+		"clean": "rm -rf accessibility mq palette size themes typography utils foundations.js foundations.esm.js *.d.ts tsconfig.tsbuildinfo src/*.d.ts",
 		"copy:types": "ts-node --script-mode scripts/copy-type-definitions --esModuleInterop",
 		"publish:public": "yarn publish --access public",
 		"prepublishOnly": "yarn build",
@@ -39,6 +39,7 @@
 		"src/accessibility/index.ts",
 		"src/mq/index.ts",
 		"src/palette/**",
+		"src/size/**",
 		"src/themes/**",
 		"src/typography/**",
 		"src/utils/**"

--- a/src/core/foundations/rollup.config.js
+++ b/src/core/foundations/rollup.config.js
@@ -7,6 +7,7 @@ const folders = [
 	"accessibility",
 	"mq",
 	"palette",
+	"size",
 	"themes",
 	"typography",
 	"typography/obj",

--- a/src/core/foundations/scripts/paths.ts
+++ b/src/core/foundations/scripts/paths.ts
@@ -5,6 +5,7 @@ const folders = [
 	"accessibility",
 	"mq",
 	"palette",
+	"size",
 	"themes",
 	"typography",
 	"utils",

--- a/src/core/foundations/src/index.ts
+++ b/src/core/foundations/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./animation"
 export * from "./breakpoints"
 export * from "./palette"
-export * from "./size"
+export * from "./size__legacy"
 export * from "./space"
 
 // Avoid importing the entire palette directly in your application. Prefer using the named exports

--- a/src/core/foundations/src/size/global.ts
+++ b/src/core/foundations/src/size/global.ts
@@ -1,0 +1,39 @@
+import { size as _size } from "../theme"
+import { pxToRem } from "../utils"
+
+/*
+   The size scale is based entirely on the medium, small and
+   xsmall buttons. The medium size meets WCAG 2.1 AAA compliance
+   for touch targets.
+*/
+const size = {
+	xsmall: _size[0],
+	small: _size[1],
+	medium: _size[2],
+}
+
+const remSize: { [K in keyof (typeof size)]: number } = {
+	xsmall: pxToRem(_size[0]),
+	small: pxToRem(_size[1]),
+	medium: pxToRem(_size[2]),
+}
+
+/*
+   We attempt to use these values for icons within Source components.
+   They are analogous with component heights defined by the size values
+   above. They are based on the size of icons used within the button
+   component.
+*/
+const iconSize = {
+	xsmall: 20,
+	small: 26,
+	medium: 30,
+}
+
+const remIconSize: { [K in keyof (typeof iconSize)]: number } = {
+	xsmall: pxToRem(20),
+	small: pxToRem(26),
+	medium: pxToRem(30),
+}
+
+export { size, remSize, iconSize, remIconSize }

--- a/src/core/foundations/src/size/index.ts
+++ b/src/core/foundations/src/size/index.ts
@@ -1,0 +1,49 @@
+import { size, remSize, iconSize, remIconSize } from "./global"
+
+const height = {
+	ctaMedium: size.medium,
+	ctaSmall: size.small,
+	ctaXsmall: size.xsmall,
+	inputMedium: size.medium,
+	inputXsmall: size.xsmall,
+	iconMedium: iconSize.medium,
+	iconSmall: iconSize.small,
+	iconXsmall: iconSize.xsmall,
+	iconPayment: iconSize.xsmall,
+}
+
+const remHeight = {
+	ctaMedium: remSize.medium,
+	ctaSmall: remSize.small,
+	ctaXsmall: remSize.xsmall,
+	inputMedium: remSize.medium,
+	inputXsmall: remSize.xsmall,
+	iconMedium: remIconSize.medium,
+	iconSmall: remIconSize.small,
+	iconXsmall: remIconSize.xsmall,
+	iconPayment: remIconSize.xsmall,
+}
+
+const width = {
+	ctaMedium: size.medium,
+	ctaSmall: size.small,
+	ctaXsmall: size.xsmall,
+	inputXsmall: size.xsmall,
+	iconMedium: iconSize.medium,
+	iconSmall: iconSize.small,
+	iconXsmall: iconSize.xsmall,
+	iconPayment: iconSize.medium,
+}
+
+const remWidth = {
+	ctaMedium: remSize.medium,
+	ctaSmall: remSize.small,
+	ctaXsmall: remSize.xsmall,
+	inputXsmall: remSize.xsmall,
+	iconMedium: remIconSize.medium,
+	iconSmall: remIconSize.small,
+	iconXsmall: remIconSize.xsmall,
+	iconPayment: remIconSize.medium,
+}
+
+export { height, remHeight, width, remWidth, size, iconSize }

--- a/src/core/foundations/src/size__legacy.ts
+++ b/src/core/foundations/src/size__legacy.ts
@@ -1,5 +1,9 @@
 import { size as _size } from "./theme"
 
+/*
+This API is now deprecated. Use the values under
+@guardian/src-foundations/size instead
+*/
 const size = {
 	xsmall: _size[0],
 	small: _size[1],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
 			"@guardian/src-foundations/palette": [
 				"core/foundations/src/palette"
 			],
+			"@guardian/src-foundations/size": ["core/foundations/src/size"],
 			"@guardian/src-foundations/themes": ["core/foundations/src/themes"],
 			"@guardian/src-foundations/typography": [
 				"core/foundations/src/typography"


### PR DESCRIPTION
## What is the purpose of this change?

At the moment we have three one-size-fits-all sizing values:

- xsmall
- small
- medium

We need to define context-specific tokens to help people understand how our sizing scale works, to help them make decisions and to drive consistency.

We need tokens for:

- call to action height (xsmall, small, medium)
- input elements (such as checkboxes, text fields)
- icons used inside Source components

We expose `rem` and `px` versions of each token.

In the future, we may need tokens for:

- icons used outside Source components (TBC)

### Icon sizes

There are very few instances of icons being used outside of Source components. We anticipate that Editorial Tools will find icons more useful. We will make a decision on external icon size recommendations when we have conducted an inventory of Editorial Tools.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

- add a new endpoint that delivers sizes

