### PR TITLE
Centre align icon and text at mobile

### DIFF
--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -166,14 +166,11 @@ export const contentWrapper = css`
 	}
 
 	& svg {
-		position: absolute;
 		width: ${width.iconMedium}px;
 		max-height: ${height.iconMedium}px;
-		left: ${-width.iconMedium - space[1]}px; /* width + 4px "margin" */
 		fill: currentColor;
 
 		${from.mobileLandscape} {
-			position: static;
 			margin-bottom: -${space[1]}px;
 		}
 	}


### PR DESCRIPTION
## What is the purpose of this change?

At mobile width, currently the text label is centre-alignd and the icon floats to the left of the text.

We want the both the text + icon to be centre-aligned

## What does this change?

- centre-align icon + text

## Screenshots

**Before**

<img width="369" alt="Screenshot 2020-06-12 at 11 57 44" src="https://user-images.githubusercontent.com/5931528/84495924-f186a000-aca3-11ea-847e-eaf5d7f94142.png">

**After**

<img width="371" alt="Screenshot 2020-06-12 at 11 57 12" src="https://user-images.githubusercontent.com/5931528/84495886-e03d9380-aca3-11ea-8d11-54858157435c.png">
