### PR TITLE
Improve support for controlled approach in choice cards

### DIFF
--- a/src/core/components/choice-card/README.md
+++ b/src/core/components/choice-card/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```sh
-$ yarn add @guardian/src-choice-card @guardian/src-foundations
+$ yarn add @guardian/src-choice-card
 ```
 
 ## Use
@@ -13,28 +13,34 @@ $ yarn add @guardian/src-choice-card @guardian/src-foundations
 ```js
 import { ChoiceCardGroup, ChoiceCard } from "@guardian/src-choice-card"
 
-const Form = () => (
-    <form>
-        <ChoiceCardGroup
-            name="consent"
-            label="Do you accept the terms?"
-            supporting="Answer as honestly as possible"
-            multi={false}
-        >
-            <ChoiceCard
-                value="no"
-                label="No"
-                supporting="I do not accept the terms"
-                checked={true}
-            />
-            <ChoiceCard
-                value="yes"
-                label="Yes"
-                supporting="I accept the terms"
-            />,
-        </ChoiceCardGroup>
-    </form>
-)
+const Form = () => {
+    const [selected, setSelected] = useState(null)
+    return (
+        <form>
+            <ChoiceCardGroup
+                name="consent"
+                label="Do you accept the terms?"
+                supporting="Answer as honestly as possible"
+                multi={false}
+            >
+                <ChoiceCard
+                    value="no"
+                    label="No"
+                    supporting="I do not accept the terms"
+                    checked={selected === "no"}
+                    onChange={() => setSelected("no")}
+                />
+                <ChoiceCard
+                    value="yes"
+                    label="Yes"
+                    supporting="I accept the terms"
+                    checked={selected === "yes"}
+                    onChange={() => setSelected("yes")}
+                />,
+            </ChoiceCardGroup>
+        </form>
+    )
+}
 ```
 
 ## `ChoiceCardGroup` Props
@@ -94,7 +100,9 @@ An icon that appears inside the button, alongside text
 
 **`boolean`**
 
-Whether choice card is checked
+Whether choice card is checked. This is necessary when using the [controlled approach](https://reactjs.org/docs/forms.html#controlled-components) to form state management.
+
+**Note:** if you pass the `checked` prop, you **must** also pass an `onChange` handler, or the field will be rendered as read-only.
 
 ## Supported themes
 

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -1,8 +1,6 @@
 import React, {
 	ReactNode,
 	ReactElement,
-	useRef,
-	useEffect,
 	useState,
 	InputHTMLAttributes,
 } from "react"
@@ -26,7 +24,7 @@ export { choiceCardDefault } from "@guardian/src-foundations/themes"
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return (
-		<div css={theme => groupLabelSupporting(theme.textInput && theme)}>
+		<div css={(theme) => groupLabelSupporting(theme.textInput && theme)}>
 			{children}
 		</div>
 	)
@@ -53,7 +51,7 @@ const ChoiceCardGroup = ({
 	return (
 		<fieldset css={[fieldset, cssOverrides]} {...props}>
 			{label ? (
-				<legend css={theme => groupLabel(theme.choiceCard && theme)}>
+				<legend css={(theme) => groupLabel(theme.choiceCard && theme)}>
 					{label}
 				</legend>
 			) : (
@@ -62,7 +60,7 @@ const ChoiceCardGroup = ({
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
 			{typeof error === "string" && <InlineError>{error}</InlineError>}
 			<div css={flexContainer}>
-				{React.Children.map(children, child => {
+				{React.Children.map(children, (child) => {
 					return React.cloneElement(
 						child,
 						Object.assign(
@@ -103,7 +101,6 @@ const ChoiceCard = ({
 	onChange,
 	...props
 }: ChoiceCardProps) => {
-	const inputEl = useRef<HTMLInputElement>(null)
 	const isChecked = (): boolean => {
 		if (checked != null) {
 			return checked
@@ -114,16 +111,10 @@ const ChoiceCard = ({
 	// prevent the animation firing if a Choice Card has been checked by default
 	const [userChanged, setUserChanged] = useState(false)
 
-	useEffect(() => {
-		if (!userChanged && checked != null && inputEl && inputEl.current) {
-			inputEl.current.checked = checked
-		}
-	})
-
 	return (
 		<>
 			<input
-				css={theme => [
+				css={(theme) => [
 					input(theme.choiceCard && theme),
 					userChanged ? tickAnimation : "",
 					cssOverrides,
@@ -132,8 +123,11 @@ const ChoiceCard = ({
 				value={value}
 				aria-invalid={error}
 				aria-checked={isChecked()}
-				ref={inputEl}
-				onChange={event => {
+				defaultChecked={
+					defaultChecked != null ? defaultChecked : undefined
+				}
+				checked={checked != null ? isChecked() : undefined}
+				onChange={(event) => {
 					if (onChange) {
 						onChange(event)
 					}
@@ -142,7 +136,7 @@ const ChoiceCard = ({
 				{...props}
 			/>
 			<label
-				css={theme => [
+				css={(theme) => [
 					choiceCard(theme.choiceCard && theme),
 					error ? errorChoiceCard(theme.choiceCard && theme) : "",
 				]}
@@ -157,7 +151,7 @@ const ChoiceCard = ({
 					{iconSvg ? iconSvg : ""}
 					<div>{labelContent}</div>
 				</div>
-				<span css={theme => [tick(theme.checkbox && theme)]} />
+				<span css={(theme) => [tick(theme.checkbox && theme)]} />
 			</label>
 		</>
 	)
@@ -166,7 +160,6 @@ const ChoiceCard = ({
 const choiceCardDefaultProps = {
 	disabled: false,
 	type: "radio",
-	defaultChecked: false,
 	error: false,
 }
 

--- a/src/core/components/choice-card/stories.tsx
+++ b/src/core/components/choice-card/stories.tsx
@@ -4,7 +4,9 @@ export default {
 
 export * from "./stories/error"
 export * from "./stories/multi-state-supporting"
+export * from "./stories/multi-state-controlled-example"
 export * from "./stories/single-state"
+export * from "./stories/single-state-controlled-example"
 export * from "./stories/single-state-icon"
 export * from "./stories/single-state-icon-mobile"
 export * from "./stories/single-state-label"

--- a/src/core/components/choice-card/stories/multi-state-controlled-example.tsx
+++ b/src/core/components/choice-card/stories/multi-state-controlled-example.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react"
+import { css } from "@emotion/core"
+import { textSans } from "@guardian/src-foundations/typography"
+import { text } from "@guardian/src-foundations/palette"
+import { space } from "@guardian/src-foundations"
+import { ChoiceCardGroup, ChoiceCard } from "../index"
+
+const medium = css`
+	width: 30em;
+`
+
+const spaced = css`
+	margin-bottom: ${space[3]}px;
+`
+
+const message = css`
+	${textSans.medium()};
+	color: ${text.primary};
+`
+
+export const multiStateControlled = () => {
+	const [state, setState] = useState({ opt1: true, opt2: true, opt3: false })
+	const selectedCards = Object.entries(state)
+		.filter((entry) => entry[1] === true)
+		.map((entry) => entry[0])
+		.join(", ")
+	const messageText = selectedCards
+		? `${selectedCards} selected`
+		: "Nothing selected"
+
+	return (
+		<div css={medium}>
+			<div css={spaced}>
+				<ChoiceCardGroup
+					name="multi"
+					label="This is the question label"
+					supporting="Select all that apply"
+					multi={true}
+				>
+					<ChoiceCard
+						id="multi-1"
+						value="option-1"
+						label="Option 1"
+						checked={state.opt1 === true}
+						onChange={() =>
+							setState({
+								opt1: !state.opt1,
+								opt2: state.opt2,
+								opt3: state.opt3,
+							})
+						}
+					/>
+					<ChoiceCard
+						id="multi-2"
+						value="option-2"
+						label="Option 2"
+						checked={state.opt2 === true}
+						onChange={() =>
+							setState({
+								opt1: state.opt1,
+								opt2: !state.opt2,
+								opt3: state.opt3,
+							})
+						}
+					/>
+					<ChoiceCard
+						id="multi-3"
+						value="option-3"
+						label="Option 3"
+						checked={state.opt3 === true}
+						onChange={() =>
+							setState({
+								opt1: state.opt1,
+								opt2: state.opt2,
+								opt3: !state.opt3,
+							})
+						}
+					/>
+				</ChoiceCardGroup>
+			</div>
+			<span css={message}>{messageText}</span>
+		</div>
+	)
+}
+
+multiStateControlled.story = {
+	name: `multi state controlled example`,
+}

--- a/src/core/components/choice-card/stories/multi-state-supporting.tsx
+++ b/src/core/components/choice-card/stories/multi-state-supporting.tsx
@@ -9,14 +9,14 @@ const multiChoiceCards = [
 	<ChoiceCard
 		value="option-1"
 		label="Option 1"
-		checked={true}
+		defaultChecked={true}
 		id="multi-1"
 	/>,
 	<ChoiceCard
 		value="option-2"
 		label="Option 2"
 		id="multi-2"
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard value="option-3" label="Option 3" id="multi-3" />,
 ]

--- a/src/core/components/choice-card/stories/single-state-controlled-example.tsx
+++ b/src/core/components/choice-card/stories/single-state-controlled-example.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react"
+import { css } from "@emotion/core"
+import { textSans } from "@guardian/src-foundations/typography"
+import { text } from "@guardian/src-foundations/palette"
+import { space } from "@guardian/src-foundations"
+import { ChoiceCardGroup, ChoiceCard } from "../index"
+
+const medium = css`
+	width: 30em;
+`
+
+const spaced = css`
+	margin-bottom: ${space[3]}px;
+`
+
+const message = css`
+	${textSans.medium()};
+	color: ${text.primary};
+`
+
+export const singleStateControlled = () => {
+	const [selected, setSelected] = useState<string | null>("green")
+
+	return (
+		<div css={medium}>
+			<div css={spaced}>
+				<ChoiceCardGroup name="colours">
+					<ChoiceCard
+						value="red"
+						label="Red"
+						id="default-red"
+						checked={selected === "red"}
+						onChange={() => setSelected("red")}
+					/>
+					<ChoiceCard
+						value="green"
+						label="Green"
+						id="default-green"
+						checked={selected === "green"}
+						onChange={() => setSelected("green")}
+					/>
+					<ChoiceCard
+						value="blue"
+						label="Blue"
+						id="default-blue"
+						checked={selected === "blue"}
+						onChange={() => setSelected("blue")}
+					/>
+				</ChoiceCardGroup>
+			</div>
+			<span css={message}>{selected} is selected</span>
+		</div>
+	)
+}
+
+singleStateControlled.story = {
+	name: `single state controlled example`,
+}

--- a/src/core/components/choice-card/stories/single-state-icon-mobile.tsx
+++ b/src/core/components/choice-card/stories/single-state-icon-mobile.tsx
@@ -17,7 +17,7 @@ const iconChoiceCards = [
 		label="Audio"
 		id="audio"
 		icon={<SvgAudio />}
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard value="video" label="Video" id="video" icon={<SvgVideo />} />,
 ]

--- a/src/core/components/choice-card/stories/single-state-icon.tsx
+++ b/src/core/components/choice-card/stories/single-state-icon.tsx
@@ -18,7 +18,7 @@ const iconChoiceCards = [
 		label="Audio"
 		id="audio"
 		icon={<SvgAudio />}
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard value="video" label="Video" id="video" icon={<SvgVideo />} />,
 ]

--- a/src/core/components/choice-card/stories/single-state-label.tsx
+++ b/src/core/components/choice-card/stories/single-state-label.tsx
@@ -14,7 +14,7 @@ const singleChoiceCards = [
 		value="single-1"
 		label="Preselected"
 		id="single-1"
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard value="single-2" label="Deselected" id="single-2" />,
 	<ChoiceCard value="single-3" label="Deselected" id="single-3" />,

--- a/src/core/components/choice-card/stories/single-state-mobile.tsx
+++ b/src/core/components/choice-card/stories/single-state-mobile.tsx
@@ -10,7 +10,7 @@ const choiceCards = [
 		value="green"
 		label="Green"
 		id="default-green"
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard value="blue" label="Blue" id="default-blue" />,
 ]

--- a/src/core/components/choice-card/stories/single-state-payment-icon-mobile.tsx
+++ b/src/core/components/choice-card/stories/single-state-payment-icon-mobile.tsx
@@ -17,7 +17,7 @@ const paymentIconChoiceCards = [
 		label="Credit Card"
 		id="credit-card"
 		icon={<SvgCreditCard />}
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard
 		value="paypal"

--- a/src/core/components/choice-card/stories/single-state-payment-icon.tsx
+++ b/src/core/components/choice-card/stories/single-state-payment-icon.tsx
@@ -22,7 +22,7 @@ const paymentIconChoiceCards = [
 		label="Credit Card"
 		id="credit-card"
 		icon={<SvgCreditCard />}
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard
 		value="paypal"

--- a/src/core/components/choice-card/stories/single-state.tsx
+++ b/src/core/components/choice-card/stories/single-state.tsx
@@ -15,7 +15,7 @@ const choiceCards = [
 		value="green"
 		label="Green"
 		id="default-green"
-		checked={true}
+		defaultChecked={true}
 	/>,
 	<ChoiceCard value="blue" label="Blue" id="default-blue" />,
 ]


### PR DESCRIPTION
## What is the purpose of this change?

Builds on #432 

Controlled components unlock a lot of advantages but the current implementation of Source components does a poor job at supporting them. There's ambiguity about the source of truth as the checked attribute for choice cards is set on the DOM element rather than in the React element. Also `defaultChecked` is not currently passed to the underlying `<input>` element.

See #360

## What does this change?

-   Remove `defaultChecked` from default props
- Pass `defaultChecked` to underlying `<input>` element
- Make React the source of truth for all state
- Fix stories that erroneously apply `checked` instead of `defaultChecked`
- Add new stories to demonstrate how to write controlled inputs

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)

### Cross browser and device testing

-   [ ] Tested with touch screen device


### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->
