### PR TITLE
Update icon widths in buttons

### DIFF
--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@emotion/core"
-import { size, space, transitions } from "@guardian/src-foundations"
+import { space, transitions } from "@guardian/src-foundations"
+import { size, height, width } from "@guardian/src-foundations/size"
 import { buttonDefault, ButtonTheme } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
@@ -82,28 +83,28 @@ const fontSpacingVerticalOffset = css`
 
 export const defaultSize = css`
 	${textSans.medium({ fontWeight: "bold" })};
-	height: ${size.medium}px;
-	min-height: ${size.medium}px;
-	padding: 0 ${size.medium / 2}px;
-	border-radius: ${size.medium / 2}px;
+	height: ${height.ctaMedium}px;
+	min-height: ${height.ctaMedium}px;
+	padding: 0 ${space[5]}px;
+	border-radius: ${height.ctaMedium}px;
 	${fontSpacingVerticalOffset};
 `
 
 export const smallSize = css`
 	${textSans.medium({ fontWeight: "bold" })};
-	height: ${size.small}px;
-	min-height: ${size.small}px;
-	padding: 0 ${size.small / 2}px;
-	border-radius: ${size.small / 2}px;
+	height: ${height.ctaSmall}px;
+	min-height: ${height.ctaSmall}px;
+	padding: 0 ${space[4]}px;
+	border-radius: ${height.ctaSmall}px;
 	${fontSpacingVerticalOffset};
 `
 
 export const xsmallSize = css`
 	${textSans.small({ fontWeight: "bold" })};
-	height: ${size.xsmall}px;
-	min-height: ${size.xsmall}px;
-	padding: 0 ${size.xsmall / 2}px;
-	border-radius: ${size.xsmall / 2}px;
+	height: ${height.ctaXsmall}px;
+	min-height: ${height.ctaXsmall}px;
+	padding: 0 ${space[3]}px;
+	border-radius: ${height.ctaXsmall}px;
 	${fontSpacingVerticalOffset};
 `
 
@@ -113,7 +114,7 @@ export const iconDefault = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.medium / 2}px;
+		width: ${width.iconMedium}px;
 		height: auto;
 	}
 `
@@ -124,7 +125,7 @@ export const iconSmall = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.small / 2}px;
+		width: ${width.iconSmall}px;
 		height: auto;
 	}
 `
@@ -135,7 +136,7 @@ export const iconXsmall = css`
 		display: block;
 		fill: currentColor;
 		position: relative;
-		width: ${size.xsmall / 2}px;
+		width: ${width.iconXsmall}px;
 		height: auto;
 	}
 `
@@ -159,17 +160,17 @@ const iconOnly = css`
 
 export const iconOnlyDefault = css`
 	${iconOnly};
-	width: ${size.medium}px;
+	width: ${width.ctaMedium}px;
 `
 
 export const iconOnlySmall = css`
 	${iconOnly};
-	width: ${size.small}px;
+	width: ${width.ctaSmall}px;
 `
 
 export const iconOnlyXsmall = css`
 	${iconOnly};
-	width: ${size.xsmall}px;
+	width: ${width.ctaXsmall}px;
 `
 
 export const iconNudgeAnimation = css`


### PR DESCRIPTION
## What is the purpose of this change?

We need to update the size of icons in buttons to match Figma. We can do this using our new icon-specific width and height tokens.

Generally, we ought to make better use of the size tokens we've defined:

- `width.iconMedium` / `iconSmall` / `iconXsmall`
- `height.ctaMedium` / `ctaSmall` / `ctaXsmall`
- `width.ctaMedium` / `ctaSmall` / `ctaXsmall`

Supercedes #403 

Co-author: Max Duval, @mxdvl 

## What does this change?

- Update icon sizes in buttons to match design
- BONUS: Use component-specific width and height tokens

## TODO

The spacing is still not correct but we'll fix this in a subsequent PR

## Screenshots

**Before**

![Screenshot 2020-06-26 at 11 33 47](https://user-images.githubusercontent.com/5931528/85848353-ec941700-b7a0-11ea-9058-3bdcac8b27d6.png)


**After**

![Screenshot 2020-06-26 at 11 33 12](https://user-images.githubusercontent.com/5931528/85848302-d6865680-b7a0-11ea-8e31-03f7d70e54be.png)
