### PR TITLE
Accept ReactNode children

### DIFF
--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -9,7 +9,7 @@ interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement>, Props {
 	supporting?: string
 	optional: boolean
 	cssOverrides?: SerializedStyles | SerializedStyles[]
-	children?: string
+	children?: ReactNode
 }
 interface LegendProps extends HTMLAttributes<HTMLLegendElement>, Props {
 	text: string


### PR DESCRIPTION
## What is the purpose of this change?

Currently Label only accepts string as children. It should accept any ReactNode

## What does this change?


- Allow Label component to accept any ReactNode as its children
