### PR TITLE
Support long inline messages

### DIFF
--- a/src/core/components/inline-error/stories.tsx
+++ b/src/core/components/inline-error/stories.tsx
@@ -46,4 +46,16 @@ const [defaultLight, defaultBlue] = themes.map(({ name, theme }) => {
 	return story
 })
 
-export { defaultLight, defaultBlue }
+const errorLongLightMobile = () => (
+	<InlineError>
+		Please pick a date in the future, but not a leap year
+	</InlineError>
+)
+
+errorLongLightMobile.story = {
+	name: `long inline error light mobile`,
+	parameters: {
+		viewport: { defaultViewport: "mobileMedium" },
+	},
+}
+export { defaultLight, defaultBlue, errorLongLightMobile }

--- a/src/core/components/inline-error/styles.ts
+++ b/src/core/components/inline-error/styles.ts
@@ -10,7 +10,7 @@ export const inlineError = ({
 	inlineError,
 }: { inlineError: InlineErrorTheme } = inlineErrorLight) => css`
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	${textSans.medium()};
 	color: ${inlineError.text};
 	margin-bottom: ${space[1]}px;

--- a/src/core/components/user-feedback/stories.tsx
+++ b/src/core/components/user-feedback/stories.tsx
@@ -69,4 +69,17 @@ const [successLight] = themes.map(({ name, theme }) => {
 	return story
 })
 
-export { errorLight, errorBlue, successLight }
+const errorLongLightMobile = () => (
+	<InlineError>
+		Please pick a date in the future, but not a leap year
+	</InlineError>
+)
+
+errorLongLightMobile.story = {
+	name: `long inline error light mobile`,
+	parameters: {
+		viewport: { defaultViewport: "mobileMedium" },
+	},
+}
+
+export { errorLight, errorBlue, successLight, errorLongLightMobile }

--- a/src/core/components/user-feedback/styles.ts
+++ b/src/core/components/user-feedback/styles.ts
@@ -10,7 +10,7 @@ import { width, height } from "@guardian/src-foundations/size"
 const inlineMessage = css`
 	/* we use flex purely for vertical centering */
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	${textSans.medium()};
 	/* TODO: we shouldn't be opinionated about layout inside the component */
 	margin-bottom: ${space[1]}px;


### PR DESCRIPTION
## What is the purpose of this change?

Currently long inline messages that wrap cause the icon to be vertically centered against the entire message. 

Preferably the icon should be aligned with the first line of the error message

## What does this change?

- align the icon with the first line of the message in user-feedback package
- align the icon with the first line of the message in inline-error package

## Screenshots

**Before**

![Screenshot_2020-06-09_at_15 37 54](https://user-images.githubusercontent.com/5931528/84890042-c29c6f80-b091-11ea-95be-b61e5fffc4b8.png)


**After**

![Screenshot 2020-06-17 at 11 58 00](https://user-images.githubusercontent.com/5931528/84890076-cfb95e80-b091-11ea-8416-2af4b2dd5fa7.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] The component doesn't use only colour to convey meaning

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->
