### PR TITLE
Ensure Chromatic runs when Source packages are updated

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,11 +1,11 @@
-name: "Chromatic"
+name: Chromatic
 on:
     push:
-        paths:
-            - "src"
         branches-ignore:
             - "gh-pages"
             - "[0-9]+.[0-9]+"
+        paths:
+            - "src/**"
 jobs:
     test:
         runs-on: ubuntu-latest

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -48,9 +48,6 @@ export const textInput = ({
 		/*
 		We automatically apply error styling to fields in an invalid state,
 		but stop short of applying it to empty required fields.
-
-		Note: the following class will only be applied to a controlled
-		component: https://reactjs.org/docs/forms.html#controlled-components
 		*/
 		&[value]:not([value=""]) {
 			${errorInput({ textInput })};


### PR DESCRIPTION
## What is the purpose of this change?

Chromatic is not currently running when a Source package changes

## What does this change?

-   Make paths more globby
-   Make a superficial change to ensure Chromatic runs as expected
