### PR TITLE
User feedback spacing

### DIFF
--- a/src/core/components/user-feedback/styles.ts
+++ b/src/core/components/user-feedback/styles.ts
@@ -1,5 +1,4 @@
 import { css } from "@emotion/core"
-import { space } from "@guardian/src-foundations"
 import {
 	userFeedbackDefault,
 	UserFeedbackTheme,
@@ -11,8 +10,6 @@ const inlineMessage = css`
 	display: flex;
 	align-items: flex-start;
 	${textSans.medium({ lineHeight: "regular" })};
-	/* TODO: we shouldn't be opinionated about layout inside the component */
-	margin-bottom: ${space[1]}px;
 
 	svg {
 		fill: currentColor;


### PR DESCRIPTION
## What is the purpose of this change?

The user feedback components are opinionated about layout by specifying a margin-bottom property. We should remove this opinion so it can be determined by the containing component.

## What does this change?

-   Remove margin-bottom from inline success and error

