### PR TITLE
NPM Example In Editorial Lines README

### DIFF
--- a/src/editorial/web/components/lines/README.md
+++ b/src/editorial/web/components/lines/README.md
@@ -7,6 +7,10 @@
 ```sh
 $ yarn add @guardian/src-ed-lines @guardian/src-foundations
 ```
+or
+```sh
+$ npm i @guardian/src-ed-lines @guardian/src-foundations
+```
 
 ## Use
 


### PR DESCRIPTION
## What is the purpose of this change?

Gives an example of how to add the Editorial Lines package if you're using `npm`.

## What does this change?

- Add npm example to ed-lines README
