### PR TITLE
Add back to top link to footer

### DIFF
--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -1,12 +1,22 @@
 import React, { HTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/core"
-import { footer, copyright } from "./styles"
+import { footer, copyright, links, backToTop, backToTopIcon } from "./styles"
 import { Props } from "@guardian/src-helpers"
+import { SvgChevronUpSingle } from "@guardian/src-icons"
 export { footerBrand } from "@guardian/src-foundations/themes"
 
 interface FooterProps extends HTMLAttributes<HTMLElement>, Props {
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 }
+
+const backToTopLink = (
+	<a href="#top" css={(theme) => backToTop(theme.footer && theme)}>
+		Back to top
+		<div css={(theme) => backToTopIcon(theme.footer && theme)}>
+			<SvgChevronUpSingle />
+		</div>
+	</a>
+)
 
 const Footer = ({ cssOverrides, ...props }: FooterProps) => {
 	return (
@@ -14,6 +24,9 @@ const Footer = ({ cssOverrides, ...props }: FooterProps) => {
 			css={(theme) => [footer(theme.footer && theme), cssOverrides]}
 			{...props}
 		>
+			<div css={(theme) => links(theme.footer && theme)}>
+				{backToTopLink}
+			</div>
 			<small css={copyright}>
 				&copy; 2020 Guardian News and Media Limited or its affiliated
 				companies. All rights reserved.

--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -2,6 +2,7 @@ import React, { HTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/core"
 import { footer, copyright } from "./styles"
 import { Props } from "@guardian/src-helpers"
+export { footerBrand } from "@guardian/src-foundations/themes"
 
 interface FooterProps extends HTMLAttributes<HTMLElement>, Props {
 	cssOverrides?: SerializedStyles | SerializedStyles[]

--- a/src/core/components/footer/stories.tsx
+++ b/src/core/components/footer/stories.tsx
@@ -1,5 +1,18 @@
-export default {
-  title: "Footer",
+import React from "react"
+import { Footer } from "./index"
+import { css } from "@emotion/core"
+
+const topMargin = css`
+	margin-top: 3em;
+`
+
+const footerStoryWrapper = (storyFn: () => JSX.Element) => {
+	return <div css={topMargin}>{storyFn()}</div>
 }
 
+export default {
+	component: Footer,
+	title: "Footer",
+	decorators: [footerStoryWrapper],
+}
 export * from "./stories/default"

--- a/src/core/components/footer/stories/default.tsx
+++ b/src/core/components/footer/stories/default.tsx
@@ -12,3 +12,27 @@ defaultBlue.story = {
 		],
 	},
 }
+
+export const defaultBlueTablet = () => <Footer />
+
+defaultBlueTablet.story = {
+	name: "default blue tablet",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+		viewport: { defaultViewport: "tablet" },
+	},
+}
+
+export const defaultBlueMobile = () => <Footer />
+
+defaultBlueMobile.story = {
+	name: "default blue mobile",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+		viewport: { defaultViewport: "mobileMedium" },
+	},
+}

--- a/src/core/components/footer/stories/default.tsx
+++ b/src/core/components/footer/stories/default.tsx
@@ -1,8 +1,14 @@
 import React from "react"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 import { Footer } from "../index"
 
 export const defaultBlue = () => <Footer />
 
 defaultBlue.story = {
 	name: "default blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/components/footer/styles.ts
+++ b/src/core/components/footer/styles.ts
@@ -2,6 +2,7 @@ import { css } from "@emotion/core"
 import { footerBrand, FooterTheme } from "@guardian/src-foundations/themes"
 import { from } from "@guardian/src-foundations/mq"
 import { space } from "@guardian/src-foundations"
+import { height, width } from "@guardian/src-foundations/size"
 import { textSans } from "@guardian/src-foundations/typography"
 
 export const footer = ({
@@ -16,6 +17,62 @@ export const footer = ({
 	}
 `
 
+export const links = ({ footer }: { footer: FooterTheme } = footerBrand) => css`
+	position: relative;
+	border-style: solid;
+	border-color: ${footer.border};
+	border-width: 0 0 1px 0;
+
+	/* TODO: viewport-specific layout for when footer supports content */
+	/* border-width: 1px 0 1px 0;
+
+	${from.desktop} {
+		border-width: 1px;
+	} */
+`
+
 export const copyright = css`
 	${textSans.xsmall()};
+	display: block;
+	margin-top: ${space[5]}px;
+
+	${from.desktop} {
+		margin-top: ${space[1]}px;
+	}
+`
+
+export const backToTop = ({
+	footer,
+}: { footer: FooterTheme } = footerBrand) => css`
+	display: flex;
+	align-items: center;
+	height: ${height.ctaMedium}px;
+	position: absolute;
+	top: -${height.ctaMedium / 2}px;
+	right: 0;
+	padding: 0 ${space[2]}px;
+
+	${textSans.medium({ fontWeight: "bold" })};
+	color: ${footer.text};
+	background-color: ${footer.background};
+	text-decoration: none;
+`
+
+export const backToTopIcon = ({
+	footer,
+}: { footer: FooterTheme } = footerBrand) => css`
+	height: ${height.ctaMedium}px;
+	width: ${width.ctaMedium}px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: ${height.ctaMedium}px;
+	background: ${footer.anchor};
+	margin-left: ${space[2]}px;
+
+	svg {
+		height: ${height.iconSmall}px;
+		width: ${width.iconSmall}px;
+		fill: ${footer.background};
+	}
 `

--- a/src/core/foundations/src/themes/footer.ts
+++ b/src/core/foundations/src/themes/footer.ts
@@ -8,6 +8,7 @@ export type FooterTheme = {
 	border: string
 	background: string
 	text: string
+	anchor: string
 }
 
 export const footerBrand: {
@@ -17,5 +18,6 @@ export const footerBrand: {
 		border: brandBorder.primary,
 		background: brandBackground.primary,
 		text: brandText.primary,
+		anchor: brandText.anchorPrimary,
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

Some footers have a "back to top" link. When clicked, the button hits a standardised page anchor called `#top` which scrolls the user back to the top of the current page.

## What does this change?

-  add back to top button
- make stories use brand background

## Screenshots

**Mobile Medium**

<img width="375" alt="Screenshot 2020-08-12 at 11 26 45" src="https://user-images.githubusercontent.com/5931528/90005208-c6620200-dc8e-11ea-8954-030a14489489.png">

**Desktop**

<img width="976" alt="Screenshot 2020-08-12 at 11 26 54" src="https://user-images.githubusercontent.com/5931528/90005212-c82bc580-dc8e-11ea-835d-b1ca50169e7b.png">


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
