### PR TITLE
Add support for children in footer

### DIFF
--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from "react"
+import React, { HTMLAttributes, ReactNode } from "react"
 import { SerializedStyles } from "@emotion/core"
 import {
 	footer,
@@ -14,6 +14,7 @@ export { footerBrand } from "@guardian/src-foundations/themes"
 
 interface FooterProps extends HTMLAttributes<HTMLElement>, Props {
 	showBackToTop: boolean
+	children?: ReactNode
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 }
 
@@ -26,13 +27,19 @@ const backToTopLink = (
 	</a>
 )
 
-const Footer = ({ showBackToTop, cssOverrides, ...props }: FooterProps) => {
+const Footer = ({
+	showBackToTop,
+	children,
+	cssOverrides,
+	...props
+}: FooterProps) => {
 	return (
 		<footer
 			css={(theme) => [footer(theme.footer && theme), cssOverrides]}
 			{...props}
 		>
 			<div css={(theme) => links(theme.footer && theme)}>
+				{children}
 				{showBackToTop ? backToTopLink : ""}
 			</div>
 			<small

--- a/src/core/components/footer/stories.tsx
+++ b/src/core/components/footer/stories.tsx
@@ -16,5 +16,6 @@ export default {
 	decorators: [footerStoryWrapper],
 }
 
-export * from "./stories/default"
 export * from "./stories/back-to-top"
+export * from "./stories/default"
+export * from "./stories/with-children"

--- a/src/core/components/footer/stories/with-children.tsx
+++ b/src/core/components/footer/stories/with-children.tsx
@@ -1,0 +1,156 @@
+import React from "react"
+import { css } from "@emotion/core"
+import { storybookBackgrounds } from "@guardian/src-helpers"
+import { space } from "@guardian/src-foundations"
+import { textSans } from "@guardian/src-foundations/typography"
+import { from } from "@guardian/src-foundations/mq"
+import { brandText, brandBorder } from "@guardian/src-foundations/palette"
+import { Footer } from "../index"
+
+const container = css`
+	${from.desktop} {
+		border-style: solid;
+		border-color: ${brandBorder.primary};
+		border-width: 0 1px 0 1px;
+	}
+`
+
+const para = css`
+	${textSans.medium({ lineHeight: "tight" })};
+	max-width: 58.75rem;
+
+	${from.desktop} {
+		padding-left: ${space[4]}px;
+	}
+`
+
+const ul = css`
+	list-style: none;
+	padding: 0;
+	border-top: 1px solid ${brandBorder.primary};
+
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-template-areas:
+		"link1 link3"
+		"link2 link4";
+
+	${from.desktop} {
+		grid-template-columns: 1fr 1fr 1fr 1fr;
+		grid-template-areas: "link1 link2 link3 link4";
+		margin-bottom: 0;
+	}
+`
+
+const li = css`
+	padding: ${space[1]}px 0 ${space[4]}px 0;
+	border-style: solid;
+	border-color: ${brandBorder.primary};
+	border-width: 0;
+
+	${from.desktop} {
+		padding: ${space[2]}px 0 ${space[4]}px ${space[4]}px;
+	}
+`
+
+const anchor = css`
+	${textSans.medium({ lineHeight: "regular" })};
+	color: ${brandText.anchorPrimary};
+	text-decoration: none;
+
+	& :hover {
+		color: ${brandText.anchorPrimaryHover};
+	}
+`
+
+const link1 = css`
+	grid-area: link1;
+	border-right-width: 1px;
+`
+const link2 = css`
+	grid-area: link2;
+	border-right-width: 1px;
+`
+const link3 = css`
+	grid-area: link3;
+	padding-left: ${space[4]}px;
+
+	${from.desktop} {
+		border-right-width: 1px;
+	}
+`
+const link4 = css`
+	grid-area: link4;
+	padding-left: ${space[4]}px;
+`
+
+const footerContents = (
+	<div css={container}>
+		<p css={para}>
+			<strong>
+				Promotion terms and conditions Offer subject to availability.
+			</strong>
+			<br />
+			Guardian News and Media Ltd (&quot;GNM&quot;) reserves the right to
+			withdraw this promotion at any time. Full promotion terms and
+			conditions for our monthly and annual offers.
+		</p>
+		<ul css={ul}>
+			<li css={[li, link1]}>
+				<a css={anchor} href="#">
+					Privacy policy
+				</a>
+			</li>
+			<li css={[li, link2]}>
+				<a css={anchor} href="#">
+					Contact us
+				</a>
+			</li>
+			<li css={[li, link3]}>
+				<a css={anchor} href="#">
+					Frequently asked questions
+				</a>
+			</li>
+			<li css={[li, link4]}>
+				<a css={anchor} href="#">
+					Terms &amp; conditions
+				</a>
+			</li>
+		</ul>
+	</div>
+)
+
+export const withChildrenBlue = () => <Footer>{footerContents}</Footer>
+
+withChildrenBlue.story = {
+	name: "with children blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
+}
+
+export const withChildrenBlueTablet = () => <Footer>{footerContents}</Footer>
+
+withChildrenBlueTablet.story = {
+	name: "with children blue tablet",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+		viewport: { defaultViewport: "tablet" },
+	},
+}
+
+export const withChildrenBlueMobile = () => <Footer>{footerContents}</Footer>
+
+withChildrenBlueMobile.story = {
+	name: "with children blue mobile",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+		viewport: { defaultViewport: "mobileMedium" },
+	},
+}


### PR DESCRIPTION
## What is the purpose of this change?

The footer should be able to house arbitrary elements. We should add support for children to the component, and provide an example of how to do this in storybook.

## What does this change?

-   Add suport for children in the footer component
-   Add storybook exmaples at mobile, tablet and desktop

## Screenshots

**mobile**

![Screenshot 2020-08-13 at 17 14 32](https://user-images.githubusercontent.com/5931528/90159563-7d8e7400-dd88-11ea-97fe-16b54985ffac.png)

**tablet**

![Screenshot 2020-08-13 at 17 14 25](https://user-images.githubusercontent.com/5931528/90159559-7c5d4700-dd88-11ea-857e-7775a8725c32.png)

**desktop**

![Screenshot 2020-08-13 at 17 14 17](https://user-images.githubusercontent.com/5931528/90159556-7b2c1a00-dd88-11ea-9930-32536f5d84f1.png)

