### PR TITLE
Add leftCol support to grid

### DIFF
--- a/src/core/components/grid/README.md
+++ b/src/core/components/grid/README.md
@@ -1,11 +1,11 @@
 # Grid
 
-📣 For more context and visual guides relating grid usage on the [Source Design System website](https://zeroheight.com/2a1e5182b/p/41be19)
+📣 For more context and visual guides relating grid usage on the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/978527--grid-component/b/304251)
 
 ## Install
 
 ```sh
-$ yarn add @guardian/src-grid @guardian/src-foundations
+$ yarn add @guardian/src-grid
 ```
 
 ## Use
@@ -14,11 +14,11 @@ $ yarn add @guardian/src-grid @guardian/src-foundations
 import { GridRow, GridItem } from "@guardian/src-grid"
 
 const Article = () => (
-    <GridRow breakpoints={["mobile", "tablet", "desktop", "wide"]}>
-        <GridItem span={[0, 3, 3, 4]} borderRight={true}>
+    <GridRow breakpoints={["mobile", "tablet", "desktop", "leftCol", "wide"]}>
+        <GridItem span={[0, 3, 3, 4, 4]} borderRight={true}>
             <Sidebar />
         </GridItem>
-        <GridItem span={[4, 9, 9, 12]}>
+        <GridItem span={[4, 9, 9, 10, 12]}>
             <Main />
         </GridItem>
     </GridRow>
@@ -29,15 +29,13 @@ const Article = () => (
 
 ### `breakpoints`
 
-**`Array<GridBreakpoint | CustomBreakpoint>`** _= ["mobile", "tablet", "desktop", "wide"]_
+**`Array<GridBreakpoint | CustomBreakpoint>`** _= ["mobile", "tablet", "desktop", "leftCol", "wide"]_
 
 A list of breakpoints at which grid column span may change. GridRow currently
-supports changes at `"mobile"`, `"tablet"`, `"desktop"` and `"wide"` breakpoints.
+supports changes at `"mobile"`, `"tablet"`, `"desktop"`, `"leftCol"` and `"wide"` breakpoints.
 Any of these may be omitted.
 
 For best results, breakpoints should be ordered ascending by minimum viewport width.
-
-**Custom breakpoints should be considered experimental. Please tell the Design System Team before you use them**
 
 A custom breakpoint may be specified, which must have the following properties:
 

--- a/src/core/components/grid/data.ts
+++ b/src/core/components/grid/data.ts
@@ -2,12 +2,13 @@ import { Breakpoint, space, breakpoints } from "@guardian/src-foundations"
 
 export type GridBreakpoint = Extract<
 	Breakpoint,
-	"mobile" | "tablet" | "desktop" | "wide"
+	"mobile" | "tablet" | "desktop" | "leftCol" | "wide"
 >
 export const gridBreakpoints: readonly GridBreakpoint[] = [
 	"mobile",
 	"tablet",
 	"desktop",
+	"leftCol",
 	"wide",
 ] as const
 
@@ -30,6 +31,7 @@ export const gridColumns: GridColumns = {
 	mobile: 4,
 	tablet: 12,
 	desktop: 12,
+	leftCol: 14,
 	wide: 16,
 }
 
@@ -37,6 +39,7 @@ export const containerWidths: ContainerWidths = {
 	mobile: "100%",
 	tablet: `${breakpoints.tablet}px`,
 	desktop: `${breakpoints.desktop}px`,
+	leftCol: `${breakpoints.leftCol}px`,
 	wide: `${breakpoints.wide}px`,
 }
 

--- a/src/core/components/grid/index.tsx
+++ b/src/core/components/grid/index.tsx
@@ -5,6 +5,7 @@ import {
 	gridRowMobile,
 	gridRowTablet,
 	gridRowDesktop,
+	gridRowLeftCol,
 	gridRowWide,
 	gridItem,
 	borderRightStyle,
@@ -20,6 +21,7 @@ const gridRowBreakpoints: GridRowBreakpoints = {
 	mobile: gridRowMobile,
 	tablet: gridRowTablet,
 	desktop: gridRowDesktop,
+	leftCol: gridRowLeftCol,
 	wide: gridRowWide,
 }
 
@@ -59,17 +61,14 @@ const GridRow = ({ breakpoints, cssOverrides, children }: GridRowProps) => {
 		<div
 			css={[
 				gridRow,
-				breakpoints.reduce(
-					(acc, breakpoint) => {
-						const gridRowStyles =
-							typeof breakpoint === "string"
-								? gridRowBreakpoints[breakpoint]
-								: createCustomGridRow(breakpoint)
+				breakpoints.reduce((acc, breakpoint) => {
+					const gridRowStyles =
+						typeof breakpoint === "string"
+							? gridRowBreakpoints[breakpoint]
+							: createCustomGridRow(breakpoint)
 
-						return acc.concat([gridRowStyles])
-					},
-					[] as SerializedStyles[],
-				),
+					return acc.concat([gridRowStyles])
+				}, [] as SerializedStyles[]),
 				cssOverrides,
 			]}
 		>
@@ -113,9 +112,11 @@ const GridItem = ({
 	)
 }
 
-GridRow.defaultProps = { breakpoints: ["mobile", "tablet", "desktop", "wide"] }
+GridRow.defaultProps = {
+	breakpoints: ["mobile", "tablet", "desktop", "leftCol", "wide"],
+}
 GridItem.defaultProps = {
-	breakpoints: ["mobile", "tablet", "desktop", "wide"],
+	breakpoints: ["mobile", "tablet", "desktop", "leftCol", "wide"],
 	startingPositions: [],
 }
 

--- a/src/core/components/grid/stories.tsx
+++ b/src/core/components/grid/stories.tsx
@@ -21,17 +21,17 @@ const itemStyle = css`
 `
 
 const fourColLayout = (
-	<GridRow>
-		<GridItem spans={[1, 3, 3, 4]}>
+	<GridRow breakpoints={["mobile", "tablet", "desktop", "leftCol", "wide"]}>
+		<GridItem spans={[1, 3, 3, 2, 4]}>
 			<div css={itemStyle}></div>
 		</GridItem>
-		<GridItem spans={[1, 3, 3, 4]}>
+		<GridItem spans={[1, 3, 3, 4, 4]}>
 			<div css={itemStyle}></div>
 		</GridItem>
-		<GridItem spans={[1, 3, 3, 4]}>
+		<GridItem spans={[1, 3, 3, 4, 4]}>
 			<div css={itemStyle}></div>
 		</GridItem>
-		<GridItem spans={[1, 3, 3, 4]}>
+		<GridItem spans={[1, 3, 3, 4, 4]}>
 			<div css={itemStyle}></div>
 		</GridItem>
 	</GridRow>
@@ -61,6 +61,15 @@ desktop.story = {
 		viewport: { defaultViewport: "desktop" },
 	},
 }
+export const leftCol = () => fourColLayout
+
+leftCol.story = {
+	name: "leftCol four column layout",
+	parameters: {
+		viewport: { defaultViewport: "leftCol" },
+	},
+}
+
 export const wide = () => fourColLayout
 
 wide.story = {

--- a/src/core/components/grid/styles.ts
+++ b/src/core/components/grid/styles.ts
@@ -33,6 +33,7 @@ const [
 	gridRowMobile,
 	gridRowTablet,
 	gridRowDesktop,
+	gridRowLeftCol,
 	gridRowWide,
 ] = gridBreakpoints.map((breakpoint) => {
 	const msGridColumns = `-ms-grid-columns: (minmax(0, 1fr))[${gridColumns[breakpoint]}]`
@@ -154,6 +155,7 @@ export {
 	gridRowMobile,
 	gridRowTablet,
 	gridRowDesktop,
+	gridRowLeftCol,
 	gridRowWide,
 	gridItem,
 	borderRightStyle,


### PR DESCRIPTION
## What is the purpose of this change?

The Grid components don't currently support `leftCol`. We should add this breakpoint.

## What does this change?

-  Add leftCol suport to Grid components

## Screenshots

![Screenshot 2020-07-22 at 15 20 03](https://user-images.githubusercontent.com/5931528/88187755-d7d76180-cc2e-11ea-8cb6-16ee3b71137c.png)


