### PR TITLE
Remove legacy icon name

### DIFF
--- a/src/core/components/button/stories/icon-only-buttons.tsx
+++ b/src/core/components/button/stories/icon-only-buttons.tsx
@@ -1,18 +1,18 @@
 import React from "react"
 import { css } from "@emotion/core"
-import { SvgClose } from "@guardian/src-icons"
+import { SvgCross } from "@guardian/src-icons"
 import { space } from "@guardian/src-foundations"
 import { Button } from "../index"
 
 /* eslint-disable react/jsx-key */
 const iconButtons = [
-	<Button icon={<SvgClose />} hideLabel={true}>
+	<Button icon={<SvgCross />} hideLabel={true}>
 		Dismiss the subscribe banner
 	</Button>,
-	<Button size="small" icon={<SvgClose />} hideLabel={true}>
+	<Button size="small" icon={<SvgCross />} hideLabel={true}>
 		Dismiss the subscribe banner
 	</Button>,
-	<Button size="xsmall" icon={<SvgClose />} hideLabel={true}>
+	<Button size="xsmall" icon={<SvgCross />} hideLabel={true}>
 		Dismiss the subscribe banner
 	</Button>,
 ]

--- a/src/core/components/button/stories/icon-only-link-buttons.tsx
+++ b/src/core/components/button/stories/icon-only-link-buttons.tsx
@@ -1,18 +1,18 @@
 import React from "react"
 import { css } from "@emotion/core"
-import { SvgClose } from "@guardian/src-icons"
+import { SvgCross } from "@guardian/src-icons"
 import { space } from "@guardian/src-foundations"
 import { LinkButton } from "../index"
 
 /* eslint-disable react/jsx-key */
 const iconLinkButtons = [
-	<LinkButton href="#" icon={<SvgClose />} hideLabel={true}>
+	<LinkButton href="#" icon={<SvgCross />} hideLabel={true}>
 		Dismiss the subscribe banner
 	</LinkButton>,
-	<LinkButton href="#" size="small" icon={<SvgClose />} hideLabel={true}>
+	<LinkButton href="#" size="small" icon={<SvgCross />} hideLabel={true}>
 		Dismiss the subscribe banner
 	</LinkButton>,
-	<LinkButton href="#" size="xsmall" icon={<SvgClose />} hideLabel={true}>
+	<LinkButton href="#" size="xsmall" icon={<SvgCross />} hideLabel={true}>
 		Dismiss the subscribe banner
 	</LinkButton>,
 ]

--- a/src/core/icons/cross.tsx
+++ b/src/core/icons/cross.tsx
@@ -9,6 +9,3 @@ export const SvgCross = () => (
 		/>
 	</svg>
 )
-
-// TODO: Remove legacy name
-export const SvgClose = SvgCross

--- a/src/core/svgs/cross.tsx
+++ b/src/core/svgs/cross.tsx
@@ -9,6 +9,3 @@ export const SvgCross = () => (
 		/>
 	</svg>
 )
-
-// TODO: Remove legacy name
-export const SvgClose = SvgCross


### PR DESCRIPTION
## What is the purpose of this change?

Icons now take more literal names. We should remove references to legacy non-literal names to declutter the API.

## What does this change?


-   Remove reference to legacy name `SvgClose`
-   Migrate button stories to use new name, `SvgCross`
