### PR TITLE
Add an Inline component

### DIFF
--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -49,3 +49,25 @@ const Wrapper = () => (
 **`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
 
 Units of space between stack items (one unit is 4px)
+
+## Inline
+
+```tsx
+import { Inline } from "@guardian/src-layout"
+
+const Wrapper = () => (
+    <Inline>
+        <div css={contents}>Item 1</div>
+        <div css={contents}>Item 2</div>
+        <div css={contents}>Item 3</div>
+    </Inline>
+)
+```
+
+### Props
+
+#### `space`
+
+**`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
+
+Units of space between inline items (one unit is 4px)

--- a/src/core/components/layout/components/inline/inline.tsx
+++ b/src/core/components/layout/components/inline/inline.tsx
@@ -1,0 +1,29 @@
+import React, { HTMLAttributes, ReactNode } from "react"
+import { SerializedStyles } from "@emotion/core"
+import { inline, inlineSpace } from "./styles"
+import { Props } from "@guardian/src-helpers"
+
+export type InlineSpace = 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24
+
+interface InlineProps extends HTMLAttributes<HTMLDivElement>, Props {
+	space?: InlineSpace
+	cssOverrides?: SerializedStyles | SerializedStyles[]
+	children: ReactNode
+}
+
+const Inline = ({ cssOverrides, children, space, ...props }: InlineProps) => {
+	return (
+		<div
+			css={[inline, space ? inlineSpace[space] : "", cssOverrides]}
+			{...props}
+		>
+			{children}
+		</div>
+	)
+}
+
+const defaultProps = {}
+
+Inline.defaultProps = { ...defaultProps }
+
+export { Inline }

--- a/src/core/components/layout/components/inline/styles.ts
+++ b/src/core/components/layout/components/inline/styles.ts
@@ -1,0 +1,35 @@
+import { css, SerializedStyles } from "@emotion/core"
+import { space } from "@guardian/src-foundations"
+import { InlineSpace } from "./inline"
+
+export const inline = css`
+	display: flex;
+`
+
+const inlineSpaceStyle = (number: InlineSpace) => css`
+	& > * + * {
+		margin-left: ${space[number]}px;
+	}
+`
+
+export const inlineSpace: {
+	1: SerializedStyles
+	2: SerializedStyles
+	3: SerializedStyles
+	4: SerializedStyles
+	5: SerializedStyles
+	6: SerializedStyles
+	9: SerializedStyles
+	12: SerializedStyles
+	24: SerializedStyles
+} = {
+	1: inlineSpaceStyle(1),
+	2: inlineSpaceStyle(2),
+	3: inlineSpaceStyle(3),
+	4: inlineSpaceStyle(4),
+	5: inlineSpaceStyle(5),
+	6: inlineSpaceStyle(6),
+	9: inlineSpaceStyle(9),
+	12: inlineSpaceStyle(12),
+	24: inlineSpaceStyle(24),
+}

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -1,2 +1,3 @@
 export { Container } from "./components/container/container"
 export { Stack } from "./components/stack/stack"
+export { Inline } from "./components/inline/inline"

--- a/src/core/components/layout/inline.stories.tsx
+++ b/src/core/components/layout/inline.stories.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import { Inline } from "./index"
+
+const gridStoryWrapper = (storyFn: () => JSX.Element) => {
+	// override 8px margin applied globally to every preview body
+	return <div style={{ margin: "0 -8px" }}>{storyFn()}</div>
+}
+
+export default {
+	title: "Inline",
+	component: Inline,
+	decorators: [gridStoryWrapper],
+}
+
+export * from "./stories/inline/default"

--- a/src/core/components/layout/stories/inline/default.tsx
+++ b/src/core/components/layout/stories/inline/default.tsx
@@ -1,0 +1,131 @@
+import React from "react"
+import { css } from "@emotion/core"
+import { Inline } from "../../index"
+import { textSans } from "@guardian/src-foundations/typography"
+import { sport } from "@guardian/src-foundations/palette"
+
+const contents = css`
+	${textSans.medium()};
+	text-align: center;
+	background-color: ${sport[600]};
+`
+
+export const noSpace = () => (
+	<Inline>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+noSpace.story = {
+	name: "no space",
+}
+
+export const space1 = () => (
+	<Inline space={1}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space1.story = {
+	name: "space 1",
+}
+
+export const space2 = () => (
+	<Inline space={2}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space2.story = {
+	name: "space 2",
+}
+
+export const space3 = () => (
+	<Inline space={3}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space3.story = {
+	name: "space 3",
+}
+
+export const space4 = () => (
+	<Inline space={4}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space4.story = {
+	name: "space 4",
+}
+
+export const space5 = () => (
+	<Inline space={5}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space5.story = {
+	name: "space 5",
+}
+
+export const space6 = () => (
+	<Inline space={6}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space6.story = {
+	name: "space 6",
+}
+
+export const space9 = () => (
+	<Inline space={9}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space9.story = {
+	name: "space 9",
+}
+
+export const space12 = () => (
+	<Inline space={12}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space12.story = {
+	name: "space 12",
+}
+
+export const space24 = () => (
+	<Inline space={24}>
+		<div css={contents}>Item 1</div>
+		<div css={contents}>Item 2</div>
+		<div css={contents}>Item 3</div>
+	</Inline>
+)
+
+space24.story = {
+	name: "space 24",
+}


### PR DESCRIPTION
#67  What is the purpose of this change?

This is for elements to sit next to each other with even spacing, for example:

![image](https://user-images.githubusercontent.com/9820960/94568507-794ce600-0264-11eb-8bee-2fe200a0b509.png)

This is part of addressing Issue #526

## Checklist

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
