### PR TITLE
Clean up stacks

### DIFF
--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -26,6 +26,6 @@ const Wrapper = () => (
 
 ### `space`
 
-**`1 | 2 | 3 | 4 | 5`**
+**`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
 
 Units of space between stack items (one unit is 4px)

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -1,41 +1,20 @@
 import React, { HTMLAttributes, ReactNode } from "react"
 import { SerializedStyles } from "@emotion/core"
-import {
-	stack,
-	stackSpace1,
-	stackSpace2,
-	stackSpace3,
-	stackSpace4,
-	stackSpace5,
-	stackSpace6,
-	stackSpace9,
-	stackSpace12,
-	stackSpace24,
-} from "./styles"
+import { stack, stackSpace } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
+export type StackSpace = 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24
+
 interface StackProps extends HTMLAttributes<HTMLDivElement>, Props {
-	space?: 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24
+	space?: StackSpace
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 	children: ReactNode
-}
-
-const stackSpaceMap = {
-	1: stackSpace1,
-	2: stackSpace2,
-	3: stackSpace3,
-	4: stackSpace4,
-	5: stackSpace5,
-	6: stackSpace6,
-	9: stackSpace9,
-	12: stackSpace12,
-	24: stackSpace24,
 }
 
 const Stack = ({ cssOverrides, children, space, ...props }: StackProps) => {
 	return (
 		<div
-			css={[stack, space ? stackSpaceMap[space] : "", cssOverrides]}
+			css={[stack, space ? stackSpace(space) : "", cssOverrides]}
 			{...props}
 		>
 			{children}

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -14,7 +14,7 @@ interface StackProps extends HTMLAttributes<HTMLDivElement>, Props {
 const Stack = ({ cssOverrides, children, space, ...props }: StackProps) => {
 	return (
 		<div
-			css={[stack, space ? stackSpace(space) : "", cssOverrides]}
+			css={[stack, space ? stackSpace[space] : "", cssOverrides]}
 			{...props}
 		>
 			{children}

--- a/src/core/components/layout/stories/stack/default.tsx
+++ b/src/core/components/layout/stories/stack/default.tsx
@@ -81,3 +81,51 @@ export const space5 = () => (
 space5.story = {
 	name: "space 5",
 }
+
+export const space6 = () => (
+	<Stack space={6}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Stack>
+)
+
+space6.story = {
+	name: "space 6",
+}
+
+export const space9 = () => (
+	<Stack space={9}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Stack>
+)
+
+space9.story = {
+	name: "space 9",
+}
+
+export const space12 = () => (
+	<Stack space={12}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Stack>
+)
+
+space12.story = {
+	name: "space 12",
+}
+
+export const space24 = () => (
+	<Stack space={24}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Stack>
+)
+
+space24.story = {
+	name: "space 24",
+}

--- a/src/core/components/layout/styles.ts
+++ b/src/core/components/layout/styles.ts
@@ -7,52 +7,8 @@ export const stack = css`
 	}
 `
 
-export const stackSpace1 = css`
+export const stackSpace = (space) => css`
 	& > * + * {
-		margin-top: ${space[1]}px;
-	}
-`
-export const stackSpace2 = css`
-	& > * + * {
-		margin-top: ${space[2]}px;
-	}
-`
-export const stackSpace3 = css`
-	& > * + * {
-		margin-top: ${space[3]}px;
-	}
-`
-export const stackSpace4 = css`
-	& > * + * {
-		margin-top: ${space[4]}px;
-	}
-`
-export const stackSpace5 = css`
-	& > * + * {
-		margin-top: ${space[5]}px;
-	}
-`
-
-export const stackSpace6 = css`
-	& > * + * {
-		margin-top: ${space[6]}px;
-	}
-`
-
-export const stackSpace9 = css`
-	& > * + * {
-		margin-top: ${space[9]}px;
-	}
-`
-
-export const stackSpace12 = css`
-	& > * + * {
-		margin-top: ${space[12]}px;
-	}
-`
-
-export const stackSpace24 = css`
-	& > * + * {
-		margin-top: ${space[24]}px;
+		margin-top: ${space[space]}px;
 	}
 `

--- a/src/core/components/layout/styles.ts
+++ b/src/core/components/layout/styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@emotion/core"
 import { space } from "@guardian/src-foundations"
+import { StackSpace } from "."
 
 export const stack = css`
 	& > * {
@@ -7,8 +8,8 @@ export const stack = css`
 	}
 `
 
-export const stackSpace = (space) => css`
+export const stackSpace = (number: StackSpace) => css`
 	& > * + * {
-		margin-top: ${space[space]}px;
+		margin-top: ${space[number]}px;
 	}
 `

--- a/src/core/components/layout/styles.ts
+++ b/src/core/components/layout/styles.ts
@@ -1,4 +1,4 @@
-import { css } from "@emotion/core"
+import { css, SerializedStyles } from "@emotion/core"
 import { space } from "@guardian/src-foundations"
 import { StackSpace } from "."
 
@@ -8,8 +8,30 @@ export const stack = css`
 	}
 `
 
-export const stackSpace = (number: StackSpace) => css`
+const stackSpaceStyle = (number: StackSpace) => css`
 	& > * + * {
 		margin-top: ${space[number]}px;
 	}
 `
+
+export const stackSpace: {
+	1: SerializedStyles
+	2: SerializedStyles
+	3: SerializedStyles
+	4: SerializedStyles
+	5: SerializedStyles
+	6: SerializedStyles
+	9: SerializedStyles
+	12: SerializedStyles
+	24: SerializedStyles
+} = {
+	1: stackSpaceStyle(1),
+	2: stackSpaceStyle(2),
+	3: stackSpaceStyle(3),
+	4: stackSpaceStyle(4),
+	5: stackSpaceStyle(5),
+	6: stackSpaceStyle(6),
+	9: stackSpaceStyle(9),
+	12: stackSpaceStyle(12),
+	24: stackSpaceStyle(24),
+}


### PR DESCRIPTION
## What is the purpose of this change?

Follow-up on #539, to clean some of the usage.

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Replace named SerialisedStyles with a function taking a space parameter
-   Use that this new `stackSpace` function to prevent repetition

## Screenshots

No visual changes, but added the unused spaces 6, 9, 12, and 24.

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [X] Full API surface area is documented in the README
-   [X] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
