### PR TITLE
Back to top hover styling

### DIFF
--- a/src/core/components/footer/styles.ts
+++ b/src/core/components/footer/styles.ts
@@ -1,9 +1,10 @@
 import { css } from "@emotion/core"
+import { space } from "@guardian/src-foundations"
 import { footerBrand, FooterTheme } from "@guardian/src-foundations/themes"
 import { from, between } from "@guardian/src-foundations/mq"
-import { space } from "@guardian/src-foundations"
 import { height, width } from "@guardian/src-foundations/size"
 import { textSans } from "@guardian/src-foundations/typography"
+import { focusHalo } from "@guardian/src-foundations/accessibility"
 
 export const footer = ({
 	footer,
@@ -60,9 +61,17 @@ export const backToTop = ({
 	padding-left: ${space[2]}px;
 
 	${textSans.medium({ fontWeight: "bold" })};
-	color: ${footer.text};
+	color: ${footer.anchor};
 	background-color: ${footer.background};
 	text-decoration: none;
+
+	& :hover {
+		color: ${footer.anchorHover};
+	}
+
+	& :focus {
+		${focusHalo};
+	}
 `
 
 export const backToTopIcon = ({
@@ -74,7 +83,7 @@ export const backToTopIcon = ({
 	align-items: center;
 	justify-content: center;
 	border-radius: ${height.ctaMedium}px;
-	background: ${footer.anchor};
+	background: currentColor;
 	margin-left: ${space[2]}px;
 
 	svg {

--- a/src/core/foundations/src/palette/text/brand.ts
+++ b/src/core/foundations/src/palette/text/brand.ts
@@ -1,4 +1,10 @@
-import { neutral, success as _success, error as _error, brand } from "../global"
+import {
+	neutral,
+	success as _success,
+	error as _error,
+	brand,
+	brandAlt,
+} from "../global"
 
 export const brandText = {
 	primary: neutral[100],
@@ -9,6 +15,7 @@ export const brandText = {
 	ctaSecondary: neutral[100],
 	ctaTertiary: neutral[100],
 	anchorPrimary: neutral[100],
+	anchorPrimaryHover: brandAlt[400],
 	userInput: neutral[100],
 	inputLabel: neutral[100],
 	inputLabelSupporting: brand[800],

--- a/src/core/foundations/src/themes/footer.ts
+++ b/src/core/foundations/src/themes/footer.ts
@@ -9,6 +9,7 @@ export type FooterTheme = {
 	background: string
 	text: string
 	anchor: string
+	anchorHover: string
 }
 
 export const footerBrand: {
@@ -19,5 +20,6 @@ export const footerBrand: {
 		background: brandBackground.primary,
 		text: brandText.primary,
 		anchor: brandText.anchorPrimary,
+		anchorHover: brandText.anchorPrimaryHover,
 	},
 }


### PR DESCRIPTION
## What is the purpose of this change?

The back to top link should change to yellow on hover.

## What does this change?

-   add anchor hover style to foundations (text palette and footer theme)
-   add hover style to back to top link
-   BONUS: apply focus ring to back to top link

## Screenshots

![2020-08-12 17 03 54](https://user-images.githubusercontent.com/5931528/90038893-db09be80-dcbd-11ea-9395-033cd5ff6bcb.gif)


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
