### PR TITLE
Extract px to rem logic into module

### DIFF
--- a/src/core/foundations/src/space.ts
+++ b/src/core/foundations/src/space.ts
@@ -1,6 +1,5 @@
 import { space as _space } from "./theme"
-
-const rootPixelFontSize = 16
+import { pxToRem } from "./utils"
 
 const space = {
 	1: _space[1],
@@ -14,18 +13,18 @@ const space = {
 	24: _space[9],
 }
 
-const pxToRem = (px: number): string => `${px / rootPixelFontSize}rem`
-
+/* TODO: this should be exposed as a number instead of a string,
+   so consumers can perform calculations on it */
 const remSpace: { [K in keyof (typeof space)]: string } = {
-	1: pxToRem(space[1]),
-	2: pxToRem(space[2]),
-	3: pxToRem(space[3]),
-	4: pxToRem(space[4]),
-	5: pxToRem(space[5]),
-	6: pxToRem(space[6]),
-	9: pxToRem(space[9]),
-	12: pxToRem(space[12]),
-	24: pxToRem(space[24]),
+	1: `${pxToRem(space[1])}rem`,
+	2: `${pxToRem(space[2])}rem`,
+	3: `${pxToRem(space[3])}rem`,
+	4: `${pxToRem(space[4])}rem`,
+	5: `${pxToRem(space[5])}rem`,
+	6: `${pxToRem(space[6])}rem`,
+	9: `${pxToRem(space[9])}rem`,
+	12: `${pxToRem(space[12])}rem`,
+	24: `${pxToRem(space[24])}rem`,
 }
 
 export { space, remSpace }

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -1,4 +1,5 @@
 import { fontSizes, fonts, lineHeights, fontWeights } from "../theme"
+import { pxToRem } from "../utils"
 import {
 	Category,
 	LineHeight,
@@ -51,7 +52,7 @@ const fontSizeMapping: {
 	textSans: textSansSizes,
 }
 
-const remFontSizes = fontSizes.map(fontSize => fontSize / 16)
+const remFontSizes = fontSizes.map(fontSize => pxToRem(fontSize))
 
 const remTitlepieceSizes: TitlepieceSizes = {
 	small: remFontSizes[7], //42px

--- a/src/core/foundations/src/typography/fs.ts
+++ b/src/core/foundations/src/typography/fs.ts
@@ -1,6 +1,7 @@
 import {
 	fontMapping,
 	fontSizeMapping,
+	remFontSizeMapping,
 	lineHeightMapping,
 	fontWeightMapping,
 	availableFonts,
@@ -30,10 +31,12 @@ export const fs: Fs = category => (
 	const fontSizeValue =
 		unit === "px"
 			? fontSizeMapping[category][level]
-			: `${fontSizeMapping[category][level] / 16}rem`
+			: `${remFontSizeMapping[category][level]}rem`
 	const lineHeightValue =
 		unit === "px"
-			? `${lineHeightMapping[lineHeight] *
+			? // line-height is defined as a unitless value, so we multiply
+			  // by the element's font-size in px to get the px value
+			  `${lineHeightMapping[lineHeight] *
 					fontSizeMapping[category][level]}px`
 			: lineHeightMapping[lineHeight]
 	// TODO: consider logging an error in development if a requested

--- a/src/core/foundations/src/utils/index.ts
+++ b/src/core/foundations/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { FocusStyleManager } from "./focus-style-manager"
+export { pxToRem, rootPixelFontSize } from "./px-to-rem"

--- a/src/core/foundations/src/utils/px-to-rem.test.ts
+++ b/src/core/foundations/src/utils/px-to-rem.test.ts
@@ -1,0 +1,7 @@
+import { pxToRem, rootPixelFontSize } from "./px-to-rem"
+
+it("should calculate a rem equivalent of a pixel value", () => {
+	const value = 17
+	const result = pxToRem(value)
+	expect(result).toBe(value / rootPixelFontSize)
+})

--- a/src/core/foundations/src/utils/px-to-rem.ts
+++ b/src/core/foundations/src/utils/px-to-rem.ts
@@ -1,0 +1,2 @@
+export const rootPixelFontSize = 16
+export const pxToRem = (px: number): number => px / rootPixelFontSize


### PR DESCRIPTION
## What is the purpose of this change?

We are calculating rem values from px values using a very rudimentary piece of logic. We should centralise this logic so that we can make it more robust later if necessary.

## What does this change?

- create a new `pxToRem` module that is consumed by typography and space
- add test for `pxToRem`
