### PR TITLE
Widen stories glob

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
-	stories: ["../**/stories.tsx"],
+	stories: ["../**/*stories.tsx"],
 	addons: ["@storybook/addon-backgrounds", "@storybook/addon-viewport"],
 }


### PR DESCRIPTION
## What is the purpose of this change?

Some packages (such as label) expose multiple components. It's useful to split stories into separate modules so their stories can be developed in isolation.

## What does this change?

-   Widen stories glob to search for any filename that ends with `stories.tsx`

