### PR TITLE
Various button label improvements

### DIFF
--- a/src/core/components/button/README.md
+++ b/src/core/components/button/README.md
@@ -85,6 +85,13 @@ An icon that appears inside the button, alongside text
 
 The side of the button on which the icon appears
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Whether to hide the text label visually. It is only appropriate to set this flag
+if an `icon` is passed. The text label will still be read out by screen readers.
+
 ## Supported themes
 
 ### Standard

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -4,8 +4,10 @@ import React, {
 	ButtonHTMLAttributes,
 	AnchorHTMLAttributes,
 } from "react"
+import { css } from "@emotion/core"
 import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
+import { visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { SvgArrowRightStraight } from "@guardian/src-svgs"
 import {
 	button,
@@ -89,6 +91,7 @@ interface ButtonProps extends Props, ButtonHTMLAttributes<HTMLButtonElement> {
 	size: Size
 	iconSide: IconSide
 	icon?: ReactElement
+	hideLabel: boolean
 	children?: ReactNode
 }
 
@@ -97,6 +100,7 @@ const Button = ({
 	size,
 	icon: iconSvg,
 	iconSide,
+	hideLabel,
 	cssOverrides,
 	children,
 	...props
@@ -114,13 +118,32 @@ const Button = ({
 				sizes[size],
 				priorities[priority](theme.button && theme),
 				iconSvg ? iconSizes[size] : "",
-				iconSvg && children ? iconSides[iconSide] : "",
-				!children ? iconOnlySizes[size] : "",
+				/*
+				TODO: We should be able to assume that children
+				will always be passed to the Button component.
+				A future breaking change might be to remove the
+				logic that checks for the (non-)existence of children.
+				*/
+				iconSvg && (!hideLabel && children) ? iconSides[iconSide] : "",
+				hideLabel || !children ? iconOnlySizes[size] : "",
 				cssOverrides,
 			]}
 			{...props}
 		>
-			{buttonContents}
+			{hideLabel ? (
+				<>
+					<span
+						css={css`
+							${visuallyHidden};
+						`}
+					>
+						{children}
+					</span>
+					{buttonContents[1]}
+				</>
+			) : (
+				buttonContents
+			)}
 		</button>
 	)
 }
@@ -182,6 +205,7 @@ const defaultButtonProps = {
 	priority: "primary",
 	size: "default",
 	iconSide: "left",
+	hideLabel: false,
 }
 
 const defaultLinkButtonProps = {

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -90,17 +90,15 @@ const textIconButtonsXsmall = [
 	</LinkButton>,
 ]
 const iconButtons = [
-	<Button icon={<SvgClose />} aria-label="Dismiss the subscribe banner" />,
-	<Button
-		icon={<SvgClose />}
-		size="small"
-		aria-label="Dismiss the subscribe banner"
-	/>,
-	<Button
-		icon={<SvgClose />}
-		size="xsmall"
-		aria-label="Dismiss the subscribe banner"
-	/>,
+	<Button icon={<SvgClose />} hideLabel={true}>
+		Dismiss the subscribe banner
+	</Button>,
+	<Button size="small" icon={<SvgClose />} hideLabel={true}>
+		Dismiss the subscribe banner
+	</Button>,
+	<Button size="xsmall" icon={<SvgClose />} hideLabel={true}>
+		Dismiss the subscribe banner
+	</Button>,
 ]
 const linkButtons = [
 	<LinkButton href="#">Primary</LinkButton>,

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -70,12 +70,23 @@ export const subdued = ({
 	border-radius: 0;
 `
 
+/*
+	Guardian Text Sans appears to be encoded with slightly more space above the lettering
+	than below. We add a small amount of padding to the bottom of the button to ensure
+	the button label is vertically centred visually.
+	TODO: find a more scalable solution to this (see https://css-tricks.com/how-to-tame-line-height-in-css/)
+*/
+const fontSpacingVerticalOffset = css`
+	padding-bottom: 2px;
+`
+
 export const defaultSize = css`
 	${textSans.medium({ fontWeight: "bold" })};
 	height: ${size.medium}px;
 	min-height: ${size.medium}px;
 	padding: 0 ${size.medium / 2}px;
 	border-radius: ${size.medium / 2}px;
+	${fontSpacingVerticalOffset};
 `
 
 export const smallSize = css`
@@ -84,6 +95,7 @@ export const smallSize = css`
 	min-height: ${size.small}px;
 	padding: 0 ${size.small / 2}px;
 	border-radius: ${size.small / 2}px;
+	${fontSpacingVerticalOffset};
 `
 
 export const xsmallSize = css`
@@ -92,6 +104,7 @@ export const xsmallSize = css`
 	min-height: ${size.xsmall}px;
 	padding: 0 ${size.xsmall / 2}px;
 	border-radius: ${size.xsmall / 2}px;
+	${fontSpacingVerticalOffset};
 `
 
 export const iconDefault = css`

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -14,6 +14,7 @@ export const button = css`
 	cursor: pointer;
 	transition: ${transitions.medium};
 	text-decoration: none;
+	white-space: nowrap;
 
 	&:focus {
 		${focusHalo};


### PR DESCRIPTION
## What is the purpose of this change?

1. Button label currently wraps if the available space is too narrow. We should never allow button labels to wrap (fixes #359)
2. Button label does not sit vertically centre due to spacing encoded in the font
3. The docs currently advocate not passing any children when using icon-only variant. This should be discouraged. Children should always be passed for accessibility reasons. We should provide a way to hide the text label for icon-only buttons.

## What does this change?

- Use `white-space: nowrap` to prevent button labels from wrapping
- Add `padding-bottom: 2px` to offset font white space and ensure button label sits vertically centred, visually
- Add `hideLabel` prop that visually hides the text label. The text label will still be read by screen readers.

## Screenshots

**Label wrapping - BEFORE**

![Screenshot 2020-06-01 at 16 23 09](https://user-images.githubusercontent.com/5931528/83424379-39940000-a424-11ea-9992-b571e43bdcd8.png)

**Label wrapping - AFTER**

![Screenshot 2020-06-01 at 16 23 15](https://user-images.githubusercontent.com/5931528/83424389-3d278700-a424-11ea-9a82-01e348cda469.png)

**Vertical centring adjustment**

![2020-06-01 15 13 22](https://user-images.githubusercontent.com/5931528/83424155-f0dc4700-a423-11ea-84c6-53d926c3f810.gif)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

