### PR TITLE
Text Area Rows/Height support

### DIFF
--- a/src/core/components/text-area/README.md
+++ b/src/core/components/text-area/README.md
@@ -54,7 +54,7 @@ Whether error styling should apply to this text area. The string appears as an i
 
 **`string`**
 
-Specify the number of rows the component should display by default.
+Specify the number of rows the component should display by default. Defaults to 3 rows.
 
 ## Supported themes
 

--- a/src/core/components/text-area/README.md
+++ b/src/core/components/text-area/README.md
@@ -50,6 +50,12 @@ Adds the word "Optional" after the label
 
 Whether error styling should apply to this text area. The string appears as an inline error message.
 
+### `rows`
+
+**`string`**
+
+Specify the number of rows the component should display by default.
+
 ## Supported themes
 
 ### Standard

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -51,6 +51,7 @@ const TextArea = ({
 					cssOverrides,
 				]}
 				aria-required={!optional}
+				rows={rows}
 				{...props}
 			/>
 		</label>

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -32,6 +32,7 @@ const TextArea = ({
 	supporting,
 	error,
 	cssOverrides,
+	rows = 3,
 	...props
 }: TextAreaProps) => {
 	return (

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -24,7 +24,6 @@ interface TextAreaProps
 	supporting?: string
 	error?: string
 	rows?: number
-	cols?: number
 }
 
 const TextArea = ({

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -23,6 +23,8 @@ interface TextAreaProps
 	optional: boolean
 	supporting?: string
 	error?: string
+	rows?: number
+	cols?: number
 }
 
 const TextArea = ({

--- a/src/core/components/text-area/stories.tsx
+++ b/src/core/components/text-area/stories.tsx
@@ -11,6 +11,12 @@ defaultLight.story = {
 	name: `default light`,
 }
 
+const withRows = () => <TextArea label="Comments" rows={10} />
+
+withRows.story = {
+	name: `with rows`,
+}
+
 const optionalLight = () => <TextArea label="Comments" optional={true} />
 
 optionalLight.story = {
@@ -38,6 +44,7 @@ errorWithMessageLight.story = {
 
 export {
 	defaultLight,
+	withRows,
 	optionalLight,
 	supportingTextLight,
 	errorWithMessageLight,

--- a/src/core/components/text-area/stories.tsx
+++ b/src/core/components/text-area/stories.tsx
@@ -1,33 +1,50 @@
 import React from "react"
+import { css } from "@emotion/core"
+
 import { TextArea } from "./index"
+
+const wrapperStyles = css`
+	width: 400px;
+`
 
 export default {
 	title: "TextArea",
 }
 
-const defaultLight = () => <TextArea label="Comments" />
+const defaultLight = () =>
+	<div css={wrapperStyles}>
+		<TextArea label="Comments" />
+	</div>
 
 defaultLight.story = {
 	name: `default light`,
 }
 
-const withRows = () => <TextArea label="Comments" rows={10} />
+const withRows = () =>
+	<div css={wrapperStyles}>
+		<TextArea label="Comments" rows={10} />
+	</div>
 
 withRows.story = {
 	name: `with rows`,
 }
 
-const optionalLight = () => <TextArea label="Comments" optional={true} />
+const optionalLight = () =>
+	<div css={wrapperStyles}>
+		<TextArea label="Comments" optional={true} />
+	</div>
 
 optionalLight.story = {
 	name: `optional light`,
 }
 
 const supportingTextLight = () => (
-	<TextArea
-		label="Comments"
-		supporting="Please keep comments respectful and abide by the community guidelines."
-	/>
+	<div css={wrapperStyles}>
+		<TextArea
+			label="Comments"
+			supporting="Please keep comments respectful and abide by the community guidelines."
+		/>
+	</div>
 )
 
 supportingTextLight.story = {
@@ -35,7 +52,9 @@ supportingTextLight.story = {
 }
 
 const errorWithMessageLight = () => (
-	<TextArea label="Comments" error="Please tell us your views" />
+	<div css={wrapperStyles}>
+		<TextArea label="Comments" error="Please tell us your views" />
+	</div>
 )
 
 errorWithMessageLight.story = {

--- a/src/core/components/text-area/styles.ts
+++ b/src/core/components/text-area/styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core"
-import { size, space } from "@guardian/src-foundations"
+import { space } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 import { text, border, background } from "@guardian/src-foundations/palette"
@@ -11,7 +11,6 @@ export const errorInput = css`
 
 export const textArea = css`
 	box-sizing: border-box;
-	height: ${size.medium}px;
 	${textSans.medium()};
 	color: ${text.userInput};
 	background-color: ${background.input};


### PR DESCRIPTION
## What is the purpose of this change?

Remove `height` css from TextArea and explicitly support `rows` props.

## What does this change?

Allow textArea to use rows to determine height.

## Screenshots

**Before**

<img width="670" alt="Screenshot 2020-06-11 at 10 19 53" src="https://user-images.githubusercontent.com/8831403/84368161-2247d600-abcd-11ea-91cd-97091247532e.png">

**After**
<img width="670" alt="Screenshot 2020-06-11 at 10 18 39" src="https://user-images.githubusercontent.com/8831403/84368170-2542c680-abcd-11ea-8fa4-c311724d8f3d.png">


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook


