### PR TITLE
Update default branch name to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 on:
     push:
         branches:
-            - master
+            - main
 jobs:
     deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
     push:
         branches-ignore:
-            - "master"
+            - "main"
             - "gh-pages"
             - "[0-9]+.[0-9]+"
 jobs:

--- a/src/core/components/inline-error/README.md
+++ b/src/core/components/inline-error/README.md
@@ -1,5 +1,5 @@
 # Inline Error
 
-**:warning: Deprecation warning: This package has been replaced by [`@guardian/src-user-feedback`](https://github.com/guardian/source/tree/master/src/core/components/user-feedback)**
+**:warning: Deprecation warning: This package has been replaced by [`@guardian/src-user-feedback`](https://github.com/guardian/source/tree/main/src/core/components/user-feedback)**
 
 📣 For more context and visual guides relating to user feedback, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/108ed3--user-feedback/b/3803b4)

--- a/src/core/svgs/README.md
+++ b/src/core/svgs/README.md
@@ -1,5 +1,5 @@
 # SVGs
 
-**:warning: Deprecation warning: This package has been replaced by [`@guardian/src-icons`](https://github.com/guardian/source/tree/master/src/core/icons)**
+**:warning: Deprecation warning: This package has been replaced by [`@guardian/src-icons`](https://github.com/guardian/source/tree/main/src/core/icons)**
 
 📣 For more context and visual guides relating to icon usage, visit the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/74a822-overview)


### PR DESCRIPTION
## What is the purpose of this change?

We have renamed our default branch from “master” to “main”. This is in spirit with [the department’s pledge](https://github.com/guardian/.github/blob/master/CODE_OF_CONDUCT.md#our-pledge) to make our environment inclusive and follows [a campaign within the software industry](https://www.theregister.com/2020/06/15/github_replaces_master_with_main/) to eradicate the master-slave metaphor from the tech lexicon

## What does this change?

- Updates branch names in links in READMEs
- Updates the name of the branch against which GitHub Actions execute
