### PR TITLE
Select style tweaks

### DIFF
--- a/src/core/components/select/styles.ts
+++ b/src/core/components/select/styles.ts
@@ -48,6 +48,7 @@ export const selectWrapper = ({
 		width: ${width.iconMedium}px;
 		height: ${height.iconMedium}px;
 		fill: ${select.textUserInput};
+		pointer-events: none;
 	}
 `
 

--- a/src/core/components/select/styles.ts
+++ b/src/core/components/select/styles.ts
@@ -43,8 +43,8 @@ export const selectWrapper = ({
 	svg {
 		display: none;
 		position: absolute;
-		right: 4px;
-		top: 8px;
+		right: ${space[3]}px;
+		top: ${space[2]}px;
 		width: ${width.iconMedium}px;
 		height: ${height.iconMedium}px;
 		fill: ${select.textUserInput};

--- a/src/core/components/select/styles.ts
+++ b/src/core/components/select/styles.ts
@@ -55,14 +55,6 @@ export const selectWrapper = ({
 export const select = ({
 	select,
 }: { select: SelectTheme } = selectDefault) => css`
-	@supports (appearance: none) {
-		appearance: none;
-
-		& ~ svg {
-			display: block;
-		}
-	}
-
 	color: ${select.textUserInput};
 	box-sizing: border-box;
 	height: ${height.inputMedium}px;
@@ -70,7 +62,16 @@ export const select = ({
 	${textSans.medium({ lineHeight: "regular" })};
 	background-color: ${select.backgroundInput};
 	border: 2px solid ${select.border};
-	padding: 0 ${space[2]}px;
+	padding-left: ${space[2]}px;
+
+	@supports (appearance: none) {
+		appearance: none;
+		padding-right: ${space[2]}px;
+
+		& ~ svg {
+			display: block;
+		}
+	}
 
 	&:active {
 		border: 2px solid ${select.borderActive};


### PR DESCRIPTION
## What is the purpose of this change?

- clicking the chevron doesn't open the select box
- select box needs more padding to the right of the chevron
- there's some ugly padding to the right of the down arrow on IE11

## What does this change?

-   add `pointer-events: none` to the chevron to ensure user click "through" it and expand select box
-   added more right padding
- removed right padding in IE11

## Screenshots

**Before (modern)**

![Screenshot 2020-08-03 at 11 30 30](https://user-images.githubusercontent.com/5931528/89173830-c0786c80-d57c-11ea-9194-5222a3ff4992.png)

**After (modern)**

![Screenshot 2020-08-03 at 11 28 56](https://user-images.githubusercontent.com/5931528/89173660-8909c000-d57c-11ea-84b1-f1e2879e92e3.png)

**Before (IE11)**

![Screenshot 2020-08-03 at 11 29 21](https://user-images.githubusercontent.com/5931528/89173710-9757dc00-d57c-11ea-91ac-61c754b86aa6.png)

**After (IE11)**

![Screenshot 2020-08-03 at 11 29 48](https://user-images.githubusercontent.com/5931528/89173752-a8085200-d57c-11ea-9dd1-dd04b1bab147.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
