### PR TITLE
Add container component

### DIFF
--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -8,7 +8,27 @@
 $ yarn add @guardian/src-layout
 ```
 
-## Use
+## Container
+
+```tsx
+import { Container } from "@guardian/src-layout"
+
+const Wrapper = () => (
+    <Container>
+        <div css={contents}>Contents</div>
+    </Container>
+)
+```
+
+### Props
+
+#### `border`
+
+**`boolean`** _= false_
+
+Whether to show a border to the left and right of the Container
+
+## Stack
 
 ```tsx
 import { Stack } from "@guardian/src-layout"
@@ -22,9 +42,9 @@ const Wrapper = () => (
 )
 ```
 
-## Stack Props
+### Props
 
-### `space`
+#### `space`
 
 **`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
 

--- a/src/core/components/layout/components/container/container.tsx
+++ b/src/core/components/layout/components/container/container.tsx
@@ -1,0 +1,31 @@
+import React, { HTMLAttributes, ReactNode } from "react"
+import { SerializedStyles } from "@emotion/core"
+import { container, containerBorder } from "./styles"
+import { Props } from "@guardian/src-helpers"
+
+interface Container extends HTMLAttributes<HTMLDivElement>, Props {
+	border?: boolean
+	cssOverrides?: SerializedStyles | SerializedStyles[]
+	children: ReactNode
+}
+
+const Container = ({
+	border = false,
+	cssOverrides,
+	children,
+	...props
+}: Container) => {
+	return (
+		<div
+			css={[container, border ? containerBorder : "", cssOverrides]}
+			{...props}
+		>
+			{children}
+		</div>
+	)
+}
+const defaultProps = {}
+
+Container.defaultProps = { ...defaultProps }
+
+export { Container }

--- a/src/core/components/layout/components/container/styles.ts
+++ b/src/core/components/layout/components/container/styles.ts
@@ -1,0 +1,44 @@
+import { css } from "@emotion/core"
+import { breakpoints, space } from "@guardian/src-foundations"
+import { from } from "@guardian/src-foundations/mq"
+import { border } from "@guardian/src-foundations/palette"
+
+export const container = css`
+	margin: 0 auto;
+	box-sizing: border-box;
+	padding: 0 ${space[3]}px;
+	width: 100%;
+	${from.tablet} {
+		padding: 0 ${space[5]}px;
+		width: ${breakpoints.tablet}px;
+	}
+	${from.desktop} {
+		width: ${breakpoints.desktop}px;
+	}
+	${from.leftCol} {
+		width: ${breakpoints.leftCol}px;
+	}
+	${from.wide} {
+		width: ${breakpoints.wide}px;
+	}
+`
+
+export const containerBorder = css`
+	border-style: solid;
+	border-color: ${border.secondary};
+	border-width: 0;
+
+	${from.tablet} {
+		width: ${breakpoints.tablet + 2}px;
+		border-width: 0 1px 0 1px;
+	}
+	${from.desktop} {
+		width: ${breakpoints.desktop + 2}px;
+	}
+	${from.leftCol} {
+		width: ${breakpoints.leftCol + 2}px;
+	}
+	${from.wide} {
+		width: ${breakpoints.wide + 2}px;
+	}
+`

--- a/src/core/components/layout/container.stories.tsx
+++ b/src/core/components/layout/container.stories.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import { Container } from "./index"
+
+const gridStoryWrapper = (storyFn: () => JSX.Element) => {
+	// override 8px margin applied globally to every preview body
+	return <div style={{ margin: "0 -8px" }}>{storyFn()}</div>
+}
+
+export default {
+	title: "Container",
+	component: Container,
+	decorators: [gridStoryWrapper],
+}
+
+export * from "./stories/container/default"

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -1,1 +1,2 @@
+export { Container } from "./components/container/container"
 export { Stack } from "./components/stack/stack"

--- a/src/core/components/layout/stories/container/default.tsx
+++ b/src/core/components/layout/stories/container/default.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { css } from "@emotion/core"
+import { Container } from "../../index"
+import { textSans } from "@guardian/src-foundations/typography"
+import { sport } from "@guardian/src-foundations/palette"
+
+const contents = css`
+	${textSans.medium()};
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: ${sport[600]};
+	margin: 0;
+	height: 300px;
+`
+
+export const defaultLight = () => (
+	<Container>
+		<p css={contents}>Container contents</p>
+	</Container>
+)
+
+defaultLight.story = {
+	name: "default light",
+}
+
+export const withBorder = () => (
+	<Container border={true}>
+		<p css={contents}>Container contents</p>
+	</Container>
+)
+
+withBorder.story = {
+	name: "with border",
+}


### PR DESCRIPTION
## What is the purpose of this change?

Based on discussions in #526 and following on from #539, it would be useful to provide a series of single-purpose layout components that allow developers to achieve common layout patterns. 

The Container centres the page content and applies a width that corresponds to the grid at the current breakpoint.

## What does this change?

-   Add Container component

## Screenshots

**No border**

```tsx
<Container>
  <article></article>
</Container>
```

![Screenshot 2020-09-28 at 15 57 12](https://user-images.githubusercontent.com/5931528/94448848-4db5f700-01a3-11eb-8e7a-bc3d7d3616c4.png)

**With border**

```tsx
<Container border={true}>
  <article></article>
</Container>
```
![Screenshot 2020-09-28 at 15 57 02](https://user-images.githubusercontent.com/5931528/94448845-4d1d6080-01a3-11eb-8f29-b1bcc08da23f.png)


## Checklist
### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [ ] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook
