### PR TITLE
Improve support for controlled approach in radio buttons

### DIFF
--- a/src/core/components/radio/README.md
+++ b/src/core/components/radio/README.md
@@ -1,11 +1,11 @@
 # Radios
 
-📣 For more context and visual guides relating radio usage on the [Source Design System website](https://zeroheight.com/2a1e5182b/p/2891dd)
+📣 For more context and visual guides relating radio usage on the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/2891dd-radio-button/b/46940d)
 
 ## Install
 
 ```sh
-$ yarn add @guardian/src-radio @guardian/src-foundations
+$ yarn add @guardian/src-radio
 ```
 
 ## Use
@@ -13,19 +13,30 @@ $ yarn add @guardian/src-radio @guardian/src-foundations
 ```js
 import { RadioGroup, Radio } from "@guardian/src-radio"
 
-const Form = () => (
-    <form>
-        <RadioGroup name="consent" orientation="vertical">
-            <Radio
-                value="no"
-                label="No"
-                supporting="I do not accept the terms"
-                checked={true}
-            />
-            <Radio value="yes" label="Yes" supporting="I accept the terms" />,
-        </RadioGroup>
-    </form>
-)
+const Form = () => {
+    const [selected, setSelected] = (useState < string) | (null > null)
+
+    return (
+        <form>
+            <RadioGroup name="consent" orientation="vertical">
+                <Radio
+                    value="no"
+                    label="No"
+                    supporting="I do not accept the terms"
+                    checked={selected === "no"}
+                    onChange={setSelected("no")}
+                />
+                <Radio
+                    value="yes"
+                    label="Yes"
+                    supporting="I accept the terms"
+                    checked={selected === "yes"}
+                    onChange={setSelected("yes")}
+                />,
+            </RadioGroup>
+        </form>
+    )
+}
 ```
 
 ## `RadioGroup` Props
@@ -68,7 +79,9 @@ Additional text or a component that appears below the label
 
 **`boolean`**
 
-Whether radio button is checked
+Whether radio button is checked. This is necessary when using the [controlled approach](https://reactjs.org/docs/forms.html#controlled-components) to form state management.
+
+**Note:** if you pass the `checked` prop, you **must** also pass an `onChange` handler, or the field will be rendered as read-only.
 
 ## Supported themes
 

--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -47,7 +47,7 @@ const RadioGroup = ({
 			{...props}
 		>
 			{error && <InlineError>{error}</InlineError>}
-			{React.Children.map(children, child => {
+			{React.Children.map(children, (child) => {
 				return React.cloneElement(
 					child,
 					Object.assign(error ? { error: true } : {}, {
@@ -68,7 +68,7 @@ const LabelText = ({
 }) => {
 	return (
 		<div
-			css={theme => [
+			css={(theme) => [
 				hasSupportingText ? labelTextWithSupportingText : "",
 				labelText(theme.radio && theme),
 			]}
@@ -80,7 +80,7 @@ const LabelText = ({
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return (
-		<div css={theme => supportingText(theme.radio && theme)}>
+		<div css={(theme) => supportingText(theme.radio && theme)}>
 			{children}
 		</div>
 	)
@@ -97,38 +97,42 @@ const Radio = ({
 	value,
 	supporting,
 	checked,
+	defaultChecked,
 	cssOverrides,
 	error,
 	...props
 }: RadioProps) => {
-	const setRadioState = (el: HTMLInputElement | null) => {
-		if (el && checked != null) {
-			el.checked = checked
+	const isChecked = (): boolean => {
+		if (checked != null) {
+			return checked
 		}
-	}
 
-	const RadioControl = () => (
+		return !!defaultChecked
+	}
+	const radioControl = (
 		<input
-			css={theme => [
+			css={(theme) => [
 				radio(theme.radio && theme),
 				error ? errorRadio(theme.radio && theme) : "",
 				cssOverrides,
 			]}
 			value={value}
 			aria-invalid={error}
-			ref={setRadioState}
+			aria-checked={isChecked()}
+			defaultChecked={defaultChecked != null ? defaultChecked : undefined}
+			checked={checked != null ? isChecked() : undefined}
 			{...props}
 		/>
 	)
 
-	const LabelledRadioControl = () => (
+	const labelledRadioControl = (
 		<label
-			css={theme => [
+			css={(theme) => [
 				label(theme.radio && theme),
 				supporting ? labelWithSupportingText : "",
 			]}
 		>
-			<RadioControl />
+			{radioControl}
 			{supporting ? (
 				<div>
 					<LabelText hasSupportingText={true}>
@@ -143,13 +147,7 @@ const Radio = ({
 	)
 
 	return (
-		<>
-			{labelContent || supporting ? (
-				<LabelledRadioControl />
-			) : (
-				<RadioControl />
-			)}
-		</>
+		<>{labelContent || supporting ? labelledRadioControl : radioControl}</>
 	)
 }
 
@@ -159,7 +157,6 @@ const radioGroupDefaultProps = {
 const radioDefaultProps = {
 	disabled: false,
 	type: "radio",
-	defaultChecked: false,
 	error: false,
 }
 

--- a/src/core/components/radio/stories.tsx
+++ b/src/core/components/radio/stories.tsx
@@ -2,10 +2,11 @@ export default {
 	title: "Radio",
 }
 
-export * from "./stories/vertical"
+export * from "./stories/controlled"
+export * from "./stories/error"
 export * from "./stories/horizontal"
 export * from "./stories/supporting-text"
 export * from "./stories/supporting-text-only"
-export * from "./stories/error"
 export * from "./stories/ungrouped"
 export * from "./stories/unlabelled"
+export * from "./stories/vertical"

--- a/src/core/components/radio/stories/controlled.tsx
+++ b/src/core/components/radio/stories/controlled.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react"
+import { RadioGroup, Radio } from "../index"
+
+const controlled = () => {
+	const [selected, setSelected] = useState<string | null>(null)
+
+	return (
+		<RadioGroup name="colours">
+			<Radio
+				value="red"
+				label="Red"
+				checked={selected === "red"}
+				onChange={() => setSelected("red")}
+			/>
+			<Radio
+				value="green"
+				label="Green"
+				checked={selected === "green"}
+				onChange={() => setSelected("green")}
+			/>
+			<Radio
+				value="blue"
+				label="Blue"
+				checked={selected === "blue"}
+				onChange={() => setSelected("blue")}
+			/>
+		</RadioGroup>
+	)
+}
+controlled.story = {
+	name: "controlled example",
+}
+
+export { controlled }

--- a/src/core/components/radio/stories/horizontal.tsx
+++ b/src/core/components/radio/stories/horizontal.tsx
@@ -4,7 +4,7 @@ import { RadioGroup, Radio } from "../index"
 const horizontal = () => (
 	<RadioGroup orientation="horizontal" name="yes-or-no">
 		<Radio value="yes" label="Yes" />
-		<Radio value="no" label="No" checked={true} />
+		<Radio value="no" label="No" defaultChecked={true} />
 	</RadioGroup>
 )
 horizontal.story = {

--- a/src/core/components/radio/stories/supporting-text-only.tsx
+++ b/src/core/components/radio/stories/supporting-text-only.tsx
@@ -15,7 +15,7 @@ const radiosWithSupportingTextOnly = [
 	<Radio
 		value="quarterly"
 		supporting="£37.50 every quarter"
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<Radio
 		value="annual"

--- a/src/core/components/radio/stories/supporting-text.tsx
+++ b/src/core/components/radio/stories/supporting-text.tsx
@@ -17,7 +17,7 @@ const radiosWithSupportingText = [
 		value="quarterly"
 		label="Quarterly"
 		supporting="£37.50 every quarter"
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<Radio
 		value="annual"

--- a/src/core/components/radio/stories/ungrouped.tsx
+++ b/src/core/components/radio/stories/ungrouped.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from "emotion-theming"
 /* eslint-disable react/jsx-key */
 const radios = [
 	<Radio value="red" label="Red" name="colours" />,
-	<Radio value="green" label="Green" name="colours" checked={true} />,
+	<Radio value="green" label="Green" name="colours" defaultChecked={true} />,
 	<Radio value="blue" label="Blue" name="colours" />,
 ]
 /* eslint-enable react/jsx-key */

--- a/src/core/components/radio/stories/unlabelled.tsx
+++ b/src/core/components/radio/stories/unlabelled.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "emotion-theming"
 
 const unlabelled = () => (
 	<ThemeProvider theme={radioDefault}>
-		<Radio value="red" checked={true} aria-label="Red" />
+		<Radio value="red" defaultChecked={true} aria-label="Red" />
 	</ThemeProvider>
 )
 

--- a/src/core/components/radio/stories/vertical.tsx
+++ b/src/core/components/radio/stories/vertical.tsx
@@ -8,7 +8,7 @@ import { RadioTheme, UserFeedbackTheme } from "@guardian/src-foundations/themes"
 /* eslint-disable react/jsx-key */
 const radios = [
 	<Radio value="red" label="Red" />,
-	<Radio value="green" label="Green" checked={true} />,
+	<Radio value="green" label="Green" defaultChecked={true} />,
 	<Radio value="blue" label="Blue" />,
 ]
 /* eslint-enable react/jsx-key */


### PR DESCRIPTION
## What is the purpose of this change?

Similar to #432 but for radio buttons

Controlled components unlock a lot of advantages but the current implementation of Source components does a poor job at supporting them. State transition animation appears to be broken. There's also ambiguity about the source of truth as the checked attribute for radio buttons is set on the DOM element rather than in the React element.

We are also missing the `aria-checked` attribute.

See #360

## What does this change?


-   Fix broken animation for checkbox radio transition
-   Remove `defaultChecked` from default props
-   Make React the source of truth for all state
-   Fix stories that erroneously apply `checked` instead of `defaultChecked`
-   Add new story to demonstrate how to write controlled inputs
- document controlled approach in README
- set `aria-checked`

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

