### PR TITLE
Use more accessible colour for opinion.300

### DIFF
--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -55,7 +55,7 @@ const colors = {
 	oranges: [
 		"#672005", //opinion-100
 		"#8D2700", //opinion-200
-		"#BD5318", //opinion-300
+		"#CB4700", //opinion-300
 		"#E05E00", //opinion-400
 		"#FF7F0F", //opinion-500
 		"#F9B376", //opinion-600


### PR DESCRIPTION
## What is the purpose of this change?

The current `opinion.300` has been earmarked for use in links on opinion pages. We need to ensure this colour passes colour contrast checks for use as a text colour.

## What does this change?

-   Use more accessible colour for opinion.300

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

![Screenshot 2020-08-17 at 17 01 47](https://user-images.githubusercontent.com/5931528/90417326-711d5a80-e0ab-11ea-94fc-d5d3134a0f44.png)

![Screenshot 2020-08-17 at 17 04 33](https://user-images.githubusercontent.com/5931528/90417615-dec98680-e0ab-11ea-8b54-b48248ca6151.png)

**After**

![Screenshot 2020-08-17 at 17 02 20](https://user-images.githubusercontent.com/5931528/90417338-74b0e180-e0ab-11ea-874c-a834d8b3df9a.png)

![Screenshot 2020-08-17 at 17 05 25](https://user-images.githubusercontent.com/5931528/90417622-e25d0d80-e0ab-11ea-946a-71d696a19044.png)


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

