### PR TITLE
Allow label component to render as legend

### DIFF
--- a/src/core/components/label/README.md
+++ b/src/core/components/label/README.md
@@ -57,6 +57,13 @@ Appears as an inline error message below the label and supporting text.
 Appears as an inline error message below the label and supporting text. This prop should not have a
 value set at the same time as the error prop. In the event that both are set, errors take precedence.
 
+### `as`
+
+**`"label" | "legend"`** _="label"_
+
+The HTML element that the Label component gets rendered as. By default it is `<label>`, but `<legend>`
+is also available for when labelling a fieldset.
+
 ### Standard
 
 -   `light`

--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -1,14 +1,15 @@
-import React, { ReactNode, HTMLAttributes } from "react"
+import React, { ReactNode, LabelHTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/core"
 import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
 import { labelText, optionalText, supportingText } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
-interface LabelProps extends HTMLAttributes<HTMLDivElement>, Props {
+interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement>, Props {
 	text: string
 	supporting?: string
 	error?: string
 	success?: string
+	as: "label" | "legend"
 	optional: boolean
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 	children?: string
@@ -28,12 +29,13 @@ const Label = ({
 	error,
 	success,
 	optional,
+	as,
 	cssOverrides,
 	children,
 }: LabelProps) => {
-	return (
-		<label css={cssOverrides}>
-			<div css={(theme) => labelText(theme.textInput && theme)}>
+	const contents = (
+		<>
+			<span css={(theme) => labelText(theme.textInput && theme)}>
 				{text}{" "}
 				{optional ? (
 					<span
@@ -44,16 +46,22 @@ const Label = ({
 				) : (
 					""
 				)}
-			</div>
+			</span>
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
 			{error && <InlineError>{error}</InlineError>}
 			{!error && success && <InlineSuccess>{success}</InlineSuccess>}
 			{children}
-		</label>
+		</>
 	)
+
+	if (as === "legend") {
+		return <legend css={cssOverrides}>{contents}</legend>
+	}
+
+	return <label css={cssOverrides}>{contents}</label>
 }
 
-const defaultProps = { optional: false }
+const defaultProps = { optional: false, as: "label" }
 
 Label.defaultProps = { ...defaultProps }
 

--- a/src/core/components/label/stories.tsx
+++ b/src/core/components/label/stories.tsx
@@ -7,6 +7,8 @@ export default {
 
 export * from "./stories/default"
 export * from "./stories/error"
+export * from "./stories/legend"
 export * from "./stories/optional"
+export * from "./stories/optional-error"
 export * from "./stories/success"
 export * from "./stories/supporting"

--- a/src/core/components/label/stories/legend.tsx
+++ b/src/core/components/label/stories/legend.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import { Label } from "../index"
+
+export const legendLight = () => (
+	<Label text="Subscribe to our newsletters" as="legend" />
+)
+
+legendLight.story = {
+	name: "legend light",
+}

--- a/src/core/components/label/stories/optional-error.tsx
+++ b/src/core/components/label/stories/optional-error.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { Label } from "../index"
+
+export const optionalWithErrorMessageLight = () => (
+	<Label
+		text="Telephone number"
+		error="The number must have at least 11 digits"
+		optional={true}
+	/>
+)
+
+optionalWithErrorMessageLight.story = {
+	name: `optional with error message light`,
+}

--- a/src/core/components/label/styles.ts
+++ b/src/core/components/label/styles.ts
@@ -1,5 +1,4 @@
 import { css } from "@emotion/core"
-import { space } from "@guardian/src-foundations"
 import { textSans } from "@guardian/src-foundations/typography"
 import { LabelTheme, labelDefault } from "@guardian/src-foundations/themes"
 
@@ -8,7 +7,6 @@ export const labelText = ({
 }: { label: LabelTheme } = labelDefault) => css`
 	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
 	color: ${label.textLabel};
-	margin-bottom: ${space[1]}px;
 `
 
 export const optionalText = ({
@@ -24,5 +22,4 @@ export const supportingText = ({
 }: { label: LabelTheme } = labelDefault) => css`
 	${textSans.small({ lineHeight: "regular" })};
 	color: ${label.textSupporting};
-	margin-bottom: ${space[1]}px;
 `


### PR DESCRIPTION
## What is the purpose of this change?

The label styling is applicable to legends in fieldsets. Since the differences in markup are small, it's worth allowing the label to render as a legend, if specified by the consuming application.

## What does this change?

-   Add `as` prop to component that accepts `label` or `legend`
- BONUS: remove margin from bottom of label text

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->
