### PR TITLE
Use correct line heights in component labels

### DIFF
--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -90,12 +90,12 @@ export const checkbox = ({
 export const labelText = ({
 	checkbox,
 }: { checkbox: CheckboxTheme } = checkboxDefault) => css`
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: "regular" })};
 	color: ${checkbox.textLabel};
 `
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: "regular" })};
 `
 
 export const supportingText = ({

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -32,15 +32,17 @@ export const flexContainer = css`
 export const groupLabel = ({
 	choiceCard,
 }: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
-	${textSans.medium({ fontWeight: "bold" })};
+	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 	color: ${choiceCard.textGroupLabel};
 	margin-bottom: ${space[1]}px;
+	/* override user agent defaults */
+	padding: 0;
 `
 
 export const groupLabelSupporting = ({
 	choiceCard,
 }: { choiceCard: ChoiceCardTheme } = choiceCardDefault) => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: "regular" })};
 	color: ${choiceCard.textGroupLabelSupporting};
 	margin-bottom: ${space[3]}px;
 	/* Negate the user agent spacing between legend and fieldset content */
@@ -161,7 +163,7 @@ export const contentWrapper = css`
 	}
 
 	& > * {
-		${textSans.medium({ fontWeight: "bold" })};
+		${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 		text-align: center;
 	}
 

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -86,12 +86,12 @@ export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 `
 
 export const labelText = ({ radio }: { radio: RadioTheme } = radioLight) => css`
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: "regular" })};
 	color: ${radio.textLabel};
 `
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium({ fontWeight: "bold" })};
+	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 `
 
 export const supportingText = ({

--- a/src/core/components/text-area/styles.ts
+++ b/src/core/components/text-area/styles.ts
@@ -35,7 +35,7 @@ export const widthFluid = css`
 `
 
 export const label = css`
-	${textSans.medium({ fontWeight: "bold" })};
+	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 	color: ${text.inputLabel};
 	margin-bottom: ${space[1]}px;
 `

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -15,7 +15,7 @@ export const errorInput = ({
 `
 
 export const successInput = ({
-   textInput,
+	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
 	border: 4px solid ${textInput.borderSuccess};
 	color: ${textInput.textSuccess};
@@ -65,7 +65,7 @@ export const width4 = css`
 export const text = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
-	${textSans.medium({ fontWeight: "bold" })};
+	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 	color: ${textInput.textLabel};
 	margin-bottom: ${space[1]}px;
 `
@@ -73,7 +73,7 @@ export const text = ({
 export const optionalLabel = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: "regular" })};
 	color: ${textInput.textLabelOptional};
 	font-style: italic;
 `
@@ -81,7 +81,7 @@ export const optionalLabel = ({
 export const supportingText = ({
 	textInput,
 }: { textInput: TextInputTheme } = textInputLight) => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: "regular" })};
 	color: ${textInput.textLabelSupporting};
 	margin-bottom: ${space[1]}px;
 `


### PR DESCRIPTION
## What is the purpose of this change?

Labels, supporting text and "optional" labels should use text sans with line height set to 135% (`regular`). In a lot of places, we're currently setting line height to 150% (`loose`)

## What does this change?

Use correct line height in:

-   Checkbox
-   Choice card
-   Radio
-   Text area
-   Text input
