### PR TITLE
Eight lines of anything

### DIFF
--- a/src/editorial/web/components/lines/README.md
+++ b/src/editorial/web/components/lines/README.md
@@ -27,11 +27,10 @@ const Section = () => (
 
 **`"straight" | "dotted" | "squiggly"`** _= "straight"_
 
-The appearance of the lines
+The appearance of the lines.
 
 ### `count`
 
 **`4 | 8`** _= 4_
 
-How many lines appear. Note: this applies to the `straight` effect only.
-Other effects always have 4 lines.
+How many lines appear.

--- a/src/editorial/web/components/lines/dotted.ts
+++ b/src/editorial/web/components/lines/dotted.ts
@@ -1,11 +1,12 @@
 import { line } from "@guardian/src-foundations/palette"
+import { LineCount } from "."
 
 const dotRadius = 1
 const gridSize = 3
 
-export const height = (count: 4 | 8): number => gridSize * count
+export const height = (count: LineCount): number => gridSize * count
 
-const dottedSvg = (count: 4 | 8): string => {
+const dottedSvg = (count: LineCount): string => {
 	const svg = [
 		`<svg xmlns="http://www.w3.org/2000/svg" ` +
 			`width="${gridSize}" height="${height(count)}" ` +
@@ -25,5 +26,5 @@ const dottedSvg = (count: 4 | 8): string => {
 	return encodeURIComponent(svg.join())
 }
 
-export const dottedImage = (count: 4 | 8) =>
+export const dottedImage = (count: LineCount) =>
 	`data:image/svg+xml,${dottedSvg(count)}`

--- a/src/editorial/web/components/lines/dotted.ts
+++ b/src/editorial/web/components/lines/dotted.ts
@@ -2,23 +2,28 @@ import { line } from "@guardian/src-foundations/palette"
 
 const dotRadius = 1
 const gridSize = 3
-const count = 4
 
-export const height = gridSize * count
+export const height = (count: 4 | 8): number => gridSize * count
 
-const svg = [
-	`<svg width="${gridSize}" height="${height}" viewBox="0 0 ${gridSize} ${height}" xmlns="http://www.w3.org/2000/svg">`,
-]
+const dottedSvg = (count: 4 | 8): string => {
+	const svg = [
+		`<svg xmlns="http://www.w3.org/2000/svg" ` +
+			`width="${gridSize}" height="${height(count)}" ` +
+			`viewBox="0 0 ${gridSize} ${height(count)}" >`,
+	]
 
-for (let offset = gridSize / 2; offset < height; offset += gridSize) {
-	svg.push(
-		`<circle fill="${line.primary}"
-		cx="${gridSize / 2}" cy="${offset}" r="${dotRadius}" />`,
-	)
+	for (let index = 1; index < count; index++) {
+		svg.push(
+			`<circle fill="${line.primary}" ` +
+				`cx="${gridSize / 2}" ` +
+				`cy="${gridSize * (index + 1 / 2)}" ` +
+				`r="${dotRadius}" />`,
+		)
+	}
+
+	svg.push(`</svg>`)
+	return encodeURIComponent(svg.join())
 }
 
-svg.push(`</svg>`)
-
-const dottedSvg = encodeURIComponent(svg.join())
-
-export const dottedImage = `data:image/svg+xml,${dottedSvg}`
+export const dottedImage = (count: 4 | 8) =>
+	`data:image/svg+xml,${dottedSvg(count)}`

--- a/src/editorial/web/components/lines/dotted.ts
+++ b/src/editorial/web/components/lines/dotted.ts
@@ -13,11 +13,11 @@ const dottedSvg = (count: LineCount): string => {
 			`viewBox="0 0 ${gridSize} ${height(count)}" >`,
 	]
 
-	for (let index = 1; index < count; index++) {
+	for (let index = 1; index <= count; index++) {
 		svg.push(
 			`<circle fill="${line.primary}" ` +
 				`cx="${gridSize / 2}" ` +
-				`cy="${gridSize * (index + 1 / 2)}" ` +
+				`cy="${gridSize * (index - 1 / 2)}" ` +
 				`r="${dotRadius}" />`,
 		)
 	}

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -17,10 +17,10 @@ interface LinesProps extends Props {
 
 export const Lines = ({ effect = "straight", count = 4 }: LinesProps) => {
 	if (effect === "squiggly") {
-		return <div css={squigglyLines} />
+		return <div css={squigglyLines(count)} />
 	}
 	if (effect === "dotted") {
-		return <div css={dottedLines} />
+		return <div css={dottedLines(count)} />
 	}
 	return <div css={[straightLines, count === 4 ? fourLines : eightLines]} />
 }

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -10,9 +10,11 @@ import {
 
 type LineEffectType = "squiggly" | "dotted" | "straight"
 
+export type LineCount = 4 | 8
+
 interface LinesProps extends Props {
 	effect?: LineEffectType
-	count?: 4 | 8
+	count?: LineCount
 }
 
 export const Lines = ({ effect = "straight", count = 4 }: LinesProps) => {

--- a/src/editorial/web/components/lines/squiggly.ts
+++ b/src/editorial/web/components/lines/squiggly.ts
@@ -3,11 +3,11 @@ import { line } from "@guardian/src-foundations/palette"
 const wavelength = 12
 const amplitude = 3
 const thickness = 1
-const count = 4
 const gap = 3
 const squiggliness = wavelength / 8
 
-export const height = thickness + gap * Math.max(count, 1)
+export const height = (count: 4 | 8): number =>
+	thickness + gap * Math.max(count, 1)
 
 const d = [
 	`M 0 ${thickness / 2}`,
@@ -18,16 +18,17 @@ const d = [
 	`t 12 0`,
 ].join(" ")
 
-const repeatedLines = []
-for (let index = 1; index < count; index++) {
-	repeatedLines.push(`<use y="${gap * index}" xlink:href="#squiggle" />`)
-}
+const squigglySvg = (count: 4 | 8): string => {
+	const repeatedLines = []
+	for (let index = 1; index < count; index++) {
+		repeatedLines.push(`<use y="${gap * index}" xlink:href="#squiggle" />`)
+	}
 
-const squigglySvg = encodeURIComponent(`
-<svg
-	xmlns="http://www.w3.org/2000/svg" width="${wavelength}" height="${height}"
-	viewBox="0 0 ${wavelength} ${height}"
+	return encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg"
 	xmlns:xlink="http://www.w3.org/1999/xlink"
+	width="${wavelength}" height="${height(count)}"
+	viewBox="0 0 ${wavelength} ${height(count)}"
 >
 	<g stroke-width="${thickness}" stroke="${line.primary}" fill="none">
 		<path id="squiggle" d="${d}" />
@@ -35,5 +36,7 @@ const squigglySvg = encodeURIComponent(`
 	</g>
 </svg>
 `)
+}
 
-export const squigglyImage = `data:image/svg+xml;utf-8,${squigglySvg}`
+export const squigglyImage = (count: 4 | 8 = 4): string =>
+	`data:image/svg+xml;utf-8,${squigglySvg(count)}`

--- a/src/editorial/web/components/lines/squiggly.ts
+++ b/src/editorial/web/components/lines/squiggly.ts
@@ -1,4 +1,5 @@
 import { line } from "@guardian/src-foundations/palette"
+import { LineCount } from "."
 
 const wavelength = 12
 const amplitude = 3
@@ -6,7 +7,7 @@ const thickness = 1
 const gap = 3
 const squiggliness = wavelength / 8
 
-export const height = (count: 4 | 8): number =>
+export const height = (count: LineCount): number =>
 	thickness + gap * Math.max(count, 1)
 
 const d = [
@@ -18,7 +19,7 @@ const d = [
 	`t 12 0`,
 ].join(" ")
 
-const squigglySvg = (count: 4 | 8): string => {
+const squigglySvg = (count: LineCount): string => {
 	const repeatedLines = []
 	for (let index = 1; index < count; index++) {
 		repeatedLines.push(`<use y="${gap * index}" xlink:href="#squiggle" />`)
@@ -38,5 +39,5 @@ const squigglySvg = (count: 4 | 8): string => {
 `)
 }
 
-export const squigglyImage = (count: 4 | 8 = 4): string =>
+export const squigglyImage = (count: LineCount = 4): string =>
 	`data:image/svg+xml;utf-8,${squigglySvg(count)}`

--- a/src/editorial/web/components/lines/stories.tsx
+++ b/src/editorial/web/components/lines/stories.tsx
@@ -12,8 +12,14 @@ fourStraightLines.story = { name: "four straight lines" }
 export const eightStraightLines = () => <Lines count={8} />
 eightStraightLines.story = { name: "eight straight lines" }
 
-export const dottedLines = () => <Lines effect="dotted" />
-dottedLines.story = { name: "dotted lines" }
+export const fourDottedLines = () => <Lines effect="dotted" />
+fourDottedLines.story = { name: "four dotted lines" }
 
-export const squigglyLines = () => <Lines effect="squiggly" />
-squigglyLines.story = { name: "squiggly lines" }
+export const eightDottedLines = () => <Lines count={8} effect="dotted" />
+eightDottedLines.story = { name: "eight dotted lines" }
+
+export const fourSquigglyLines = () => <Lines effect="squiggly" />
+fourSquigglyLines.story = { name: "four squiggly lines" }
+
+export const eightSquigglyLines = () => <Lines count={8} effect="squiggly" />
+eightSquigglyLines.story = { name: "eight squiggly lines" }

--- a/src/editorial/web/components/lines/styles.ts
+++ b/src/editorial/web/components/lines/styles.ts
@@ -28,14 +28,14 @@ export const eightLines = css`
 	height: calc(${lineGap} * 7 + 1px);
 `
 
-export const squigglyLines = css`
-	background-image: url(${squigglyImage});
+export const squigglyLines = (count: 4 | 8) => css`
+	background-image: url(${squigglyImage(count)});
 	background-repeat: repeat-x;
 	background-position: left;
-	height: ${squigglyImageHeight}px;
+	height: ${squigglyImageHeight(count)}px;
 `
 
-export const dottedLines = css`
-	background-image: url(${dottedImage});
-	height: ${dottedImageHeight}px;
+export const dottedLines = (count: 4 | 8) => css`
+	background-image: url(${dottedImage(count)});
+	height: ${dottedImageHeight(count)}px;
 `

--- a/src/editorial/web/components/lines/styles.ts
+++ b/src/editorial/web/components/lines/styles.ts
@@ -3,6 +3,7 @@ import { squigglyImage, height as squigglyImageHeight } from "./squiggly"
 import { dottedImage, height as dottedImageHeight } from "./dotted"
 import { line } from "@guardian/src-foundations/palette"
 import { remSpace } from "@guardian/src-foundations"
+import { LineCount } from "."
 
 const lineGap = remSpace[1]
 
@@ -28,14 +29,14 @@ export const eightLines = css`
 	height: calc(${lineGap} * 7 + 1px);
 `
 
-export const squigglyLines = (count: 4 | 8) => css`
+export const squigglyLines = (count: LineCount) => css`
 	background-image: url(${squigglyImage(count)});
 	background-repeat: repeat-x;
 	background-position: left;
 	height: ${squigglyImageHeight(count)}px;
 `
 
-export const dottedLines = (count: 4 | 8) => css`
+export const dottedLines = (count: LineCount) => css`
 	background-image: url(${dottedImage(count)});
 	height: ${dottedImageHeight(count)}px;
 `


### PR DESCRIPTION
## What is the purpose of this change?

Why stick to four when you can have eight? This is a proof of concept to make these SVG. Follow-up of #505 and #302.

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

## What does this change?

- Allow eight dotted lines.
- Allow eight squiggly lines.
- Removed some of the spaces in the SVG, making for an even smaller source.

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

![image](https://user-images.githubusercontent.com/76776/92242092-30994b80-eeb7-11ea-893e-6b08b18186fa.png)

![image](https://user-images.githubusercontent.com/76776/92242127-3b53e080-eeb7-11ea-8a21-d1a93cdb366f.png)

**After**

![image](https://user-images.githubusercontent.com/76776/92450508-7144dd80-f1b3-11ea-830b-bf75ca319bc5.png)

![image](https://user-images.githubusercontent.com/76776/92241883-dd26fd80-eeb6-11ea-9d8b-63fa50c93ad8.png)


## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [X] Tested at all breakpoints
-   [ ] Tested with with long text
-   [X] Stretched to fill a wide container

### Documentation

-   [X] Full API surface area is documented in the README
-   [X] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

Sometimes it can appear like there is one line extra or missing. If it does, let your eyes rest for a while, then check again. (Thanks @JamieB-gu / 430ebc4)
