### PR TITLE
Fix grid row width

### DIFF
--- a/src/core/components/grid/stories.tsx
+++ b/src/core/components/grid/stories.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { css } from "@emotion/core"
 
-import { GridRow, GridItem } from "@guardian/src-grid"
+import { GridRow, GridItem } from "./index"
 import { sport } from "@guardian/src-foundations/palette"
 
 export default {

--- a/src/core/components/grid/stories.tsx
+++ b/src/core/components/grid/stories.tsx
@@ -4,8 +4,14 @@ import { css } from "@emotion/core"
 import { GridRow, GridItem } from "./index"
 import { sport } from "@guardian/src-foundations/palette"
 
+const gridStoryWrapper = (storyFn: () => JSX.Element) => {
+	// override 8px margin applied globally to every preview body
+	return <div style={{ margin: "0 -8px" }}>{storyFn()}</div>
+}
+
 export default {
 	title: "Grid",
+	decorators: [gridStoryWrapper],
 }
 
 const itemStyle = css`

--- a/src/core/components/grid/styles.ts
+++ b/src/core/components/grid/styles.ts
@@ -11,6 +11,8 @@ import {
 } from "./data"
 
 const gridRow = css`
+	box-sizing: border-box;
+
 	@supports (display: grid) {
 		display: grid;
 	}
@@ -32,12 +34,12 @@ const [
 	gridRowTablet,
 	gridRowDesktop,
 	gridRowWide,
-] = gridBreakpoints.map(breakpoint => {
+] = gridBreakpoints.map((breakpoint) => {
 	const msGridColumns = `-ms-grid-columns: (minmax(0, 1fr))[${gridColumns[breakpoint]}]`
 
 	return css`
 		${from[breakpoint]} {
-			width: ${containerWidths[breakpoint]}px;
+			width: ${containerWidths[breakpoint]};
 			grid-template-columns: repeat(${gridColumns[breakpoint]}, 1fr);
 			${msGridColumns};
 		}


### PR DESCRIPTION
## What is the purpose of this change?

There is a bug in which the grid row width is set to "100%px" at mobile width, along with other bizarre unit clashes at different viewport widths.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

- Ensure correct unit is applied to gridrow width
- BONUS: ensure stories use source code, not dist code
- BONUS: fix box model issues causing full-width stories to overflow

