### PR TITLE
Use alert triangle in user feedback

### DIFF
--- a/src/core/components/inline-error/index.tsx
+++ b/src/core/components/inline-error/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react"
 import { SerializedStyles } from "@emotion/core"
-import { SvgAlert } from "@guardian/src-icons"
+import { SvgAlertTriangle } from "@guardian/src-icons"
 import { Props } from "@guardian/src-helpers"
 import { inlineError } from "./styles"
 export {
@@ -17,7 +17,7 @@ const InlineError = ({ children, cssOverrides }: InlineErrorProps) => (
 	<span
 		css={(theme) => [inlineError(theme.inlineError && theme), cssOverrides]}
 	>
-		<SvgAlert />
+		<SvgAlertTriangle />
 		{children}
 	</span>
 )

--- a/src/core/components/user-feedback/index.tsx
+++ b/src/core/components/user-feedback/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, HTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/css"
-import { SvgAlert, SvgTickRound } from "@guardian/src-icons"
+import { SvgAlertTriangle, SvgTickRound } from "@guardian/src-icons"
 import { Props } from "@guardian/src-helpers"
 import { inlineError, inlineSuccess } from "./styles"
 export {
@@ -25,7 +25,7 @@ const InlineError = ({
 		]}
 		{...props}
 	>
-		<SvgAlert />
+		<SvgAlertTriangle />
 		{children}
 	</span>
 )


### PR DESCRIPTION
## What is the purpose of this change?

User Feedback displays an alert triangle icon next to the error message. We should use the new name for this icon, as the old name will be repurposed in v3.0.0 (see #536)

## What does this change?

-   use new alert traingle name in user feedback
-   use new alert traingle name in inline error

