### PR TITLE
Fix typo README: prominently

### DIFF
--- a/src/core/components/accordion/README.md
+++ b/src/core/components/accordion/README.md
@@ -47,4 +47,4 @@ _Note: the up or down chevron icon always appears._
 **`string`**
 
 A line of text to summarise the information that lies within the expanded state.
-Appears in the collapsed state, as well as prominantly at the top of the expanded state.
+Appears in the collapsed state, as well as prominently at the top of the expanded state.


### PR DESCRIPTION
## What is the purpose of this change?

Fixing a typo in readme

## What does this change?

- The spelling of the word prominently in readme
