### PR TITLE
Label brand theme

### DIFF
--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -4,6 +4,7 @@ import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
 import { descriptionId } from "@guardian/src-foundations/accessibility"
 import { labelText, optionalText, supportingText } from "./styles"
 import { Props } from "@guardian/src-helpers"
+export { labelDefault, labelBrand } from "@guardian/src-foundations/themes"
 
 interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement>, Props {
 	text: string
@@ -18,7 +19,7 @@ interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement>, Props {
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return (
-		<div css={(theme) => supportingText(theme.textInput && theme)}>
+		<div css={(theme) => supportingText(theme.label && theme)}>
 			{children}
 		</div>
 	)
@@ -37,12 +38,10 @@ const Label = ({
 }: LabelProps) => {
 	const contents = (
 		<>
-			<span css={(theme) => labelText(theme.textInput && theme)}>
+			<span css={(theme) => labelText(theme.label && theme)}>
 				{text}{" "}
 				{optional ? (
-					<span
-						css={(theme) => optionalText(theme.textInput && theme)}
-					>
+					<span css={(theme) => optionalText(theme.label && theme)}>
 						Optional
 					</span>
 				) : (

--- a/src/core/components/label/stories/default.tsx
+++ b/src/core/components/label/stories/default.tsx
@@ -1,8 +1,25 @@
 import React from "react"
-import { Label } from "../index"
+import { Label, labelBrand } from "../index"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
 export const defaultLight = () => <Label text="First name" />
 
 defaultLight.story = {
 	name: "default light",
+}
+
+export const defaultBlue = () => (
+	<ThemeProvider theme={labelBrand}>
+		<Label text="First name" />
+	</ThemeProvider>
+)
+
+defaultBlue.story = {
+	name: "default blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/components/label/stories/error.tsx
+++ b/src/core/components/label/stories/error.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import { Label } from "../index"
+import { Label, labelBrand } from "../index"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
 export const withErrorMessageLight = () => (
 	<Label text="First name" error="Enter your first name below" />
@@ -7,4 +9,19 @@ export const withErrorMessageLight = () => (
 
 withErrorMessageLight.story = {
 	name: `with error message light`,
+}
+
+export const withErrorMessageBlue = () => (
+	<ThemeProvider theme={labelBrand}>
+		<Label text="First name" error="Enter your first name below" />
+	</ThemeProvider>
+)
+
+withErrorMessageBlue.story = {
+	name: `with error message blue`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/components/label/stories/optional-error.tsx
+++ b/src/core/components/label/stories/optional-error.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import { Label } from "../index"
+import { Label, labelBrand } from "../index"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
 export const optionalWithErrorMessageLight = () => (
 	<Label
@@ -11,4 +13,23 @@ export const optionalWithErrorMessageLight = () => (
 
 optionalWithErrorMessageLight.story = {
 	name: `optional with error message light`,
+}
+
+export const optionalWithErrorMessageBlue = () => (
+	<ThemeProvider theme={labelBrand}>
+		<Label
+			text="Telephone number"
+			error="The number must have at least 11 digits"
+			optional={true}
+		/>
+	</ThemeProvider>
+)
+
+optionalWithErrorMessageBlue.story = {
+	name: `optional with error message blue`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/components/label/stories/optional.tsx
+++ b/src/core/components/label/stories/optional.tsx
@@ -1,8 +1,25 @@
 import React from "react"
-import { Label } from "../index"
+import { Label, labelBrand } from "../index"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
 export const optionalLight = () => <Label text="Middle name" optional={true} />
 
 optionalLight.story = {
 	name: "optional light",
+}
+
+export const optionalBlue = () => (
+	<ThemeProvider theme={labelBrand}>
+		<Label text="Middle name" optional={true} />
+	</ThemeProvider>
+)
+
+optionalBlue.story = {
+	name: "optional blue",
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/components/label/stories/success.tsx
+++ b/src/core/components/label/stories/success.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import { Label } from "../index"
+import { Label, labelBrand } from "../index"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
 export const withSuccessMessageLight = () => (
 	<Label text="Input Code" success="This code is valid" />
@@ -7,4 +9,19 @@ export const withSuccessMessageLight = () => (
 
 withSuccessMessageLight.story = {
 	name: `with success message light`,
+}
+
+export const withSuccessMessageBlue = () => (
+	<ThemeProvider theme={labelBrand}>
+		<Label text="Input Code" success="This code is valid" />
+	</ThemeProvider>
+)
+
+withSuccessMessageBlue.story = {
+	name: `with success message blue`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/components/label/stories/supporting.tsx
+++ b/src/core/components/label/stories/supporting.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import { Label } from "../index"
+import { Label, labelBrand } from "../index"
+import { ThemeProvider } from "emotion-theming"
+import { storybookBackgrounds } from "@guardian/src-helpers"
 
 export const withSupportingTextLight = () => (
 	<Label text="Email" supporting="alex@example.com" />
@@ -7,4 +9,19 @@ export const withSupportingTextLight = () => (
 
 withSupportingTextLight.story = {
 	name: `with supporting text light`,
+}
+
+export const withSupportingTextBlue = () => (
+	<ThemeProvider theme={labelBrand}>
+		<Label text="Email" supporting="alex@example.com" />
+	</ThemeProvider>
+)
+
+withSupportingTextBlue.story = {
+	name: `with supporting text blue`,
+	parameters: {
+		backgrounds: [
+			Object.assign({}, { default: true }, storybookBackgrounds.brand),
+		],
+	},
 }

--- a/src/core/foundations/src/themes/index.ts
+++ b/src/core/foundations/src/themes/index.ts
@@ -16,7 +16,7 @@ import { checkboxBrand, checkboxDefault } from "./checkbox"
 import { choiceCardDefault } from "./choice-card"
 import { footerBrand } from "./footer"
 import { inlineErrorBrand, inlineErrorDefault } from "./inline-error"
-import { labelDefault } from "./label"
+import { labelDefault, labelBrand } from "./label"
 import { linkBrand, linkDefault, linkBrandAlt } from "./link"
 import { radioBrand, radioDefault } from "./radio"
 import { textInputDefault } from "./text-input"
@@ -39,6 +39,7 @@ export const brand = {
 	...checkboxBrand,
 	...footerBrand,
 	...inlineErrorBrand,
+	...labelBrand,
 	...linkBrand,
 	...radioBrand,
 	...userFeedbackBrand,

--- a/src/core/foundations/src/themes/label.ts
+++ b/src/core/foundations/src/themes/label.ts
@@ -1,5 +1,9 @@
-import { text } from "@guardian/src-foundations/palette"
-import { userFeedbackDefault, UserFeedbackTheme } from "./user-feedback"
+import { text, brandText } from "@guardian/src-foundations/palette"
+import {
+	userFeedbackDefault,
+	userFeedbackBrand,
+	UserFeedbackTheme,
+} from "./user-feedback"
 
 export type LabelTheme = {
 	textLabel: string
@@ -21,4 +25,18 @@ export const labelDefault: {
 		textSuccess: text.success,
 	},
 	...userFeedbackDefault,
+}
+
+export const labelBrand: {
+	label: LabelTheme
+	userFeedback: UserFeedbackTheme
+} = {
+	label: {
+		textLabel: brandText.inputLabel,
+		textOptional: brandText.supporting,
+		textSupporting: brandText.supporting,
+		textError: brandText.error,
+		textSuccess: brandText.success,
+	},
+	...userFeedbackBrand,
 }


### PR DESCRIPTION
## What is the purpose of this change?

The checkbox will soon consume the label component, so label will need to support the brand theme.

## What does this change?

-   add brand theme for label to foundations
-   support brand theme in label component

## Screenshots

![Screenshot 2020-08-26 at 17 36 19](https://user-images.githubusercontent.com/5931528/91331530-c4399080-e7c2-11ea-8b48-9d8b3229a6c4.png)
![Screenshot 2020-08-26 at 17 36 27](https://user-images.githubusercontent.com/5931528/91331532-c4d22700-e7c2-11ea-9f51-7d1409ba19d5.png)
![Screenshot 2020-08-26 at 17 36 43](https://user-images.githubusercontent.com/5931528/91331537-c6035400-e7c2-11ea-847d-76c590fdd512.png)
![Screenshot 2020-08-26 at 17 36 38](https://user-images.githubusercontent.com/5931528/91331538-c6035400-e7c2-11ea-83f8-0f3c7b7f767e.png)
![Screenshot 2020-08-26 at 17 36 13](https://user-images.githubusercontent.com/5931528/91331540-c69bea80-e7c2-11ea-82b7-f278464e863c.png)
![Screenshot 2020-08-26 at 17 36 33](https://user-images.githubusercontent.com/5931528/91331536-c56abd80-e7c2-11ea-8bf9-29ee5dfaceb4.png)



## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)
