### PR TITLE
Expose #FF9081 as a news colour

### DIFF
--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -61,11 +61,11 @@ export const neutral = {
 }
 export const error = {
 	400: colors.reds[3],
-	500: colors.reds[7],
+	500: colors.reds[5],
 
 	// legacy names: please do not use
 	main: colors.reds[3],
-	bright: colors.reds[7],
+	bright: colors.reds[5],
 }
 export const success = {
 	400: colors.greens[1],
@@ -80,15 +80,16 @@ export const news = {
 	300: colors.reds[2],
 	400: colors.reds[3],
 	500: colors.reds[4],
-	600: colors.reds[5],
-	800: colors.reds[6],
+	550: colors.reds[5],
+	600: colors.reds[6],
+	800: colors.reds[7],
 
 	// legacy names: please do not use
 	dark: colors.reds[2],
 	main: colors.reds[3],
 	bright: colors.reds[4],
-	pastel: colors.reds[5],
-	faded: colors.reds[6],
+	pastel: colors.reds[6],
+	faded: colors.reds[7],
 }
 export const opinion = {
 	100: colors.oranges[0],

--- a/src/core/foundations/src/palette/text/default.ts
+++ b/src/core/foundations/src/palette/text/default.ts
@@ -1,4 +1,10 @@
-import { neutral, error as _error, success as _success, brand } from "../global"
+import {
+	neutral,
+	error as _error,
+	success as _success,
+	brand,
+	news,
+} from "../global"
 
 export const text = {
 	primary: neutral[7],
@@ -17,4 +23,5 @@ export const text = {
 	inputHover: brand[400], //choice card only
 	groupLabel: neutral[7],
 	groupLabelSupporting: neutral[46],
+	newsInverse: news[550],
 }

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -48,9 +48,9 @@ const colors = {
 		"#AB0613", //news-300
 		"#C70000", //news-400, error-400
 		"#FF5943", //news-500
+		"#FF9081", //news-550, error-500
 		"#FFBAC8", //news-600
 		"#FFF4F2", //news-800
-		"#FF9081", //error-500
 	],
 	oranges: [
 		"#672005", //opinion-100


### PR DESCRIPTION
## What is the purpose of this change?

#FF9081 is currently used as a global error colour in dark mode, but it may also be used as a news colour in dark mode too (specifically the kicker in dynamo containers)

## What does this change?

-   Expose #FF9081 as `news.550`
-   Add `text.newsInverse` token
