### PR TITLE
limit chromatic to run on changes to src

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,8 @@
 name: "Chromatic"
 on:
     push:
+        paths:
+            - "src"
         branches-ignore:
             - "gh-pages"
             - "[0-9]+.[0-9]+"


### PR DESCRIPTION
## What is the purpose of this change?

We're currently running Chromatic on all branches, regardless of what has changed. This should filter out branches that do not directly impact components. This is especially important now that dependabot is raising a bunch of PRs to upgrade packages at the root level every day.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

Inspired by guardian/apps-rendering#548

## What does this change?

- run Chromatic on changes to `src` only