### PR TITLE
Use src-icons instead of src-svgs

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -17,7 +17,7 @@ import {
 import { css } from "@emotion/core"
 import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
-import { SvgChevronDownSingle } from "@guardian/src-svgs"
+import { SvgChevronDownSingle } from "@guardian/src-icons"
 export { accordionDefault } from "@guardian/src-foundations/themes"
 
 const visuallyHidden = css`

--- a/src/core/components/button/README.md
+++ b/src/core/components/button/README.md
@@ -1,18 +1,18 @@
 # Buttons
 
-📣 For more context and visual guides relating to button usage, visit the [Source Design System website](https://zeroheight.com/2a1e5182b/p/435225)
+📣 For more context and visual guides relating to button usage, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/435225-button/)
 
 ## Install
 
 ```sh
-$ yarn add @guardian/src-button @guardian/src-foundations
+$ yarn add @guardian/src-button
 ```
 
 ## Use
 
 ```js
 import { LinkButton, Button } from "@guardian/src-button"
-import { SvgCheckmark, SvgArrowRightStraight } from "@guardian/src-svgs"
+import { SvgCheckmark, SvgArrowRightStraight } from "@guardian/src-icons"
 
 const Form = () => (
     <form>

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -8,7 +8,7 @@ import { css } from "@emotion/core"
 import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
 import { visuallyHidden } from "@guardian/src-foundations/accessibility"
-import { SvgArrowRightStraight } from "@guardian/src-svgs"
+import { SvgArrowRightStraight } from "@guardian/src-icons"
 import {
 	button,
 	primary,

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@guardian/src-helpers": "^1.2.0-rc.0",
-		"@guardian/src-svgs": "^1.2.0-rc.0"
+		"@guardian/src-icons": "^1.2.0-rc.0"
 	},
 	"files": [
 		"dist/*.js",

--- a/src/core/components/button/stories.tsx
+++ b/src/core/components/button/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
-import { SvgCheckmark, SvgClose } from "@guardian/src-svgs"
+import { SvgCheckmark, SvgClose } from "@guardian/src-icons"
 import { space } from "@guardian/src-foundations"
 import { background } from "@guardian/src-foundations/palette"
 import {

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -26,7 +26,7 @@
 		"@babel/preset-typescript": "^7.9.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^1.2.0-rc.0",
-		"@guardian/src-svgs": "^1.2.0-rc.0",
+		"@guardian/src-icons": "^1.2.0-rc.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 import { storybookBackgrounds } from "@guardian/src-helpers"
-import { SvgDirectDebit, SvgCreditCard, SvgPayPal } from "@guardian/src-svgs"
+import { SvgDirectDebit, SvgCreditCard, SvgPayPal } from "@guardian/src-icons"
 import { ChoiceCardGroup, ChoiceCard, choiceCardDefault } from "./index"
 import { ThemeProvider } from "emotion-theming"
 

--- a/src/core/components/inline-error/index.tsx
+++ b/src/core/components/inline-error/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react"
-import { SvgAlert } from "@guardian/src-svgs"
+import { SvgAlert } from "@guardian/src-icons"
 import { Props } from "@guardian/src-helpers"
 import { inlineError } from "./styles"
 export {

--- a/src/core/components/inline-error/package.json
+++ b/src/core/components/inline-error/package.json
@@ -43,6 +43,6 @@
 	},
 	"dependencies": {
 		"@guardian/src-helpers": "^1.2.0-rc.0",
-		"@guardian/src-svgs": "^1.2.0-rc.0"
+		"@guardian/src-icons": "^1.2.0-rc.0"
 	}
 }

--- a/src/core/components/link/README.md
+++ b/src/core/components/link/README.md
@@ -1,18 +1,18 @@
 # Link
 
-📣 For more context and visual guides relating to link usage, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/43c26b)
+📣 For more context and visual guides relating to link usage, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/43c26b-link/)
 
 ## Install
 
 ```sh
-$ yarn add @guardian/src-link @guardian/src-foundations
+$ yarn add @guardian/src-link
 ```
 
 ## Use
 
 ```js
 import { Link } from "@guardian/src-link"
-import { SvgArrowRightStraight } from "@guardian/src-svgs"
+import { SvgArrowRightStraight } from "@guardian/src-icons"
 
 const Navigation = () => (
     <Link

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -26,7 +26,7 @@
 		"@babel/preset-typescript": "^7.9.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^1.2.0-rc.0",
-		"@guardian/src-svgs": "^1.2.0-rc.0",
+		"@guardian/src-icons": "^1.2.0-rc.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -6,7 +6,7 @@ import {
 	SvgIndent,
 	SvgExternal,
 	SvgChevronLeftSingle,
-} from "@guardian/src-svgs"
+} from "@guardian/src-icons"
 import { space } from "@guardian/src-foundations"
 import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
 import { ThemeProvider } from "emotion-theming"

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -43,7 +43,6 @@
 	},
 	"dependencies": {
 		"@guardian/src-helpers": "^1.2.0-rc.0",
-		"@guardian/src-inline-error": "^1.1.0-rc.0",
-		"@guardian/src-svgs": "^1.2.0-rc.0"
+		"@guardian/src-inline-error": "^1.1.0-rc.0"
 	}
 }


### PR DESCRIPTION
## What is the purpose of this change?

Following on from #367, we should move from consuming the now-deprecated `src-svgs` over to `src-icons`

## What does this change?

- use `src-icons` as dependencies and devDependencies throughout the project
