### PR TITLE
Make Focus Manager Node.js-friendly

### DIFF
--- a/src/core/foundations/src/utils/focus-style-manager.ts
+++ b/src/core/foundations/src/utils/focus-style-manager.ts
@@ -57,13 +57,20 @@ export class InteractionModeEngine {
 
 const FOCUS_DISABLED = "src-focus-disabled"
 
-const focusEngine = new InteractionModeEngine(
-	document.documentElement,
-	FOCUS_DISABLED,
-)
+let _focusEngine: InteractionModeEngine
+
+const focusEngine = (): InteractionModeEngine => {
+	if (!_focusEngine)
+		_focusEngine = new InteractionModeEngine(
+			document.documentElement,
+			FOCUS_DISABLED,
+		)
+
+	return _focusEngine
+}
 
 export const FocusStyleManager = {
-	alwaysShowFocus: () => focusEngine.stop(),
-	isActive: () => focusEngine.isActive(),
-	onlyShowFocusOnTabs: () => focusEngine.start(),
+	alwaysShowFocus: () => focusEngine().stop(),
+	isActive: () => focusEngine().isActive(),
+	onlyShowFocusOnTabs: () => focusEngine().start(),
 }


### PR DESCRIPTION
## What is the purpose of this change?

`@guardian/src-foundations/utils` is currently broken on the server because the Focus Manager module has a side effect on import which always assumes a `document` exists

## What does this change?

- remove browser environment-assuming side effect from Focus Manager
