### PR TITLE
Inline message alignment

### DIFF
--- a/src/core/components/inline-error/styles.ts
+++ b/src/core/components/inline-error/styles.ts
@@ -5,19 +5,23 @@ import {
 	InlineErrorTheme,
 } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
+import { remWidth, remHeight } from "@guardian/src-foundations/size"
 
 export const inlineError = ({
 	inlineError,
 }: { inlineError: InlineErrorTheme } = inlineErrorLight) => css`
 	display: flex;
 	align-items: flex-start;
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: "regular" })};
 	color: ${inlineError.text};
 	margin-bottom: ${space[1]}px;
 
 	svg {
 		fill: currentColor;
-		width: 30px;
-		height: 30px;
+		width: ${remWidth.iconMedium}rem;
+		height: ${remHeight.iconMedium}rem;
+
+		/* a visual kick to vertically align the icon with the top row of text */
+		transform: translateY(-3px);
 	}
 `

--- a/src/core/components/user-feedback/styles.ts
+++ b/src/core/components/user-feedback/styles.ts
@@ -11,7 +11,7 @@ const inlineMessage = css`
 	/* we use flex purely for vertical centering */
 	display: flex;
 	align-items: flex-start;
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: "regular" })};
 	/* TODO: we shouldn't be opinionated about layout inside the component */
 	margin-bottom: ${space[1]}px;
 

--- a/src/core/components/user-feedback/styles.ts
+++ b/src/core/components/user-feedback/styles.ts
@@ -5,10 +5,9 @@ import {
 	UserFeedbackTheme,
 } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
-import { width, height } from "@guardian/src-foundations/size"
+import { remWidth, remHeight } from "@guardian/src-foundations/size"
 
 const inlineMessage = css`
-	/* we use flex purely for vertical centering */
 	display: flex;
 	align-items: flex-start;
 	${textSans.medium({ lineHeight: "regular" })};
@@ -19,8 +18,11 @@ const inlineMessage = css`
 		fill: currentColor;
 		/* we don't want the SVG to change size depending on available space */
 		flex: none;
-		width: ${width.iconMedium}px;
-		height: ${height.iconMedium}px;
+		width: ${remWidth.iconMedium}rem;
+		height: ${remHeight.iconMedium}rem;
+
+		/* a visual kick to vertically align the icon with the top row of text */
+		transform: translateY(-3px);
 	}
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

- line height for inline messages ought to be `regular` (135%)
- kick text down to vertically center top row with icon

## What does this change?

-  correct line height in user feedback and inline error
-  push icon up to sit vertically centre with text

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

![Screenshot 2020-06-24 at 16 10 12](https://user-images.githubusercontent.com/5931528/85582328-424bb080-b635-11ea-84f2-744429328e24.png)
![Screenshot 2020-06-24 at 16 10 21](https://user-images.githubusercontent.com/5931528/85582331-42e44700-b635-11ea-951b-c64a6c4ade5e.png)
![Screenshot 2020-06-24 at 16 10 33](https://user-images.githubusercontent.com/5931528/85582333-42e44700-b635-11ea-9f86-2237b6bcc65e.png)


**After**

![Screenshot 2020-06-24 at 16 11 07](https://user-images.githubusercontent.com/5931528/85582533-6c04d780-b635-11ea-9c8e-5371951c6ef2.png)
![Screenshot 2020-06-24 at 16 11 15](https://user-images.githubusercontent.com/5931528/85582524-6a3b1400-b635-11ea-9be7-badb9a60a666.png)
![Screenshot 2020-06-24 at 16 11 21](https://user-images.githubusercontent.com/5931528/85582517-6909e700-b635-11ea-820c-d9f5ba1945c8.png)
