### PR TITLE
Deprecate dynamo.400

### DIFF
--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -114,6 +114,8 @@ export const specialReport = {
 	500: colors.grays[14],
 }
 
+// Deprecated - please do not use
+// TODO: remove in v3.0.0
 export const dynamo = {
 	400: colors.grays[15],
 }


### PR DESCRIPTION
## What is the purpose of this change?

`dynamo.400` should no longer be used

## What does this change?

-  add comment deprecating `dynamo.400` and a reminder TODO to remove in v3.0.0

