### PR TITLE
Improve support for controlled approach in text area

### DIFF
--- a/src/core/components/text-area/README.md
+++ b/src/core/components/text-area/README.md
@@ -13,15 +13,21 @@ $ yarn add @guardian/src-text-area
 ```js
 import { TextArea } from "@guardian/src-text-area"
 
-const Form = () => (
-    <form>
-        <TextArea
-            label="Add a comment"
-            supporting="Please keep comments respectful and abide by the community guidelines."
-            optional={false}
-        />
-    </form>
-)
+const Form = () => {
+    const [state, setState] = useState("")
+
+    return (
+        <form>
+            <TextArea
+                label="Add a comment"
+                supporting="Please keep comments respectful and abide by the community guidelines."
+                optional={false}
+                value={state}
+                onChange={(event) => setState(event.target.value)}
+            />
+        </form>
+    )
+}
 ```
 
 ## Props
@@ -37,6 +43,14 @@ Appears above the text area
 **`string`**
 
 Additional text that appears below the label
+
+### `value`
+
+**`string`**
+
+The contents of the text area. This is necessary when using the [controlled approach](https://reactjs.org/docs/forms.html#controlled-components) to form state management.
+
+**Note:** if you pass the `value` prop, you **must** also pass an `onChange` handler, or the field will be rendered as read-only.
 
 ### `optional`
 

--- a/src/core/components/text-area/stories.tsx
+++ b/src/core/components/text-area/stories.tsx
@@ -1,5 +1,6 @@
-import React from "react"
+import React, { useState } from "react"
 import { css } from "@emotion/core"
+import { textSans } from "@guardian/src-foundations/typography"
 
 import { TextArea } from "./index"
 
@@ -11,28 +12,31 @@ export default {
 	title: "TextArea",
 }
 
-const defaultLight = () =>
+const defaultLight = () => (
 	<div css={wrapperStyles}>
 		<TextArea label="Comments" />
 	</div>
+)
 
 defaultLight.story = {
 	name: `default light`,
 }
 
-const withRows = () =>
+const withRows = () => (
 	<div css={wrapperStyles}>
 		<TextArea label="Comments" rows={10} />
 	</div>
+)
 
 withRows.story = {
 	name: `with rows`,
 }
 
-const optionalLight = () =>
+const optionalLight = () => (
 	<div css={wrapperStyles}>
 		<TextArea label="Comments" optional={true} />
 	</div>
+)
 
 optionalLight.story = {
 	name: `optional light`,
@@ -61,10 +65,37 @@ errorWithMessageLight.story = {
 	name: `error with message light`,
 }
 
+const wordCount = css`
+	${textSans.medium()}
+`
+
+const controlled = () => {
+	const [state, setState] = useState("")
+	return (
+		<div css={wrapperStyles}>
+			<TextArea
+				label="Comments"
+				supporting="Please keep comments respectful and abide by the community guidelines."
+				value={state}
+				onChange={(event) => setState(event.target.value)}
+			/>
+			<span css={wordCount}>
+				Word count:{" "}
+				{state.length > 0 ? state.trim().split(" ").length : 0}
+			</span>
+		</div>
+	)
+}
+
+controlled.story = {
+	name: "controlled example",
+}
+
 export {
 	defaultLight,
 	withRows,
 	optionalLight,
 	supportingTextLight,
 	errorWithMessageLight,
+	controlled,
 }


### PR DESCRIPTION
## What is the purpose of this change?

Builds on #432 

We should add a story that demonstrates how to use the `<TextArea>` component in a [controlled](https://reactjs.org/docs/forms.html#controlled-components) way. We should also explain the API in the docs

See #360 

## What does this change?

- Add story demonstrating controlled approach
- Add controlled API to docs
