### PR TITLE
Description ID

### DIFF
--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, LabelHTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/core"
 import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
+import { descriptionId } from "@guardian/src-foundations/accessibility"
 import { labelText, optionalText, supportingText } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
@@ -30,6 +31,7 @@ const Label = ({
 	success,
 	optional,
 	as,
+	htmlFor,
 	cssOverrides,
 	children,
 }: LabelProps) => {
@@ -48,8 +50,16 @@ const Label = ({
 				)}
 			</span>
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
-			{error && <InlineError>{error}</InlineError>}
-			{!error && success && <InlineSuccess>{success}</InlineSuccess>}
+			{error && (
+				<InlineError id={htmlFor ? descriptionId(htmlFor) : ""}>
+					{error}
+				</InlineError>
+			)}
+			{!error && success && (
+				<InlineSuccess id={htmlFor ? descriptionId(htmlFor) : ""}>
+					{success}
+				</InlineSuccess>
+			)}
 			{children}
 		</>
 	)
@@ -58,7 +68,11 @@ const Label = ({
 		return <legend css={cssOverrides}>{contents}</legend>
 	}
 
-	return <label css={cssOverrides}>{contents}</label>
+	return (
+		<label css={cssOverrides} htmlFor={htmlFor}>
+			{contents}
+		</label>
+	)
 }
 
 const defaultProps = { optional: false, as: "label" }

--- a/src/core/components/user-feedback/index.tsx
+++ b/src/core/components/user-feedback/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react"
+import React, { ReactNode, HTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/css"
 import { SvgAlert, SvgTickRound } from "@guardian/src-icons"
 import { Props } from "@guardian/src-helpers"
@@ -8,29 +8,39 @@ export {
 	userFeedbackBrand,
 } from "@guardian/src-foundations/themes"
 
-interface UserFeedbackProps extends Props {
+interface UserFeedbackProps extends Props, HTMLAttributes<HTMLSpanElement> {
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 	children: ReactNode
 }
 
-const InlineError = ({ children, cssOverrides }: UserFeedbackProps) => (
+const InlineError = ({
+	children,
+	cssOverrides,
+	...props
+}: UserFeedbackProps) => (
 	<span
 		css={(theme) => [
 			inlineError(theme.userFeedback && theme),
 			cssOverrides,
 		]}
+		{...props}
 	>
 		<SvgAlert />
 		{children}
 	</span>
 )
 
-const InlineSuccess = ({ children, cssOverrides }: UserFeedbackProps) => (
+const InlineSuccess = ({
+	children,
+	cssOverrides,
+	...props
+}: UserFeedbackProps) => (
 	<span
 		css={(theme) => [
 			inlineSuccess(theme.userFeedback && theme),
 			cssOverrides,
 		]}
+		{...props}
 	>
 		<SvgTickRound />
 		{children}

--- a/src/core/foundations/README.md
+++ b/src/core/foundations/README.md
@@ -85,8 +85,7 @@ const label = css`
 
 ### [Focus Halo](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/24562a)
 
-This mixin provides a [clear focus state](https://zeroheight.com/2a1e5182b/p/08dc26/t/314e46) for
-elements that may receive keyboard focus.
+This mixin provides a [clear focus state](https://theguardian.design/2a1e5182b/p/08dc26-interaction-states/t/314e46) for elements that may receive keyboard focus.
 
 ```ts
 import { focusHalo } from "@guardian/src-foundations/accessibility"
@@ -96,4 +95,24 @@ const input = css`
     width: 200px;
     height: 44px;
 `
+```
+
+### [Description Id](https://theguardian.design/2a1e5182b/p/6691bb-accessibility/t/062b61)
+
+A function that takes the ID of an element and generates a new ID. This should be set as the
+ID of an element that describes the first element. The generated ID should also be passed to
+the [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attribute on the first element.
+
+```tsx
+import { descriptionId } from "@guardian/src-foundations/accessibility"
+
+const Form = () => {
+    const id = "first_name"
+    return (
+        <form>
+            <input id={id} type="text" aria-describedby={descriptionId(id)} />
+            <p class="error" id={descriptionId(id)} />
+        </form>
+    )
+}
 ```

--- a/src/core/foundations/src/accessibility/index.ts
+++ b/src/core/foundations/src/accessibility/index.ts
@@ -16,4 +16,6 @@ const focusHalo = `
 	}
 `
 
-export { visuallyHidden, focusHalo }
+const descriptionId = (id: string) => `${id}_description`
+
+export { visuallyHidden, focusHalo, descriptionId }


### PR DESCRIPTION
## What is the purpose of this change?

The [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute) attribute connects an element to an element that describes it (e.g. connecting a form field to an element containing an error message for that field). It would be useful to have a helper function that can generate a consistent element ID for a description element, given the ID of the element that is being described. This will avoid hardcoding ID suffixes in lots of places.

## What does this change?

-   add `descriptionId` function to generate an ID for a description element
-   consume `descriptionId` in Label component, to be passed down to UserFeedback
-   allow UserFeedback elements to pass props down to their builtin components

