### PR TITLE
Add required attribute to non-optional text fields and textareas

### DIFF
--- a/src/core/components/text-area/README.md
+++ b/src/core/components/text-area/README.md
@@ -56,7 +56,7 @@ The contents of the text area. This is necessary when using the [controlled appr
 
 **`boolean`** _= "false"_
 
-Adds the word "Optional" after the label
+Adds the word "Optional" after the label. Non-optional fields are rendered with the `required` attribute.
 
 ### `error`
 

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -33,6 +33,8 @@ const TextArea = ({
 	error,
 	cssOverrides,
 	rows = 3,
+	className,
+	value,
 	...props
 }: TextAreaProps) => {
 	return (
@@ -51,7 +53,9 @@ const TextArea = ({
 					cssOverrides,
 				]}
 				aria-required={!optional}
+				required={!optional}
 				rows={rows}
+				className={`${className}${value ? " src-has-value" : ""}`}
 				{...props}
 			/>
 		</label>

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -53,6 +53,7 @@ const TextArea = ({
 					cssOverrides,
 				]}
 				aria-required={!optional}
+				aria-invalid={!!error}
 				required={!optional}
 				rows={rows}
 				className={`${className}${value ? " src-has-value" : ""}`}

--- a/src/core/components/text-area/stories.tsx
+++ b/src/core/components/text-area/stories.tsx
@@ -65,6 +65,20 @@ errorWithMessageLight.story = {
 	name: `error with message light`,
 }
 
+const withMaxLength = () => (
+	<div css={wrapperStyles}>
+		<TextArea label="Comments" maxLength={10} />
+	</div>
+)
+
+withMaxLength.story = {
+	name: "with maxlength",
+}
+
+errorWithMessageLight.story = {
+	name: `error with message light`,
+}
+
 const wordCount = css`
 	${textSans.medium()}
 `
@@ -97,5 +111,6 @@ export {
 	optionalLight,
 	supportingTextLight,
 	errorWithMessageLight,
+	withMaxLength,
 	controlled,
 }

--- a/src/core/components/text-area/styles.ts
+++ b/src/core/components/text-area/styles.ts
@@ -26,7 +26,19 @@ export const textArea = css`
 	}
 
 	&:invalid {
-		${errorInput};
+		/* reset UA styles (Firefox) */
+		box-shadow: none;
+
+		/*
+		We automatically apply error styling to fields in an invalid state,
+		but stop short of applying it to empty required fields.
+
+		Note: the following class will only be applied to a controlled
+		component: https://reactjs.org/docs/forms.html#controlled-components
+		*/
+		.src-has-value {
+			${errorInput}
+		}
 	}
 `
 

--- a/src/core/components/text-input/README.md
+++ b/src/core/components/text-input/README.md
@@ -57,7 +57,7 @@ The contents of the text input field. This is necessary when using the [controll
 
 **`boolean`** _= "false"_
 
-Adds the word "Optional" after the label
+Adds the word "Optional" after the label. Non-optional fields are rendered with the `required` attribute.
 
 ### `width`
 

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, InputHTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/css"
-import {InlineError, InlineSuccess} from "@guardian/src-user-feedback"
+import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
 import {
 	widthFluid,
 	width30,
@@ -28,7 +28,7 @@ const widths: {
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return (
-		<div css={theme => supportingText(theme.textInput && theme)}>
+		<div css={(theme) => supportingText(theme.textInput && theme)}>
 			{children}
 		</div>
 	)
@@ -55,11 +55,11 @@ const TextInput = ({
 }: TextInputProps) => {
 	return (
 		<label>
-			<div css={theme => text(theme.textInput && theme)}>
+			<div css={(theme) => text(theme.textInput && theme)}>
 				{labelText}{" "}
 				{optional ? (
 					<span
-						css={theme => optionalLabel(theme.textInput && theme)}
+						css={(theme) => optionalLabel(theme.textInput && theme)}
 					>
 						Optional
 					</span>
@@ -71,14 +71,17 @@ const TextInput = ({
 			{error && <InlineError>{error}</InlineError>}
 			{!error && success && <InlineSuccess>{success}</InlineSuccess>}
 			<input
-				css={theme => [
+				css={(theme) => [
 					width ? widths[width] : widthFluid,
 					textInput(theme.textInput && theme),
 					error ? errorInput(theme.textInput && theme) : "",
-					!error && success ? successInput(theme.textInput && theme) : "",
+					!error && success
+						? successInput(theme.textInput && theme)
+						: "",
 					cssOverrides,
 				]}
 				aria-required={!optional}
+				required={!optional}
 				{...props}
 			/>
 		</label>

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -81,6 +81,7 @@ const TextInput = ({
 					cssOverrides,
 				]}
 				aria-required={!optional}
+				aria-invalid={!!error}
 				required={!optional}
 				{...props}
 			/>

--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -17,13 +17,20 @@ const constrainedWith = css`
 	}
 `
 
-const defaultLight = () => (
-	<ThemeProvider theme={textInputLight}>
-		<div css={constrainedWith}>
-			<TextInput label="First name" />
-		</div>
-	</ThemeProvider>
-)
+const defaultLight = () => {
+	const [state, setState] = useState("")
+	return (
+		<ThemeProvider theme={textInputLight}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="First name"
+					value={state}
+					onChange={(event) => setState(event.target.value)}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
 
 defaultLight.story = {
 	name: `default light`,
@@ -41,14 +48,21 @@ optionalLight.story = {
 	name: `optional light`,
 }
 
-const supportingTextLight = () => (
-	<ThemeProvider theme={textInputLight}>
-		<div css={constrainedWith}>
-			<TextInput label="Email" supporting="alex@example.com" />
-		</div>
-	</ThemeProvider>
-)
-
+const supportingTextLight = () => {
+	const [state, setState] = useState("")
+	return (
+		<ThemeProvider theme={textInputLight}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="Email"
+					supporting="alex@example.com"
+					value={state}
+					onChange={(event) => setState(event.target.value)}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
 supportingTextLight.story = {
 	name: `supporting text light`,
 }
@@ -56,60 +70,118 @@ supportingTextLight.story = {
 const spacer = css`
 	margin-bottom: ${space[3]}px;
 `
-const widthsLight = () => (
-	<ThemeProvider theme={textInputLight}>
-		<div css={spacer}>
-			<TextInput label="First name" width={30} />
-		</div>
-		<div css={spacer}>
-			<TextInput label="Postcode" width={10} />
-		</div>
-		<div css={spacer}>
-			<TextInput label="Year of birth" width={4} />
-		</div>
-	</ThemeProvider>
-)
+const widthsLight = () => {
+	const [state, setState] = useState({ wide: "", medium: "", short: "" })
+	return (
+		<ThemeProvider theme={textInputLight}>
+			<div css={spacer}>
+				<TextInput
+					label="First name"
+					width={30}
+					value={state.wide}
+					onChange={(event) =>
+						setState({
+							wide: event.target.value,
+							medium: state.medium,
+							short: state.short,
+						})
+					}
+				/>
+			</div>
+			<div css={spacer}>
+				<TextInput
+					label="Postcode"
+					width={10}
+					value={state.medium}
+					onChange={(event) =>
+						setState({
+							wide: state.wide,
+							medium: event.target.value,
+							short: state.short,
+						})
+					}
+				/>
+			</div>
+			<div css={spacer}>
+				<TextInput
+					label="Year of birth"
+					width={4}
+					value={state.short}
+					onChange={(event) =>
+						setState({
+							wide: state.wide,
+							medium: state.medium,
+							short: event.target.value,
+						})
+					}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
 
 widthsLight.story = {
 	name: `widths light`,
 }
 
-const errorWithMessageLight = () => (
-	<ThemeProvider theme={textInputLight}>
-		<div css={constrainedWith}>
-			<TextInput label="First name" error="Enter your first name below" />
-		</div>
-	</ThemeProvider>
-)
+const errorWithMessageLight = () => {
+	const [state, setState] = useState("")
+	return (
+		<ThemeProvider theme={textInputLight}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="First name"
+					error="Enter your first name below"
+					value={state}
+					onChange={(event) => setState(event.target.value)}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
 
 errorWithMessageLight.story = {
 	name: `error with message light`,
 }
 
-const successWithMessageLight = () => (
-	<ThemeProvider theme={textInputLight}>
-		<div css={constrainedWith}>
-			<TextInput label="Input Code" success="This code is valid" />
-		</div>
-	</ThemeProvider>
-)
+const successWithMessageLight = () => {
+	const [state, setState] = useState("")
+	return (
+		<ThemeProvider theme={textInputLight}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="Input Code"
+					success="This code is valid"
+					value={state}
+					onChange={(event) => setState(event.target.value)}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
 
 successWithMessageLight.story = {
 	name: `success with message ${name}`,
 }
 
-const constraintLight = () => (
-	<ThemeProvider theme={textInputLight}>
-		<div css={constrainedWith}>
-			<TextInput
-				label="Phone number"
-				pattern="[0-9]{1,11}"
-				title="11 digit phone number"
-				type="tel"
-			/>
-		</div>
-	</ThemeProvider>
-)
+const constraintLight = () => {
+	const [state, setState] = useState("")
+
+	return (
+		<ThemeProvider theme={textInputLight}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="Phone number"
+					pattern="[0-9]{1,11}"
+					title="11 digit phone number"
+					type="tel"
+					value={state}
+					onChange={(event) => setState(event.target.value)}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
 
 constraintLight.story = {
 	name: `with constraint light`,

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -41,7 +41,19 @@ export const textInput = ({
 	}
 
 	&:invalid {
-		${errorInput({ textInput })};
+		/* reset UA styles (Firefox) */
+		box-shadow: none;
+
+		/*
+		We automatically apply error styling to fields in an invalid state,
+		but stop short of applying it to empty required fields.
+
+		Note: the following class will only be applied to a controlled
+		component: https://reactjs.org/docs/forms.html#controlled-components
+		*/
+		&:not([value=""]) {
+			${errorInput({ textInput })};
+		}
 	}
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

The `required` attribute is currently missing from non-optional text input fields and texareas. `aria-required` is a poor substitute because it doesn't prevent form submission when JavaScript is not available.

If we add the `required` attribute, we should ensure that empty required fields do not automatically have error styling applied to them on page load.

The `aria-invalid` attribute is also missing from these components if an error message is passed.

## What does this change?

-  Add `required` attribute to non-optional fields
-  Do not apply error styling to empty required fields
- Make all non-optional text input components in stories controlled
- BONUS: add `aria-invalid` attribute to text input fields and texareas

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

In a no-JS environment, if a required text input field or textarea has no value, form submission will be prevented. However the missing fields will be styled as invalid. 