### PR TITLE
Restore horizontal space between icon and text

### DIFF
--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -169,9 +169,11 @@ export const contentWrapper = css`
 		width: ${width.iconMedium}px;
 		max-height: ${height.iconMedium}px;
 		fill: currentColor;
+		margin-right: ${space[1]}px;
 
 		${from.mobileLandscape} {
 			margin-bottom: -${space[1]}px;
+			margin-right: 0;
 		}
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?

We introduced a bug in #391 which removed the horizontal space between the icon and text at mobile width. We need to restore this space

## What does this change?

- restore horizontal space at mobile breakpoint


## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

<img width="369" alt="Screenshot 2020-06-12 at 15 03 40" src="https://user-images.githubusercontent.com/5931528/84511103-f22c3000-acbd-11ea-81d9-9fb6923b7245.png">

**After**
<img width="369" alt="Screenshot 2020-06-12 at 15 03 52" src="https://user-images.githubusercontent.com/5931528/84511120-f6f0e400-acbd-11ea-9b0b-273aa0accba4.png">


