### PR TITLE
Add new success and error colours

### DIFF
--- a/src/core/components/user-feedback/stories.tsx
+++ b/src/core/components/user-feedback/stories.tsx
@@ -46,7 +46,7 @@ const [errorLight, errorBlue] = themes.map(({ name, theme }) => {
 	return story
 })
 
-const [successLight] = themes.map(({ name, theme }) => {
+const [successLight, successBlue] = themes.map(({ name, theme }) => {
 	const story = () => (
 		<ThemeProvider theme={theme}>
 			<InlineSuccess>Your voucher code is valid</InlineSuccess>
@@ -82,4 +82,10 @@ errorLongLightMobile.story = {
 	},
 }
 
-export { errorLight, errorBlue, successLight, errorLongLightMobile }
+export {
+	errorLight,
+	errorBlue,
+	successLight,
+	successBlue,
+	errorLongLightMobile,
+}

--- a/src/core/foundations/src/palette/border/brand.ts
+++ b/src/core/foundations/src/palette/border/brand.ts
@@ -2,7 +2,7 @@ import { neutral, success as _success, error as _error, brand } from "../global"
 
 export const brandBorder = {
 	primary: brand[800],
-	success: _success[400],
+	success: _success[500],
 	error: _error[500],
 	ctaTertiary: neutral[100],
 	input: brand[800],

--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -61,14 +61,15 @@ export const neutral = {
 }
 export const error = {
 	400: colors.reds[3],
-	500: colors.reds[4],
+	500: colors.reds[7],
 
 	// legacy names: please do not use
 	main: colors.reds[3],
-	bright: colors.reds[4],
+	bright: colors.reds[7],
 }
 export const success = {
 	400: colors.greens[1],
+	500: colors.greens[2],
 
 	// legacy names: please do not use
 	main: colors.greens[1],
@@ -154,13 +155,13 @@ export const lifestyle = {
 	faded: colors.pinks[6],
 }
 export const labs = {
-	200: colors.greens[2],
-	300: colors.greens[3],
-	400: colors.greens[4],
+	200: colors.greens[3],
+	300: colors.greens[4],
+	400: colors.greens[5],
 
 	// legacy names: please do not use
-	dark: colors.greens[3],
-	main: colors.greens[4],
+	dark: colors.greens[4],
+	main: colors.greens[5],
 }
 
 export const specialReport = {

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -3,7 +3,7 @@ import { neutral, success as _success, error as _error, brand } from "../global"
 export const brandText = {
 	primary: neutral[100],
 	supporting: brand[800],
-	success: _success[400],
+	success: _success[500],
 	error: _error[500],
 	ctaPrimary: brand[400],
 	ctaSecondary: neutral[100],

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -46,10 +46,11 @@ const colors = {
 		"#660505", //news-100
 		"#8B0000", //news-200
 		"#AB0613", //news-300
-		"#C70000", //news-400
+		"#C70000", //news-400, error-400
 		"#FF5943", //news-500
 		"#FFBAC8", //news-600
 		"#FFF4F2", //news-800
+		"#FF9081", //error-500
 	],
 	oranges: [
 		"#672005", //opinion-100
@@ -99,8 +100,9 @@ const colors = {
 		"#FFE500", //brandAlt-400
 	],
 	greens: [
-		"#185E36", //green-200
-		"#22874D", //green-400
+		"#185E36", //green-300
+		"#22874D", //green-400, success-400
+		"#58D08B", //green-500, success-500
 		"#4B8878", //labs-200
 		"#65A897", //labs-300
 		"#69D1CA", //labs-400

--- a/src/core/foundations/src/themes/user-feedback.ts
+++ b/src/core/foundations/src/themes/user-feedback.ts
@@ -1,7 +1,7 @@
 import { text, brandText } from "@guardian/src-foundations/palette"
 
 export type UserFeedbackTheme = {
-	textSuccess?: string
+	textSuccess: string
 	textError: string
 }
 
@@ -14,6 +14,7 @@ export const userFeedbackDefault: { userFeedback: UserFeedbackTheme } = {
 
 export const userFeedbackBrand: { userFeedback: UserFeedbackTheme } = {
 	userFeedback: {
+		textSuccess: brandText.success,
 		textError: brandText.error,
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

There is currently no "success" colour associated with the brand theme. The "error" colour for this theme is not accessible.

We have added two new colours to the Figma library to account for this. We should expose them in `src-foundations`.

## What does this change?

-   Add new success and error colours and expos tokens
-   BONUS - Add success colour to brand theme for User Feedback

## Screenshots

**Before**

![Screenshot 2020-07-06 at 14 39 42](https://user-images.githubusercontent.com/5931528/86599427-8c6a5580-bf96-11ea-9d59-3d7e14f298fd.png)

**After**

![Screenshot 2020-07-06 at 14 40 02](https://user-images.githubusercontent.com/5931528/86599504-a015bc00-bf96-11ea-91ba-05c941c90420.png)
![Screenshot 2020-07-06 at 14 40 09](https://user-images.githubusercontent.com/5931528/86599506-a0ae5280-bf96-11ea-9bd2-4af52325cdba.png)

## Checklist

### Accessibility

-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)
