### PR TITLE
Remove z-index from checkbox

### DIFF
--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -44,7 +44,6 @@ export const checkbox = ({
 	flex: 0 0 auto;
 	box-sizing: border-box;
 	display: inline-block;
-	z-index: 1;
 	cursor: pointer;
 	width: ${width.inputXsmall}px;
 	height: ${height.inputXsmall}px;


### PR DESCRIPTION
## What is the purpose of this change?

The checkbox styles specify a z-index but it's unclear why (introduced in https://github.com/guardian/source/commit/e5f24d445b1d0aafabc0d1d682a02c5c531ddb9a). This places the checkbox in front of the tick icon. Normally this isn't a problem since the checkbox is transparent, but if a consumer overrides the `background-color` then the tick icon becomes hidden.

## What does this change?

-  Remove z-index from checkbox

## Screenshots

**Before**

![2020-08-19 15 25 11](https://user-images.githubusercontent.com/5931528/90647427-37299100-e230-11ea-9e50-25f8609f9e7d.gif)


**After**

![2020-08-19 15 24 38](https://user-images.githubusercontent.com/5931528/90647452-3b55ae80-e230-11ea-8595-4e47aedf0943.gif)

