### PR TITLE
Don't use flexbox inside a fieldset

### DIFF
--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -87,14 +87,15 @@ const LabelText = ({
 	children: ReactNode
 }) => {
 	return (
-		<div
+		<span
 			css={(theme) => [
 				hasSupportingText ? labelTextWithSupportingText : "",
 				labelText(theme.radio && theme),
 			]}
+			className="src-radio-label-text"
 		>
 			{children}
-		</div>
+		</span>
 	)
 }
 

--- a/src/core/components/radio/stories/radio-group/horizontal.tsx
+++ b/src/core/components/radio/stories/radio-group/horizontal.tsx
@@ -8,7 +8,7 @@ const horizontal = () => (
 	</RadioGroup>
 )
 horizontal.story = {
-	name: "orientation horizontal",
+	name: "horizontal light",
 }
 
 export { horizontal }

--- a/src/core/components/radio/stories/radio-group/legend.tsx
+++ b/src/core/components/radio/stories/radio-group/legend.tsx
@@ -40,3 +40,18 @@ legendBlue.story = {
 		],
 	},
 }
+
+export const legendHorizontal = () => (
+	<RadioGroup
+		orientation="horizontal"
+		name="yes-or-no"
+		label="Do you live in the United Kingdom?"
+	>
+		<Radio value="yes" label="Yes" />
+		<Radio value="no" label="No" defaultChecked={true} />
+	</RadioGroup>
+)
+
+legendHorizontal.story = {
+	name: `legend horizontal light`,
+}

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -108,11 +108,22 @@ export const supportingText = ({
 	color: ${radio.textLabelSupporting};
 `
 
+/*
+TODO: Chrome <86 doesn't allow us to use display:flex on fieldsets.
+The display:block and vertical-align:middle here are a workaround
+which can be replaced by flex-direction:row when the issue is fixed
+https://bugs.chromium.org/p/chromium/issues/detail?id=375693
+*/
 export const horizontal = css`
-	flex-direction: row;
+	display: block;
 
 	label {
+		display: inline-flex;
 		margin-right: ${space[5]}px;
+	}
+	input,
+	.src-radio-label-text {
+		vertical-align: middle;
 	}
 `
 export const vertical = css`


### PR DESCRIPTION
## What is the purpose of this change?

There is a (recently fixed) [bug in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=375693) that prevents flexbox working correctly inside a fieldset. This manifests as an inability to switch the orientation of radio controls from vertical to horizontal using the `flex-direction` property.

Until this fix is rolled out and the next version of Chrome used more widely, we should find an alternative approach to layout within radio fieldsets.

## What does this change?

-   use `display: block` and `vertical-align: middle` instead of flex for layout

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

![Screenshot 2020-09-22 at 15 00 14](https://user-images.githubusercontent.com/5931528/93892335-56f71d80-fce4-11ea-8098-a41fe0632b0e.png)

**After**

![Screenshot 2020-09-22 at 14 59 41](https://user-images.githubusercontent.com/5931528/93892344-59597780-fce4-11ea-95b2-1c641bb7f985.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)

### Cross browser and device testing

-   [ ] Tested with touch screen device

