### PR TITLE
Button: remove showIcon API, enforce children

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -8,7 +8,6 @@ import { css } from "@emotion/core"
 import { SerializedStyles } from "@emotion/css"
 import { ButtonTheme } from "@guardian/src-foundations/themes"
 import { visuallyHidden } from "@guardian/src-foundations/accessibility"
-import { SvgArrowRightStraight } from "@guardian/src-icons"
 import {
 	button,
 	primary,
@@ -149,7 +148,6 @@ interface LinkButtonProps
 		AnchorHTMLAttributes<HTMLAnchorElement> {
 	priority: Priority
 	size: Size
-	showIcon: boolean // TODO: deprecated, remove in future version
 	iconSide: IconSide
 	icon?: ReactElement
 	nudgeIcon?: boolean
@@ -160,7 +158,6 @@ interface LinkButtonProps
 const LinkButton = ({
 	priority,
 	size,
-	showIcon,
 	iconSide,
 	icon: iconSvg,
 	nudgeIcon,
@@ -178,56 +175,36 @@ const LinkButton = ({
 		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
 	}
 
-	// TODO: deprecated API, remove in future version
-	if (showIcon) {
-		return (
-			<a
-				css={(theme) => [
-					button,
-					sizes[size],
-					priorities[priority](theme.button && theme),
-					iconSizes[size],
-					!children ? iconOnlySizes[size] : "",
-					iconNudgeAnimation,
-					cssOverrides,
-				]}
-				{...props}
-			>
-				{children}
-				<SvgArrowRightStraight />
-			</a>
-		)
-	} else {
-		return (
-			<a
-				css={(theme) => [
-					button,
-					sizes[size],
-					priorities[priority](theme.button && theme),
-					iconSvg ? iconSizes[size] : "",
-					iconSvg && !hideLabel ? iconSides[iconSide] : "",
-					nudgeIcon ? iconNudgeAnimation : "",
-					hideLabel ? iconOnlySizes[size] : "",
-				]}
-				{...props}
-			>
-				{hideLabel ? (
-					<>
-						<span
-							css={css`
-								${visuallyHidden};
-							`}
-						>
-							{children}
-						</span>
-						{buttonContents[1]}
-					</>
-				) : (
-					buttonContents
-				)}
-			</a>
-		)
-	}
+	return (
+		<a
+			css={(theme) => [
+				button,
+				sizes[size],
+				priorities[priority](theme.button && theme),
+				iconSvg ? iconSizes[size] : "",
+				iconSvg && !hideLabel ? iconSides[iconSide] : "",
+				nudgeIcon ? iconNudgeAnimation : "",
+				hideLabel ? iconOnlySizes[size] : "",
+				cssOverrides,
+			]}
+			{...props}
+		>
+			{hideLabel ? (
+				<>
+					<span
+						css={css`
+							${visuallyHidden};
+						`}
+					>
+						{children}
+					</span>
+					{buttonContents[1]}
+				</>
+			) : (
+				buttonContents
+			)}
+		</a>
+	)
 }
 
 const defaultButtonProps = {

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -90,9 +90,8 @@ interface ButtonProps extends Props, ButtonHTMLAttributes<HTMLButtonElement> {
 	icon?: ReactElement
 	hideLabel: boolean
 	nudgeIcon?: boolean
-	children?: ReactNode
+	children: ReactNode
 }
-
 const Button = ({
 	priority,
 	size,
@@ -115,20 +114,14 @@ const Button = ({
 
 	return (
 		<button
-			css={theme => [
+			css={(theme) => [
 				button,
 				sizes[size],
 				priorities[priority](theme.button && theme),
 				iconSvg ? iconSizes[size] : "",
-				/*
-				TODO: We should be able to assume that children
-				will always be passed to the Button component.
-				A future breaking change might be to remove the
-				logic that checks for the (non-)existence of children.
-				*/
-				iconSvg && !hideLabel && children ? iconSides[iconSide] : "",
+				iconSvg && !hideLabel ? iconSides[iconSide] : "",
 				nudgeIcon ? iconNudgeAnimation : "",
-				hideLabel || !children ? iconOnlySizes[size] : "",
+				hideLabel ? iconOnlySizes[size] : "",
 				cssOverrides,
 			]}
 			{...props}
@@ -161,7 +154,7 @@ interface LinkButtonProps
 	icon?: ReactElement
 	nudgeIcon?: boolean
 	hideLabel: boolean
-	children?: ReactNode
+	children: ReactNode
 }
 
 const LinkButton = ({
@@ -189,7 +182,7 @@ const LinkButton = ({
 	if (showIcon) {
 		return (
 			<a
-				css={theme => [
+				css={(theme) => [
 					button,
 					sizes[size],
 					priorities[priority](theme.button && theme),
@@ -207,22 +200,14 @@ const LinkButton = ({
 	} else {
 		return (
 			<a
-				css={theme => [
+				css={(theme) => [
 					button,
 					sizes[size],
 					priorities[priority](theme.button && theme),
 					iconSvg ? iconSizes[size] : "",
-					/*
-					TODO: We should be able to assume that children
-					will always be passed to the LinkButton component.
-					A future breaking change might be to remove the
-					logic that checks for the (non-)existence of children.
-					*/
-					iconSvg && !hideLabel && children
-						? iconSides[iconSide]
-						: "",
+					iconSvg && !hideLabel ? iconSides[iconSide] : "",
 					nudgeIcon ? iconNudgeAnimation : "",
-					hideLabel || !children ? iconOnlySizes[size] : "",
+					hideLabel ? iconOnlySizes[size] : "",
 				]}
 				{...props}
 			>

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -44,6 +44,15 @@ export type Priority = "primary" | "secondary" | "tertiary" | "subdued"
 type IconSide = "left" | "right"
 type Size = "default" | "small" | "xsmall"
 
+interface SharedButtonProps extends Props {
+	priority: Priority
+	size: Size
+	iconSide: IconSide
+	icon?: ReactElement
+	hideLabel: boolean
+	nudgeIcon?: boolean
+}
+
 const priorities: {
 	[key in Priority]: ({ button }: { button: ButtonTheme }) => SerializedStyles
 } = {
@@ -82,13 +91,65 @@ const iconOnlySizes: {
 	xsmall: iconOnlyXsmall,
 }
 
-interface ButtonProps extends Props, ButtonHTMLAttributes<HTMLButtonElement> {
-	priority: Priority
-	size: Size
-	iconSide: IconSide
-	icon?: ReactElement
+const buttonContents = ({
+	hideLabel,
+	iconSvg,
+	children,
+}: {
 	hideLabel: boolean
-	nudgeIcon?: boolean
+	iconSvg?: ReactElement
+	children: ReactNode
+}) => {
+	const contents = [children]
+
+	if (iconSvg) {
+		if (!hideLabel) {
+			contents.push(<div className="src-button-space" />)
+		}
+		contents.push(React.cloneElement(iconSvg, { key: "svg" }))
+	}
+	if (hideLabel) {
+		return (
+			<>
+				<span
+					css={css`
+						${visuallyHidden};
+					`}
+				>
+					{children}
+				</span>
+				{contents[1]}
+			</>
+		)
+	} else {
+		return contents
+	}
+}
+
+const buttonStyles = ({
+	priority,
+	size,
+	icon: iconSvg,
+	hideLabel,
+	iconSide,
+	nudgeIcon,
+	cssOverrides,
+}: SharedButtonProps) =>
+	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+	(theme: any) => [
+		button,
+		sizes[size],
+		priorities[priority](theme.button && theme),
+		iconSvg ? iconSizes[size] : "",
+		iconSvg && !hideLabel ? iconSides[iconSide] : "",
+		nudgeIcon ? iconNudgeAnimation : "",
+		hideLabel ? iconOnlySizes[size] : "",
+		cssOverrides,
+	]
+
+interface ButtonProps
+	extends SharedButtonProps,
+		ButtonHTMLAttributes<HTMLButtonElement> {
 	children: ReactNode
 }
 const Button = ({
@@ -101,50 +162,29 @@ const Button = ({
 	cssOverrides,
 	children,
 	...props
-}: ButtonProps) => {
-	const buttonContents = [children]
-
-	if (iconSvg) {
-		if (!hideLabel) {
-			buttonContents.push(<div className="src-button-space" />)
-		}
-		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
-	}
-
-	return (
-		<button
-			css={(theme) => [
-				button,
-				sizes[size],
-				priorities[priority](theme.button && theme),
-				iconSvg ? iconSizes[size] : "",
-				iconSvg && !hideLabel ? iconSides[iconSide] : "",
-				nudgeIcon ? iconNudgeAnimation : "",
-				hideLabel ? iconOnlySizes[size] : "",
-				cssOverrides,
-			]}
-			{...props}
-		>
-			{hideLabel ? (
-				<>
-					<span
-						css={css`
-							${visuallyHidden};
-						`}
-					>
-						{children}
-					</span>
-					{buttonContents[1]}
-				</>
-			) : (
-				buttonContents
-			)}
-		</button>
-	)
-}
+}: ButtonProps) => (
+	<button
+		css={buttonStyles({
+			size,
+			priority,
+			icon: iconSvg,
+			hideLabel,
+			iconSide,
+			nudgeIcon,
+			cssOverrides,
+		})}
+		{...props}
+	>
+		{buttonContents({
+			hideLabel,
+			iconSvg,
+			children,
+		})}
+	</button>
+)
 
 interface LinkButtonProps
-	extends Props,
+	extends SharedButtonProps,
 		AnchorHTMLAttributes<HTMLAnchorElement> {
 	priority: Priority
 	size: Size
@@ -165,47 +205,26 @@ const LinkButton = ({
 	cssOverrides,
 	children,
 	...props
-}: LinkButtonProps) => {
-	const buttonContents = [children]
-
-	if (iconSvg) {
-		if (!hideLabel) {
-			buttonContents.push(<div className="src-button-space" />)
-		}
-		buttonContents.push(React.cloneElement(iconSvg, { key: "svg" }))
-	}
-
-	return (
-		<a
-			css={(theme) => [
-				button,
-				sizes[size],
-				priorities[priority](theme.button && theme),
-				iconSvg ? iconSizes[size] : "",
-				iconSvg && !hideLabel ? iconSides[iconSide] : "",
-				nudgeIcon ? iconNudgeAnimation : "",
-				hideLabel ? iconOnlySizes[size] : "",
-				cssOverrides,
-			]}
-			{...props}
-		>
-			{hideLabel ? (
-				<>
-					<span
-						css={css`
-							${visuallyHidden};
-						`}
-					>
-						{children}
-					</span>
-					{buttonContents[1]}
-				</>
-			) : (
-				buttonContents
-			)}
-		</a>
-	)
-}
+}: LinkButtonProps) => (
+	<a
+		css={buttonStyles({
+			size,
+			priority,
+			icon: iconSvg,
+			hideLabel,
+			iconSide,
+			nudgeIcon,
+			cssOverrides,
+		})}
+		{...props}
+	>
+		{buttonContents({
+			hideLabel,
+			iconSvg,
+			children,
+		})}
+	</a>
+)
 
 const defaultButtonProps = {
 	type: "button",

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -26,14 +26,14 @@
 		"@babel/preset-typescript": "^7.9.0",
 		"@emotion/babel-preset-css-prop": "^10.0.14",
 		"@guardian/src-foundations": "^2.0.0-rc.0",
+		"@guardian/src-icons": "^2.0.0-rc.0",
 		"rollup": "^1.17.0",
 		"rollup-plugin-babel": "^4.3.3",
 		"rollup-plugin-commonjs": "^10.0.2",
 		"rollup-plugin-node-resolve": "^5.2.0"
 	},
 	"dependencies": {
-		"@guardian/src-helpers": "^2.0.0-rc.0",
-		"@guardian/src-icons": "^2.0.0-rc.0"
+		"@guardian/src-helpers": "^2.0.0-rc.0"
 	},
 	"files": [
 		"dist/*.js",


### PR DESCRIPTION
## What is the purpose of this change?

- the `showIcon` API for LinkButton has been deprecated and should now be removed
- Button and LinkButton components always need children for accessibility purposes. This should now be enforced
- There is a lot of logic and interfaces shared between Button and LinkButton that could be consolidated

## What does this change?

-  remove `showIcon` API
-  make children prop non-nullable on Button and LinkButton
-  extract common props into `SharedButtonProps` interface
- extract styling logic into function
- extract content logic into function
