### PR TITLE
Remove deprecated theme names

### DIFF
--- a/src/core/components/inline-error/index.tsx
+++ b/src/core/components/inline-error/index.tsx
@@ -3,7 +3,7 @@ import { SvgAlert } from "@guardian/src-icons"
 import { Props } from "@guardian/src-helpers"
 import { inlineError } from "./styles"
 export {
-	inlineErrorLight,
+	inlineErrorDefault,
 	inlineErrorBrand,
 } from "@guardian/src-foundations/themes"
 
@@ -13,7 +13,7 @@ interface InlineErrorProps extends Props {
 
 const InlineError = ({ children, cssOverrides }: InlineErrorProps) => (
 	<span
-		css={theme => [inlineError(theme.inlineError && theme), cssOverrides]}
+		css={(theme) => [inlineError(theme.inlineError && theme), cssOverrides]}
 	>
 		<SvgAlert />
 		{children}

--- a/src/core/components/inline-error/styles.ts
+++ b/src/core/components/inline-error/styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/core"
 import { space } from "@guardian/src-foundations"
 import {
-	inlineErrorLight,
+	inlineErrorDefault,
 	InlineErrorTheme,
 } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
@@ -9,7 +9,7 @@ import { remWidth, remHeight } from "@guardian/src-foundations/size"
 
 export const inlineError = ({
 	inlineError,
-}: { inlineError: InlineErrorTheme } = inlineErrorLight) => css`
+}: { inlineError: InlineErrorTheme } = inlineErrorDefault) => css`
 	display: flex;
 	align-items: flex-start;
 	${textSans.medium({ lineHeight: "regular" })};

--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -13,9 +13,9 @@ import {
 import { Props } from "@guardian/src-helpers"
 
 export {
-	linkLight,
+	linkDefault,
 	linkBrand,
-	linkBrandYellow,
+	linkBrandAlt,
 } from "@guardian/src-foundations/themes"
 
 export type Priority = "primary" | "secondary"
@@ -71,7 +71,7 @@ const Link = ({
 	}
 	return (
 		<a
-			css={theme => [
+			css={(theme) => [
 				link,
 				priorities[priority](theme.link && theme),
 				isSubdued ? subdued : "",

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -8,7 +8,7 @@ import {
 	SvgChevronLeftSingle,
 } from "@guardian/src-icons"
 import { space } from "@guardian/src-foundations"
-import { Link, linkLight, linkBrandYellow, linkBrand } from "./index"
+import { Link, linkDefault, linkBrandAlt, linkBrand } from "./index"
 import { ThemeProvider } from "emotion-theming"
 
 /* eslint-disable react/jsx-key */
@@ -44,7 +44,7 @@ export default {
 }
 
 export const priorityLight = () => (
-	<ThemeProvider theme={linkLight}>
+	<ThemeProvider theme={linkDefault}>
 		<div css={flexStart}>
 			{priorityLinks.map((button, index) => (
 				<div key={index}>{button}</div>
@@ -69,7 +69,7 @@ priorityBlue.story = {
 }
 
 export const priorityYellow = () => (
-	<ThemeProvider theme={linkBrandYellow}>
+	<ThemeProvider theme={linkBrandAlt}>
 		<Link href="#">Primary</Link>
 	</ThemeProvider>
 )
@@ -87,7 +87,7 @@ const spacer = css`
 `
 
 export const subduedLight = () => (
-	<ThemeProvider theme={linkLight}>
+	<ThemeProvider theme={linkDefault}>
 		<div css={flexStart}>
 			{subduedLinks.map((button, index) => (
 				<div key={index}>{button}</div>

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -1,6 +1,6 @@
 import { css } from "@emotion/core"
 import { size } from "@guardian/src-foundations"
-import { linkLight, LinkTheme } from "@guardian/src-foundations/themes"
+import { linkDefault, LinkTheme } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 
@@ -17,7 +17,7 @@ export const link = css`
 	}
 `
 
-export const primary = ({ link }: { link: LinkTheme } = linkLight) => css`
+export const primary = ({ link }: { link: LinkTheme } = linkDefault) => css`
 	color: ${link.textPrimary};
 
 	&:hover {
@@ -25,7 +25,7 @@ export const primary = ({ link }: { link: LinkTheme } = linkLight) => css`
 	}
 `
 
-export const secondary = ({ link }: { link: LinkTheme } = linkLight) => css`
+export const secondary = ({ link }: { link: LinkTheme } = linkDefault) => css`
 	color: ${link.textSecondary};
 
 	&:hover {

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -2,7 +2,7 @@ import { css } from "@emotion/core"
 import { space, size, transitions } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
-import { RadioTheme, radioLight } from "@guardian/src-foundations/themes"
+import { RadioTheme, radioDefault } from "@guardian/src-foundations/themes"
 
 export const fieldset = css`
 	display: flex;
@@ -10,7 +10,7 @@ export const fieldset = css`
 	border: 0;
 `
 
-export const label = ({ radio }: { radio: RadioTheme } = radioLight) => css`
+export const label = ({ radio }: { radio: RadioTheme } = radioDefault) => css`
 	cursor: pointer;
 	display: flex;
 	align-items: center;
@@ -28,7 +28,7 @@ export const labelWithSupportingText = css`
 	margin-bottom: ${space[3]}px;
 `
 
-export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
+export const radio = ({ radio }: { radio: RadioTheme } = radioDefault) => css`
 	flex: 0 0 auto;
 	cursor: pointer;
 	box-sizing: border-box;
@@ -85,7 +85,9 @@ export const radio = ({ radio }: { radio: RadioTheme } = radioLight) => css`
 	}
 `
 
-export const labelText = ({ radio }: { radio: RadioTheme } = radioLight) => css`
+export const labelText = ({
+	radio,
+}: { radio: RadioTheme } = radioDefault) => css`
 	${textSans.medium({ lineHeight: "regular" })};
 	color: ${radio.textLabel};
 `
@@ -96,7 +98,7 @@ export const labelTextWithSupportingText = css`
 
 export const supportingText = ({
 	radio,
-}: { radio: RadioTheme } = radioLight) => css`
+}: { radio: RadioTheme } = radioDefault) => css`
 	${textSans.small({ lineHeight: "regular" })};
 	color: ${radio.textLabelSupporting};
 `
@@ -114,6 +116,6 @@ export const vertical = css`
 
 export const errorRadio = ({
 	radio,
-}: { radio: RadioTheme } = radioLight) => css`
+}: { radio: RadioTheme } = radioDefault) => css`
 	border: 4px solid ${radio.borderError};
 `

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -10,8 +10,6 @@ import {
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
-export { textInputLight } from "@guardian/src-foundations/themes"
-
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return <div css={supportingText}>{children}</div>
 }

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -15,7 +15,7 @@ import {
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
-export { textInputLight } from "@guardian/src-foundations/themes"
+export { textInputDefault } from "@guardian/src-foundations/themes"
 export type Width = 30 | 10 | 4
 
 const widths: {

--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "emotion-theming"
 import { space } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { from } from "@guardian/src-foundations/mq"
-import { TextInput, textInputLight } from "./index"
+import { TextInput, textInputDefault } from "./index"
 
 export default {
 	title: "TextInput",
@@ -20,7 +20,7 @@ const constrainedWith = css`
 const defaultLight = () => {
 	const [state, setState] = useState("")
 	return (
-		<ThemeProvider theme={textInputLight}>
+		<ThemeProvider theme={textInputDefault}>
 			<div css={constrainedWith}>
 				<TextInput
 					label="First name"
@@ -37,7 +37,7 @@ defaultLight.story = {
 }
 
 const optionalLight = () => (
-	<ThemeProvider theme={textInputLight}>
+	<ThemeProvider theme={textInputDefault}>
 		<div css={constrainedWith}>
 			<TextInput label="First name" optional={true} />
 		</div>
@@ -51,7 +51,7 @@ optionalLight.story = {
 const supportingTextLight = () => {
 	const [state, setState] = useState("")
 	return (
-		<ThemeProvider theme={textInputLight}>
+		<ThemeProvider theme={textInputDefault}>
 			<div css={constrainedWith}>
 				<TextInput
 					label="Email"
@@ -73,7 +73,7 @@ const spacer = css`
 const widthsLight = () => {
 	const [state, setState] = useState({ wide: "", medium: "", short: "" })
 	return (
-		<ThemeProvider theme={textInputLight}>
+		<ThemeProvider theme={textInputDefault}>
 			<div css={spacer}>
 				<TextInput
 					label="First name"
@@ -127,7 +127,7 @@ widthsLight.story = {
 const errorWithMessageLight = () => {
 	const [state, setState] = useState("")
 	return (
-		<ThemeProvider theme={textInputLight}>
+		<ThemeProvider theme={textInputDefault}>
 			<div css={constrainedWith}>
 				<TextInput
 					label="First name"
@@ -147,7 +147,7 @@ errorWithMessageLight.story = {
 const successWithMessageLight = () => {
 	const [state, setState] = useState("")
 	return (
-		<ThemeProvider theme={textInputLight}>
+		<ThemeProvider theme={textInputDefault}>
 			<div css={constrainedWith}>
 				<TextInput
 					label="Input Code"
@@ -168,7 +168,7 @@ const constraintLight = () => {
 	const [state, setState] = useState("")
 
 	return (
-		<ThemeProvider theme={textInputLight}>
+		<ThemeProvider theme={textInputDefault}>
 			<div css={constrainedWith}>
 				<TextInput
 					label="Phone number"

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -3,27 +3,27 @@ import { size, space } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 import {
-	textInputLight,
+	textInputDefault,
 	TextInputTheme,
 } from "@guardian/src-foundations/themes"
 
 export const errorInput = ({
 	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
+}: { textInput: TextInputTheme } = textInputDefault) => css`
 	border: 4px solid ${textInput.borderError};
 	color: ${textInput.textError};
 `
 
 export const successInput = ({
 	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
+}: { textInput: TextInputTheme } = textInputDefault) => css`
 	border: 4px solid ${textInput.borderSuccess};
 	color: ${textInput.textSuccess};
 `
 
 export const textInput = ({
 	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
+}: { textInput: TextInputTheme } = textInputDefault) => css`
 	box-sizing: border-box;
 	height: ${size.medium}px;
 	${textSans.medium({ lineHeight: "regular" })};
@@ -76,7 +76,7 @@ export const width4 = css`
 
 export const text = ({
 	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
+}: { textInput: TextInputTheme } = textInputDefault) => css`
 	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 	color: ${textInput.textLabel};
 	margin-bottom: ${space[1]}px;
@@ -84,7 +84,7 @@ export const text = ({
 
 export const optionalLabel = ({
 	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
+}: { textInput: TextInputTheme } = textInputDefault) => css`
 	${textSans.small({ lineHeight: "regular" })};
 	color: ${textInput.textLabelOptional};
 	font-style: italic;
@@ -92,7 +92,7 @@ export const optionalLabel = ({
 
 export const supportingText = ({
 	textInput,
-}: { textInput: TextInputTheme } = textInputLight) => css`
+}: { textInput: TextInputTheme } = textInputDefault) => css`
 	${textSans.small({ lineHeight: "regular" })};
 	color: ${textInput.textLabelSupporting};
 	margin-bottom: ${space[1]}px;

--- a/src/core/foundations/src/themes/button.ts
+++ b/src/core/foundations/src/themes/button.ts
@@ -67,7 +67,3 @@ export const buttonBrandAlt: { button: ButtonTheme } = {
 		textSubdued: brandAltText.ctaSecondary,
 	},
 }
-
-// continue to expose legacy theme names
-export const buttonLight = buttonDefault
-export const buttonBrandYellow = buttonBrandAlt

--- a/src/core/foundations/src/themes/checkbox.ts
+++ b/src/core/foundations/src/themes/checkbox.ts
@@ -56,6 +56,3 @@ export const checkboxBrand: {
 	},
 	...userFeedbackBrand,
 }
-
-// continue to expose legacy theme names
-export const checkboxLight = checkboxDefault

--- a/src/core/foundations/src/themes/index.ts
+++ b/src/core/foundations/src/themes/index.ts
@@ -9,29 +9,13 @@ export * from "./select"
 export * from "./text-input"
 export * from "./user-feedback"
 
-import {
-	buttonLight,
-	buttonBrand,
-	buttonBrandYellow,
-	buttonDefault,
-	buttonBrandAlt,
-} from "./button"
-import { checkboxLight, checkboxBrand, checkboxDefault } from "./checkbox"
+import { buttonBrand, buttonDefault, buttonBrandAlt } from "./button"
+import { checkboxBrand, checkboxDefault } from "./checkbox"
 import { choiceCardDefault } from "./choice-card"
-import {
-	inlineErrorLight,
-	inlineErrorBrand,
-	inlineErrorDefault,
-} from "./inline-error"
-import {
-	linkLight,
-	linkBrand,
-	linkBrandYellow,
-	linkDefault,
-	linkBrandAlt,
-} from "./link"
-import { radioLight, radioBrand, radioDefault } from "./radio"
-import { textInputLight, textInputDefault } from "./text-input"
+import { inlineErrorBrand, inlineErrorDefault } from "./inline-error"
+import { linkBrand, linkDefault, linkBrandAlt } from "./link"
+import { radioBrand, radioDefault } from "./radio"
+import { textInputDefault } from "./text-input"
 import { userFeedbackDefault, userFeedbackBrand } from "./user-feedback"
 
 export const defaultTheme = {
@@ -43,13 +27,6 @@ export const defaultTheme = {
 	...radioDefault,
 	...textInputDefault,
 	...userFeedbackDefault,
-	// continue to expose legacy theme names
-	...buttonLight,
-	...checkboxLight,
-	...inlineErrorLight,
-	...linkLight,
-	...radioLight,
-	...textInputLight,
 }
 
 export const brand = {
@@ -64,11 +41,4 @@ export const brand = {
 export const brandAlt = {
 	...buttonBrandAlt,
 	...linkBrandAlt,
-	// continue to expose legacy theme names
-	...buttonBrandYellow,
-	...linkBrandYellow,
 }
-
-// continue to expose legacy theme names
-export const light = defaultTheme
-export const brandYellow = brandAlt

--- a/src/core/foundations/src/themes/inline-error.ts
+++ b/src/core/foundations/src/themes/inline-error.ts
@@ -15,6 +15,3 @@ export const inlineErrorBrand: { inlineError: InlineErrorTheme } = {
 		text: brandText.error,
 	},
 }
-
-// continue to expose legacy theme names
-export const inlineErrorLight = inlineErrorDefault

--- a/src/core/foundations/src/themes/link.ts
+++ b/src/core/foundations/src/themes/link.ts
@@ -33,7 +33,3 @@ export const linkBrandAlt: { link: LinkTheme } = {
 		textPrimaryHover: brandAltText.anchorPrimary,
 	},
 }
-
-// continue to expose legacy theme names
-export const linkLight = linkDefault
-export const linkBrandYellow = linkBrandAlt

--- a/src/core/foundations/src/themes/radio.ts
+++ b/src/core/foundations/src/themes/radio.ts
@@ -50,6 +50,3 @@ export const radioBrand: {
 	},
 	...userFeedbackBrand,
 }
-
-// continue to expose legacy theme names
-export const radioLight = radioDefault

--- a/src/core/foundations/src/themes/text-input.ts
+++ b/src/core/foundations/src/themes/text-input.ts
@@ -34,6 +34,3 @@ export const textInputDefault: {
 	},
 	...userFeedbackDefault,
 }
-
-// continue to expose legacy theme names
-export const textInputLight = textInputDefault


### PR DESCRIPTION
## What is the purpose of this change?

A number of theme names have been changed. We should remove legacy names to declutter the API.

## What does this change?

-   Stop exposing legacy theme names from foundations
-   Stop importing and re-exposing legacy theme names in text-input, link, radio, inline-error
- Stop erroneously exposing a text-input theme in text-area
