### PR TITLE
Remove z-index when focus halo is applied

### DIFF
--- a/src/core/foundations/src/accessibility/index.ts
+++ b/src/core/foundations/src/accessibility/index.ts
@@ -13,7 +13,6 @@ const focusHalo = `
 	outline: 0;
 	html:not(.src-focus-disabled) & {
 		box-shadow: 0 0 0 5px ${border.focusHalo};
-		z-index: 9;
 	}
 `
 


### PR DESCRIPTION
## What is the purpose of this change?

Applying z-index to elements with a focus halo is causing issues for our custom checkbox. 

The [z-index was added](https://github.com/guardian/source/commit/f64b107d59727a38de830f2b10eab68d81519e76) many moons ago and it's unclear whether we still need it. 

Removing it will fix some bugs and reduce complexity. The z-index value applied here is arbitrary and not sustainable in the long term. There is a [card in the backlog](https://trello.com/c/x7WvCqK1/10-z-index) to address z-index holistically.

## What does this change?

- Remove z-index from elements with the focus halo applied

## Screenshots

I can't see any visual changes

![2020-08-19 11 48 48](https://user-images.githubusercontent.com/5931528/90625771-fde22880-e211-11ea-9ba3-3ca1d57606d8.gif)


