### PR TITLE
Add user feedback components

### DIFF
--- a/src/core/components/user-feedback/.babelrc.js
+++ b/src/core/components/user-feedback/.babelrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+	presets: [
+		"@babel/preset-env",
+		"@babel/preset-react",
+		"@babel/preset-typescript",
+		"@emotion/babel-preset-css-prop",
+	],
+}

--- a/src/core/components/user-feedback/README.md
+++ b/src/core/components/user-feedback/README.md
@@ -1,0 +1,32 @@
+# User feedback
+
+📣 For more context and visual guides relating checkbox usage on the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/108ed3--user-feedback/b/3803b4)
+
+## Install
+
+```sh
+$ yarn add @guardian/src-user-feedback
+```
+
+## Usage
+
+```tsx
+import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
+
+const Form = () => (
+    <form>
+        <label>First name</label>
+        <InlineError>Please enter your name</InlineError>
+        <input type="text">
+
+        <label>Voucher code</label>
+        <InlineSuccess>Your voucher code is valid</InlineSuccess>
+        <input type="text">
+    </form>
+)
+```
+
+## Supported themes
+
+-   `default`
+-   `brand` (`InlineError` only)

--- a/src/core/components/user-feedback/index.tsx
+++ b/src/core/components/user-feedback/index.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode } from "react"
+import { SvgAlert, SvgTickRound } from "@guardian/src-icons"
+import { Props } from "@guardian/src-helpers"
+import { inlineError, inlineSuccess } from "./styles"
+export {
+	userFeedbackDefault,
+	userFeedbackBrand,
+} from "@guardian/src-foundations/themes"
+
+interface UserFeedbackProps extends Props {
+	children: ReactNode
+}
+
+const InlineError = ({ children, cssOverrides }: UserFeedbackProps) => (
+	<span
+		css={theme => [inlineError(theme.userFeedback && theme), cssOverrides]}
+	>
+		<SvgAlert />
+		{children}
+	</span>
+)
+
+const InlineSuccess = ({ children, cssOverrides }: UserFeedbackProps) => (
+	<span
+		css={theme => [
+			inlineSuccess(theme.userFeedback && theme),
+			cssOverrides,
+		]}
+	>
+		<SvgTickRound />
+		{children}
+	</span>
+)
+
+export { InlineError, InlineSuccess }

--- a/src/core/components/user-feedback/package.json
+++ b/src/core/components/user-feedback/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@guardian/src-user-feedback",
+	"version": "1.3.0-rc.0",
+	"main": "dist/user-feedback.js",
+	"module": "dist/user-feedback.esm.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/guardian/source.git"
+	},
+	"scripts": {
+		"build": "yarn clean && rollup --config",
+		"clean": "rm -rf dist",
+		"prepublish": "yarn build",
+		"publish:public": "yarn publish --access public",
+		"verbump:major": "yarn version --major --no-git-tag-version",
+		"verbump:minor": "yarn version --minor --no-git-tag-version",
+		"verbump:preminor": "yarn version --preminor --preid rc --no-git-tag-version",
+		"verbump:premajor": "yarn version --premajor --preid rc --no-git-tag-version",
+		"verbump:patch": "yarn version --patch --no-git-tag-version",
+		"verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.10.0",
+		"@babel/preset-env": "^7.10.0",
+		"@babel/preset-react": "^7.10.0",
+		"@babel/preset-typescript": "^7.9.0",
+		"@emotion/babel-preset-css-prop": "^10.0.14",
+		"@guardian/src-foundations": "^1.3.0-rc.0",
+		"rollup": "^1.17.0",
+		"rollup-plugin-babel": "^4.3.3",
+		"rollup-plugin-commonjs": "^10.0.2",
+		"rollup-plugin-node-resolve": "^5.2.0"
+	},
+	"files": [
+		"dist/*.js",
+		"index.tsx",
+		"styles.ts"
+	],
+	"peerDependencies": {
+		"@emotion/core": "^10.0.14",
+		"@guardian/src-foundations": "^1.3.0-rc.0",
+		"react": "^16.8.6"
+	},
+	"dependencies": {
+		"@guardian/src-helpers": "^1.3.0-rc.0",
+		"@guardian/src-icons": "^1.3.0-rc.0"
+	}
+}

--- a/src/core/components/user-feedback/rollup.config.js
+++ b/src/core/components/user-feedback/rollup.config.js
@@ -1,0 +1,36 @@
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
+import commonjs from "rollup-plugin-commonjs"
+
+const extensions = [".ts", ".tsx"]
+
+module.exports = {
+	input: "index.tsx",
+	output: [
+		{
+			file: "dist/user-feedback.js",
+			format: "cjs",
+			sourceMap: true,
+			paths: {
+				"@guardian/src-foundations/themes":
+					"@guardian/src-foundations/themes/cjs",
+				"@guardian/src-foundations/typography":
+					"@guardian/src-foundations/typography/cjs",
+			},
+		},
+		{
+			file: "dist/user-feedback.esm.js",
+			format: "esm",
+			sourceMap: true,
+		},
+	],
+	external: [
+		"react",
+		"@emotion/core",
+		"@emotion/css",
+		"@guardian/src-foundations",
+		"@guardian/src-foundations/themes",
+		"@guardian/src-foundations/typography",
+	],
+	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
+}

--- a/src/core/components/user-feedback/stories.tsx
+++ b/src/core/components/user-feedback/stories.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import { ThemeProvider } from "emotion-theming"
+import {
+	UserFeedbackTheme,
+	userFeedbackDefault,
+	userFeedbackBrand,
+} from "@guardian/src-foundations/themes"
+import { ThemeName, storybookBackgrounds } from "@guardian/src-helpers"
+import { InlineError, InlineSuccess } from "./index"
+
+export default {
+	title: "UserFeedback",
+}
+
+const themes: {
+	name: ThemeName
+	theme: { userFeedback: UserFeedbackTheme }
+}[] = [
+	{
+		name: "default",
+		theme: userFeedbackDefault,
+	},
+	{ name: "brand", theme: userFeedbackBrand },
+]
+
+const [errorLight, errorBlue] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<InlineError>Please enter your name</InlineError>
+		</ThemeProvider>
+	)
+
+	story.story = {
+		name: `inline error ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
+
+	return story
+})
+
+const [successLight] = themes.map(({ name, theme }) => {
+	const story = () => (
+		<ThemeProvider theme={theme}>
+			<InlineSuccess>Your voucher code is valid</InlineSuccess>
+		</ThemeProvider>
+	)
+
+	story.story = {
+		name: `inline success ${name}`,
+		parameters: {
+			backgrounds: [
+				Object.assign(
+					{},
+					{ default: true },
+					storybookBackgrounds[name],
+				),
+			],
+		},
+	}
+
+	return story
+})
+
+export { errorLight, errorBlue, successLight }

--- a/src/core/components/user-feedback/styles.ts
+++ b/src/core/components/user-feedback/styles.ts
@@ -1,0 +1,39 @@
+import { css } from "@emotion/core"
+import { space } from "@guardian/src-foundations"
+import {
+	userFeedbackDefault,
+	UserFeedbackTheme,
+} from "@guardian/src-foundations/themes"
+import { textSans } from "@guardian/src-foundations/typography"
+import { width, height } from "@guardian/src-foundations/size"
+
+const inlineMessage = css`
+	/* we use flex purely for vertical centering */
+	display: flex;
+	align-items: center;
+	${textSans.medium()};
+	/* TODO: we shouldn't be opinionated about layout inside the component */
+	margin-bottom: ${space[1]}px;
+
+	svg {
+		fill: currentColor;
+		/* we don't want the SVG to change size depending on available space */
+		flex: none;
+		width: ${width.iconMedium}px;
+		height: ${height.iconMedium}px;
+	}
+`
+
+export const inlineError = ({
+	userFeedback,
+}: { userFeedback: UserFeedbackTheme } = userFeedbackDefault) => css`
+	${inlineMessage};
+	color: ${userFeedback.textError};
+`
+
+export const inlineSuccess = ({
+	userFeedback,
+}: { userFeedback: UserFeedbackTheme } = userFeedbackDefault) => css`
+	${inlineMessage};
+	color: ${userFeedback.textSuccess};
+`

--- a/src/core/foundations/src/themes/index.ts
+++ b/src/core/foundations/src/themes/index.ts
@@ -6,6 +6,7 @@ export * from "./inline-error"
 export * from "./link"
 export * from "./radio"
 export * from "./text-input"
+export * from "./user-feedback"
 
 import {
 	buttonLight,
@@ -30,6 +31,7 @@ import {
 } from "./link"
 import { radioLight, radioBrand, radioDefault } from "./radio"
 import { textInputLight, textInputDefault } from "./text-input"
+import { userFeedbackDefault, userFeedbackBrand } from "./user-feedback"
 
 export const defaultTheme = {
 	...buttonDefault,
@@ -39,6 +41,7 @@ export const defaultTheme = {
 	...linkDefault,
 	...radioDefault,
 	...textInputDefault,
+	...userFeedbackDefault,
 	// continue to expose legacy theme names
 	...buttonLight,
 	...checkboxLight,
@@ -54,6 +57,7 @@ export const brand = {
 	...inlineErrorBrand,
 	...linkBrand,
 	...radioBrand,
+	...userFeedbackBrand,
 }
 
 export const brandAlt = {

--- a/src/core/foundations/src/themes/user-feedback.ts
+++ b/src/core/foundations/src/themes/user-feedback.ts
@@ -1,0 +1,19 @@
+import { text, brandText } from "@guardian/src-foundations/palette"
+
+export type UserFeedbackTheme = {
+	textSuccess?: string
+	textError: string
+}
+
+export const userFeedbackDefault: { userFeedback: UserFeedbackTheme } = {
+	userFeedback: {
+		textSuccess: text.success,
+		textError: text.error,
+	},
+}
+
+export const userFeedbackBrand: { userFeedback: UserFeedbackTheme } = {
+	userFeedback: {
+		textError: brandText.error,
+	},
+}


### PR DESCRIPTION
## What is the purpose of this change?

We have added an Inline Success message component to complement the Inline Error component. Since they are closely related, they should be packaged together as a new `@guardian/src-user-feedback` package.

## What does this change?

- Add user feedback package, incorporating Inline Error component (a duplicate of the component exposed by `@guardian/src-inline-error` and the new Inline Success component
- Add user feedback theme

## Screenshots

![Screenshot 2020-06-09 at 15 11 09](https://user-images.githubusercontent.com/5931528/84158193-8058aa00-aa63-11ea-9e9a-055ac11da548.png)

![Screenshot 2020-06-09 at 15 11 15](https://user-images.githubusercontent.com/5931528/84158196-80f14080-aa63-11ea-929c-26b8f46914ab.png)

![Screenshot 2020-06-09 at 15 11 21](https://user-images.githubusercontent.com/5931528/84158197-8189d700-aa63-11ea-9652-84c7e6b4fdc4.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

Long text wraps at narrow breakpoints, but the icon is still vertically centred. It looks a bit weird and ought to be addressed.

![Screenshot 2020-06-09 at 15 37 54](https://user-images.githubusercontent.com/5931528/84161911-b26c0b00-aa67-11ea-87be-6e3b2077050a.png)
