### PR TITLE
Use spacer div instead of margins for btn icons

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -60,6 +60,7 @@ const iconSides: {
 	right: iconRight,
 	left: iconLeft,
 }
+
 const sizes: {
 	[key in Size]: SerializedStyles
 } = {
@@ -104,6 +105,9 @@ const Button = ({
 	const buttonContents = [children]
 
 	if (iconSvg) {
+		if (!hideLabel) {
+			buttonContents.push(<div className="src-button-space" />)
+		}
 		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
 	}
 
@@ -120,7 +124,7 @@ const Button = ({
 				A future breaking change might be to remove the
 				logic that checks for the (non-)existence of children.
 				*/
-				iconSvg && (!hideLabel && children) ? iconSides[iconSide] : "",
+				iconSvg && !hideLabel && children ? iconSides[iconSide] : "",
 				hideLabel || !children ? iconOnlySizes[size] : "",
 				cssOverrides,
 			]}
@@ -170,6 +174,9 @@ const LinkButton = ({
 	const buttonContents = [children]
 
 	if (iconSvg) {
+		if (!hideLabel) {
+			buttonContents.push(<div className="src-button-space" />)
+		}
 		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
 	}
 
@@ -182,7 +189,6 @@ const LinkButton = ({
 					sizes[size],
 					priorities[priority](theme.button && theme),
 					iconSizes[size],
-					children ? iconSides.right : "",
 					!children ? iconOnlySizes[size] : "",
 					iconNudgeAnimation,
 					cssOverrides,
@@ -207,7 +213,7 @@ const LinkButton = ({
 					A future breaking change might be to remove the
 					logic that checks for the (non-)existence of children.
 					*/
-					iconSvg && (!hideLabel && children)
+					iconSvg && !hideLabel && children
 						? iconSides[iconSide]
 						: "",
 					hideLabel || !children ? iconOnlySizes[size] : "",

--- a/src/core/components/button/styles.ts
+++ b/src/core/components/button/styles.ts
@@ -1,6 +1,6 @@
 import { css } from "@emotion/core"
 import { space, transitions } from "@guardian/src-foundations"
-import { size, height, width } from "@guardian/src-foundations/size"
+import { height, width } from "@guardian/src-foundations/size"
 import { buttonDefault, ButtonTheme } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
@@ -117,6 +117,9 @@ export const iconDefault = css`
 		width: ${width.iconMedium}px;
 		height: auto;
 	}
+	.src-button-space {
+		width: ${space[3]}px;
+	}
 `
 
 export const iconSmall = css`
@@ -127,6 +130,9 @@ export const iconSmall = css`
 		position: relative;
 		width: ${width.iconSmall}px;
 		height: auto;
+	}
+	.src-button-space {
+		width: ${space[2]}px;
 	}
 `
 
@@ -139,20 +145,29 @@ export const iconXsmall = css`
 		width: ${width.iconXsmall}px;
 		height: auto;
 	}
-`
-
-export const iconRight = css`
-	svg {
-		margin: 0 ${-size.medium / 8}px 0 ${size.medium / 4}px;
+	.src-button-space {
+		width: ${space[1]}px;
 	}
 `
+
+/* TODO: we add some negative margin to icons to account for
+ the extra space encoded into the SVG. We should consider removing
+ or significantly reducing this space
+ */
+const pullIconTowardEdge = -space[1]
 
 export const iconLeft = css`
 	flex-direction: row-reverse;
 	svg {
-		margin: 0 ${size.medium / 4}px 0 ${-size.medium / 8}px;
+		margin-left: ${pullIconTowardEdge}px;
 	}
 `
+export const iconRight = css`
+	svg {
+		margin-right: ${pullIconTowardEdge}px;
+	}
+`
+
 const iconOnly = css`
 	justify-content: center;
 	padding: 0;


### PR DESCRIPTION
## What is the purpose of this change?

We currently hard-code margins between icons and labels in buttons. This makes it difficult to adjust the spacing for the different button sizes.

Co-Author: Max Duval, @mxdvl 

## What does this change?

- Use a spacer div to spearate the icon from the label

## Screenshots

**Before**

![Screenshot 2020-06-26 at 14 52 46](https://user-images.githubusercontent.com/5931528/85864659-b82e5400-b7bc-11ea-8d50-b712f5818860.png)

**After**

![Screenshot 2020-06-26 at 15 23 30](https://user-images.githubusercontent.com/5931528/85867576-02b1cf80-b7c1-11ea-9e35-d0fdf93bc3f9.png)

