### PR TITLE
Add icon and SVGs readmes

### DIFF
--- a/src/core/icons/README.md
+++ b/src/core/icons/README.md
@@ -1,0 +1,19 @@
+# Icons
+
+📣 For more context and visual guides relating to icon usage, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/74a822-overview)
+
+## Install
+
+```sh
+$ yarn add @guardian/src-icons
+```
+
+## Use
+
+Our icon SVGs are exported as React components.
+
+```tsx
+import { SvgCheckmark } from "@guardian/src-icons"
+
+React.render(<SvgCheckmark />, rootElement)
+```

--- a/src/core/svgs/README.md
+++ b/src/core/svgs/README.md
@@ -1,0 +1,5 @@
+# SVGs
+
+**:warning: Deprecation warning: This package has been replaced by [`@guardian/src-icons`](https://github.com/guardian/source/tree/master/src/core/icons)**
+
+📣 For more context and visual guides relating to icon usage, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/74a822-overview)


### PR DESCRIPTION
## What is the purpose of this change?

There is currently no explicit documentation for SVGs or Icons packages

## What does this change?

- add readme for icons
- add readme for svgs
