### PR TITLE
Expose all global colours

### DIFF
--- a/src/core/foundations/src/palette/index.ts
+++ b/src/core/foundations/src/palette/index.ts
@@ -1,17 +1,4 @@
-export {
-	brand,
-	brandAlt,
-	brandYellow,
-	neutral,
-	error,
-	success,
-	news,
-	opinion,
-	sport,
-	culture,
-	lifestyle,
-	labs,
-} from "./global"
+export * from "./global"
 export { background, brandBackground, brandAltBackground } from "./background"
 export { border, brandBorder, brandAltBorder } from "./border"
 export { line, brandLine, brandAltLine } from "./line"


### PR DESCRIPTION
## What is the purpose of this change?

`specialReport` and `dynamo` colours are not explicitly exported by the palette index and are therefore unavailable. @lucymonie has requested the `specialReport` colours be made available. So why not expose everything?

## What does this change?

- export all global colours from the palette index
