### PR TITLE
Define submodules centrally and use in build config

### DIFF
--- a/scripts/foundations-submodules.js
+++ b/scripts/foundations-submodules.js
@@ -1,0 +1,27 @@
+const submodules = [
+	"accessibility",
+	"mq",
+	"palette",
+	"size",
+	"themes",
+	"typography",
+	"typography/obj",
+	"utils",
+]
+const submodulePaths = submodules.map((s) => `@guardian/src-foundations/${s}`)
+
+/*
+Build an object that maps foundations submodule paths to their cjs equivalents
+e.g.
+
+{
+	'@guardian/src-foundations/submodule1': '@guardian/src-foundations/submodule1/cjs',
+	'@guardian/src-foundations/submodule2': '@guardian/src-foundations/submodule2/cjs'
+}
+*/
+const cjsPaths = submodulePaths.reduce((acc, curr) => {
+	acc[curr] = `${curr}/cjs`
+	return acc
+}, {})
+
+export { submodules, submodulePaths, cjsPaths }

--- a/src/core/components/accordion/rollup.config.js
+++ b/src/core/components/accordion/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/accordion.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/palette":
-					"@guardian/src-foundations/palette/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/accordion.esm.js",
@@ -29,9 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/palette",
-		"@guardian/src-foundations/typography",
-		"@guardian/src-foundations/accessibility",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/button/rollup.config.js
+++ b/src/core/components/button/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,16 +14,7 @@ module.exports = {
 		{
 			file: "dist/button.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/palette":
-					"@guardian/src-foundations/palette/cjs",
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/button.esm.js",
@@ -31,10 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/palette",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/checkbox/rollup.config.js
+++ b/src/core/components/checkbox/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/checkbox.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/checkbox.esm.js",
@@ -29,9 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/choice-card/rollup.config.js
+++ b/src/core/components/choice-card/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/choice-card.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/mq":
-					"@guardian/src-foundations/mq/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/choice-card.esm.js",
@@ -29,10 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/mq",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/grid/rollup.config.js
+++ b/src/core/components/grid/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -11,10 +15,7 @@ module.exports = {
 			file: "dist/grid.js",
 			format: "cjs",
 			sourceMap: true,
-			paths: {
-				"@guardian/src-foundations/mq":
-					"@guardian/src-foundations/mq/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/grid.esm.js",
@@ -27,7 +28,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/mq",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/inline-error/rollup.config.js
+++ b/src/core/components/inline-error/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -11,12 +15,7 @@ module.exports = {
 			file: "dist/inline-error.js",
 			format: "cjs",
 			sourceMap: true,
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/inline-error.esm.js",
@@ -29,8 +28,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/link/rollup.config.js
+++ b/src/core/components/link/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/link.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/link.esm.js",
@@ -29,9 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/radio/rollup.config.js
+++ b/src/core/components/radio/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/radio.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/radio.esm.js",
@@ -29,9 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/select/rollup.config.js
+++ b/src/core/components/select/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/select.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/select.esm.js",
@@ -29,9 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/text-area/rollup.config.js
+++ b/src/core/components/text-area/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,18 +14,7 @@ module.exports = {
 		{
 			file: "dist/text-area.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-				"@guardian/src-foundations/palette":
-					"@guardian/src-foundations/palette/cjs",
-				"@guardian/src-foundations/size":
-					"@guardian/src-foundations/size/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/text-area.esm.js",
@@ -33,11 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/size",
-		"@guardian/src-foundations/palette",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/text-input/rollup.config.js
+++ b/src/core/components/text-input/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,14 +14,7 @@ module.exports = {
 		{
 			file: "dist/text-input.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-				"@guardian/src-foundations/accessibility":
-					"@guardian/src-foundations/accessibility/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/text-input.esm.js",
@@ -29,9 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/accessibility",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/components/user-feedback/rollup.config.js
+++ b/src/core/components/user-feedback/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -11,12 +15,7 @@ module.exports = {
 			file: "dist/user-feedback.js",
 			format: "cjs",
 			sourceMap: true,
-			paths: {
-				"@guardian/src-foundations/themes":
-					"@guardian/src-foundations/themes/cjs",
-				"@guardian/src-foundations/typography":
-					"@guardian/src-foundations/typography/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/user-feedback.esm.js",
@@ -29,8 +28,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/themes",
-		"@guardian/src-foundations/typography",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/core/foundations/rollup.config.js
+++ b/src/core/foundations/rollup.config.js
@@ -1,20 +1,15 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
+import {
+	submodules,
+	cjsPaths,
+	submodulePaths,
+} from "../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 const plugins = [babel({ extensions }), resolve({ extensions })]
-const folders = [
-	"accessibility",
-	"mq",
-	"palette",
-	"size",
-	"themes",
-	"typography",
-	"typography/obj",
-	"utils",
-]
 
-const esmFolders = folders.map(folder => ({
+const esmFolders = submodules.map((folder) => ({
 	input: `src/${folder}/index.ts`,
 	output: [
 		{
@@ -23,29 +18,20 @@ const esmFolders = folders.map(folder => ({
 		},
 	],
 	plugins,
-	external: [
-		"@guardian/src-foundations",
-		"@guardian/src-foundations/palette",
-	],
+	external: ["@guardian/src-foundations", ...submodulePaths],
 }))
 
-const cjsFolders = folders.map(folder => ({
+const cjsFolders = submodules.map((folder) => ({
 	input: `src/${folder}/index.ts`,
 	output: [
 		{
 			file: `${folder}/cjs/index.js`,
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/palette":
-					"@guardian/src-foundations/palette/cjs",
-			},
+			paths: cjsPaths,
 		},
 	],
 	plugins,
-	external: [
-		"@guardian/src-foundations",
-		"@guardian/src-foundations/palette",
-	],
+	external: ["@guardian/src-foundations", ...submodulePaths],
 }))
 
 module.exports = [

--- a/src/core/helpers/rollup.config.js
+++ b/src/core/helpers/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -11,10 +15,7 @@ module.exports = {
 			file: "dist/helpers.js",
 			format: "cjs",
 			sourceMap: true,
-			paths: {
-				"@guardian/src-foundations/palette":
-					"@guardian/src-foundations/palette/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/helpers.esm.js",
@@ -22,6 +23,6 @@ module.exports = {
 			sourceMap: true,
 		},
 	],
-	external: ["@guardian/src-foundations/palette"],
+	external: [...submodulePaths],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }

--- a/src/editorial/web/components/lines/rollup.config.js
+++ b/src/editorial/web/components/lines/rollup.config.js
@@ -1,6 +1,10 @@
 import babel from "rollup-plugin-babel"
 import resolve from "rollup-plugin-node-resolve"
 import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../../../scripts/foundations-submodules"
 
 const extensions = [".ts", ".tsx"]
 
@@ -10,10 +14,7 @@ module.exports = {
 		{
 			file: "dist/lines.js",
 			format: "cjs",
-			paths: {
-				"@guardian/src-foundations/palette":
-					"@guardian/src-foundations/palette/cjs",
-			},
+			paths: cjsPaths,
 		},
 		{
 			file: "dist/lines.esm.js",
@@ -25,7 +26,7 @@ module.exports = {
 		"@emotion/core",
 		"@emotion/css",
 		"@guardian/src-foundations",
-		"@guardian/src-foundations/palette",
+		...submodulePaths,
 	],
 	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
 }


### PR DESCRIPTION
## What is the purpose of this change?

We have seen errors recently in which the CJS paths for foundations submodules are not explicitly being rewritten in the CJS dist files for components. This means CJS versions of components are attempting to load ESM versions of foundations which is breaking things in CJS environments such as Node.js. 

This issue was spotted most recently by @tjmw after we started importing `@guardian/src-foundations/size` in the Text Input component, but neglected to map the ESM path to the CJS path in the Rollup config.

We should centralise the foundations submodules and CJS paths to make it less likely that new submodules are missed in the future.

## What does this change?

-   add central script to hold all foundations submodules, paths and ESM -> CJS path maps
-   use CJS paths from the script in the `paths` option of the Rollup config
- treat all foundations submodules as external

