### PR TITLE
add special report 800

### DIFF
--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -112,6 +112,7 @@ export const specialReport = {
 	300: colors.grays[12],
 	400: colors.grays[13],
 	500: colors.grays[14],
+	800: colors.grays[16],
 }
 
 // Deprecated - please do not use

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -124,6 +124,7 @@ const colors = {
 		"#63717A", //specialReport-400
 		"#ABC2C9", //specialReport-500
 		"#33393D", //dynamo-400
+		"#EFF1F2", //specialReport-800
 	],
 }
 


### PR DESCRIPTION
## What is the purpose of this change?
I started adding support for special report articles in apps-rendering and noticed one of the required colours was not present in source. It's documented here https://theguardian.design/2a1e5182b/p/492a30-light-palette so this PR adds it.

## What does this change?

-   Adds a new grey colour
-   Adds a new special report colour

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

grays[15] is due to be deprecated soon and I thought about replacing that colour, but I think this is a safer addition.