### PR TITLE
Add hide label props

### DIFF
--- a/src/core/components/checkbox/README.md
+++ b/src/core/components/checkbox/README.md
@@ -60,6 +60,12 @@ Gets passed as the name attribute for each checkbox
 
 Appears as a legend at the top of the checkbox group
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Visually hides the label.
+
 ### `supporting`
 
 **`string`**

--- a/src/core/components/checkbox/index.tsx
+++ b/src/core/components/checkbox/index.tsx
@@ -29,6 +29,7 @@ interface CheckboxGroupProps extends Props {
 	id?: string
 	name: string
 	label?: string
+	hideLabel: boolean
 	supporting?: string
 	error?: string
 	children: JSX.Element | JSX.Element[]
@@ -39,13 +40,14 @@ const CheckboxGroup = ({
 	id,
 	name,
 	label,
+	hideLabel,
 	supporting,
 	error,
 	cssOverrides,
 	children,
 	...props
 }: CheckboxGroupProps) => {
-	const legend = label ? <Legend text={label} supporting={supporting} /> : ""
+	const legend = label ? <Legend text={label} supporting={supporting} hideLabel={hideLabel} /> : ""
 
 	const message =
 		typeof error === "string" ? (
@@ -194,8 +196,8 @@ const Checkbox = ({
 					<SupportingText>{supporting}</SupportingText>
 				</div>
 			) : (
-				<LabelText>{labelContent}</LabelText>
-			)}
+					<LabelText>{labelContent}</LabelText>
+				)}
 		</label>
 	)
 
@@ -209,6 +211,11 @@ const checkboxDefaultProps = {
 	error: false,
 }
 
+const checkboxGroupDefaultProps = {
+	hideLabel: false
+}
+
 Checkbox.defaultProps = { ...checkboxDefaultProps }
+CheckboxGroup.defaultProps = { ...checkboxGroupDefaultProps }
 
 export { CheckboxGroup, Checkbox }

--- a/src/core/components/checkbox/stories/checkbox-group/legend.tsx
+++ b/src/core/components/checkbox/stories/checkbox-group/legend.tsx
@@ -49,4 +49,18 @@ legendBlue.story = {
 	},
 }
 
-export { legendLight, legendBlue }
+const legendHideLabelLight = () => (
+	<ThemeProvider theme={checkboxDefault}>
+		<CheckboxGroup name="emails" label="Email newsletters" id="emails" hideLabel={true}>
+			{checkboxes.map((checkbox, index) =>
+				React.cloneElement(checkbox, { key: index }),
+			)}
+		</CheckboxGroup>
+	</ThemeProvider>
+)
+
+legendHideLabelLight.story = {
+	name: "visually hide legend light",
+}
+
+export { legendLight, legendBlue, legendHideLabelLight }

--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -1,8 +1,13 @@
 import React, { ReactNode, LabelHTMLAttributes, HTMLAttributes } from "react"
-import { SerializedStyles } from "@emotion/core"
+import { SerializedStyles, css } from "@emotion/core"
 import { legend, labelText, optionalText, supportingText } from "./styles"
 import { Props } from "@guardian/src-helpers"
 export { labelDefault, labelBrand } from "@guardian/src-foundations/themes"
+import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility";
+
+const visuallyHidden = css`
+	${_visuallyHidden}
+`
 
 interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement>, Props {
 	text: string
@@ -15,6 +20,7 @@ interface LegendProps extends HTMLAttributes<HTMLLegendElement>, Props {
 	text: string
 	supporting?: string
 	optional: boolean
+	hideLabel?: boolean
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 }
 
@@ -41,12 +47,13 @@ const Legend = ({
 	text,
 	supporting,
 	optional,
+	hideLabel,
 	cssOverrides,
 	...props
 }: LegendProps) => {
 	return (
 		<>
-			<legend css={[legend, cssOverrides]} {...props}>
+			<legend css={[legend, hideLabel ? visuallyHidden : undefined, cssOverrides]} {...props}>
 				<Text text={text} optional={optional} />
 			</legend>
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}

--- a/src/core/components/radio/README.md
+++ b/src/core/components/radio/README.md
@@ -58,6 +58,12 @@ Gets passed as the name attribute for each radio button
 
 Appears as a legend at the top of the radio group
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Visually hides the label.
+
 ### `supporting`
 
 **`string`**

--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -30,6 +30,7 @@ interface RadioGroupProps extends Props {
 	id?: string
 	name: string
 	label?: string
+	hideLabel: boolean
 	supporting?: string
 	orientation: Orientation
 	error?: string
@@ -41,6 +42,7 @@ const RadioGroup = ({
 	id,
 	name,
 	label,
+	hideLabel,
 	supporting,
 	orientation,
 	error,
@@ -48,7 +50,7 @@ const RadioGroup = ({
 	children,
 	...props
 }: RadioGroupProps) => {
-	const legend = label ? <Legend text={label} supporting={supporting} /> : ""
+	const legend = label ? <Legend text={label} supporting={supporting} hideLabel={hideLabel} /> : ""
 	const message = error && (
 		<InlineError id={id ? descriptionId(id) : ""}>{error}</InlineError>
 	)
@@ -178,7 +180,9 @@ const Radio = ({
 
 const radioGroupDefaultProps = {
 	orientation: "vertical",
+	hideLabel: false
 }
+
 const radioDefaultProps = {
 	disabled: false,
 	type: "radio",

--- a/src/core/components/radio/stories/radio-group/legend.tsx
+++ b/src/core/components/radio/stories/radio-group/legend.tsx
@@ -55,3 +55,14 @@ export const legendHorizontal = () => (
 legendHorizontal.story = {
 	name: `legend horizontal light`,
 }
+
+export const legendHideLabelLight = () => (
+	<RadioGroup name="colours" label="Select your preferred colour" hideLabel={true}>
+		{radios.map((radio, index) =>
+			React.cloneElement(radio, { key: index }),
+		)}
+	</RadioGroup>
+)
+legendHideLabelLight.story = {
+	name: `visually hide legend light`,
+}

--- a/src/core/components/select/README.md
+++ b/src/core/components/select/README.md
@@ -47,6 +47,12 @@ Additional text that appears below the label
 
 Adds the word "Optional" after the label
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Visually hides the label and the "Optional" text set by the `optional` flag.
+
 ### `error`
 
 **`string`**

--- a/src/core/components/select/index.tsx
+++ b/src/core/components/select/index.tsx
@@ -3,7 +3,7 @@ import React, {
 	SelectHTMLAttributes,
 	OptionHTMLAttributes,
 } from "react"
-import { SerializedStyles } from "@emotion/core"
+import { SerializedStyles, css } from "@emotion/core"
 import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
 import {
 	select,
@@ -19,7 +19,12 @@ import {
 import { Props } from "@guardian/src-helpers"
 import { SvgChevronDownSingle } from "@guardian/src-icons"
 
+import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility";
 export { selectDefault } from "@guardian/src-foundations/themes"
+
+const visuallyHidden = css`
+	${_visuallyHidden}
+`
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return (
@@ -32,6 +37,7 @@ const SupportingText = ({ children }: { children: ReactNode }) => {
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement>, Props {
 	label: string
 	optional: boolean
+	hideLabel: boolean
 	supporting?: string
 	error?: string
 	success?: string
@@ -42,6 +48,7 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement>, Props {
 const Select = ({
 	label: labelText,
 	optional,
+	hideLabel,
 	supporting,
 	error,
 	success,
@@ -51,7 +58,7 @@ const Select = ({
 }: SelectProps) => {
 	return (
 		<label>
-			<div css={(theme) => label(theme.select && theme)}>
+			<div css={(theme) => [label(theme.select && theme), hideLabel ? visuallyHidden : ""]}>
 				{labelText}{" "}
 				{optional ? (
 					<span css={(theme) => optionalLabel(theme.select && theme)}>
@@ -110,6 +117,7 @@ const Option = ({ cssOverrides, children, ...props }: OptionProps) => {
 const selectDefaultProps = {
 	disabled: false,
 	optional: false,
+	hideLabel: false,
 }
 
 Select.defaultProps = { ...selectDefaultProps }

--- a/src/core/components/select/stories/hideLabel.tsx
+++ b/src/core/components/select/stories/hideLabel.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { css } from "@emotion/core"
+import { from } from "@guardian/src-foundations/mq"
+import { Select, Option } from "../index"
+
+const constrainedWith = css`
+	width: 100%;
+	${from.phablet} {
+		width: 25em;
+	}
+`
+
+export const hideLabelLight = () => (
+	<div css={constrainedWith}>
+		<Select label="State" hideLabel={true}>
+			<Option value="">Select a state</Option>
+			<Option value="al">Alabama</Option>
+			<Option value="ca">California</Option>
+		</Select>
+	</div>
+)
+
+hideLabelLight.story = {
+	name: "visually hide label light",
+}

--- a/src/core/components/text-area/README.md
+++ b/src/core/components/text-area/README.md
@@ -58,6 +58,12 @@ The contents of the text area. This is necessary when using the [controlled appr
 
 Adds the word "Optional" after the label. Non-optional fields are rendered with the `required` attribute.
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Visually hides the label and the "Optional" text set by the `optional` flag.
+
 ### `error`
 
 **`string`**

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, InputHTMLAttributes } from "react"
-import { SerializedStyles } from "@emotion/core"
+import { SerializedStyles, css} from "@emotion/core"
 import { InlineError } from "@guardian/src-user-feedback"
 import {
 	widthFluid,
@@ -9,7 +9,12 @@ import {
 	optionalLabel,
 	supportingText,
 } from "./styles"
+import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility";
 import { Props } from "@guardian/src-helpers"
+
+const visuallyHidden = css`
+	${_visuallyHidden}
+`
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
 	return <div css={supportingText}>{children}</div>
@@ -21,6 +26,7 @@ interface TextAreaProps
 	value?: string
 	label: string
 	optional: boolean
+	hideLabel: boolean
 	supporting?: string
 	error?: string
 	rows?: number
@@ -31,6 +37,7 @@ interface TextAreaProps
 const TextArea = ({
 	label: labelText,
 	optional,
+	hideLabel,
 	supporting,
 	error,
 	cssOverrides,
@@ -55,7 +62,7 @@ const TextArea = ({
 
 	return (
 		<label>
-			<div css={label}>
+			<div css={[label, hideLabel ? visuallyHidden : ""]}>
 				{labelText}{" "}
 				{optional ? <span css={optionalLabel}>Optional</span> : ""}
 			</div>
@@ -82,6 +89,7 @@ const TextArea = ({
 const defaultProps = {
 	disabled: false,
 	optional: false,
+	hideLabel: false
 }
 
 TextArea.defaultProps = { ...defaultProps }

--- a/src/core/components/text-area/stories.tsx
+++ b/src/core/components/text-area/stories.tsx
@@ -42,6 +42,16 @@ optionalLight.story = {
 	name: `optional light`,
 }
 
+const hideLabelLight = () => (
+	<div css={wrapperStyles}>
+		<TextArea label="Comments" hideLabel={true} />
+	</div>
+)
+
+hideLabelLight.story = {
+	name: `visually hide label light`,
+}
+
 const supportingTextLight = () => (
 	<div css={wrapperStyles}>
 		<TextArea
@@ -109,6 +119,7 @@ export {
 	defaultLight,
 	withRows,
 	optionalLight,
+	hideLabelLight,
 	supportingTextLight,
 	errorWithMessageLight,
 	withMaxLength,

--- a/src/core/components/text-input/README.md
+++ b/src/core/components/text-input/README.md
@@ -59,6 +59,12 @@ The contents of the text input field. This is necessary when using the [controll
 
 Adds the word "Optional" after the label. Non-optional fields are rendered with the `required` attribute.
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Visually hides the label and the "Optional" text set by the `optional` flag.
+
 ### `width`
 
 **`30 | 10 | 4`**

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, InputHTMLAttributes } from "react"
-import { SerializedStyles } from "@emotion/css"
+import { SerializedStyles, css } from "@emotion/core"
 import { InlineError, InlineSuccess } from "@guardian/src-user-feedback"
 import {
 	widthFluid,
@@ -13,10 +13,15 @@ import {
 	supportingText,
 	successInput,
 } from "./styles"
+import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility";
 import { Props } from "@guardian/src-helpers"
 
 export { textInputDefault } from "@guardian/src-foundations/themes"
 export type Width = 30 | 10 | 4
+
+const visuallyHidden = css`
+	${_visuallyHidden}
+`
 
 const widths: {
 	[key in Width]: SerializedStyles
@@ -37,6 +42,7 @@ const SupportingText = ({ children }: { children: ReactNode }) => {
 interface TextInputProps extends InputHTMLAttributes<HTMLInputElement>, Props {
 	label: string
 	optional: boolean
+	hideLabel: boolean
 	supporting?: string
 	width?: Width
 	error?: string
@@ -47,6 +53,7 @@ interface TextInputProps extends InputHTMLAttributes<HTMLInputElement>, Props {
 const TextInput = ({
 	label: labelText,
 	optional,
+	hideLabel,
 	supporting,
 	width,
 	error,
@@ -56,7 +63,10 @@ const TextInput = ({
 }: TextInputProps) => {
 	return (
 		<label>
-			<div css={(theme) => text(theme.textInput && theme)}>
+			<div css={(theme) => [
+				text(theme.textInput && theme),
+				hideLabel ? visuallyHidden : "",
+			]}>
 				{labelText}{" "}
 				{optional ? (
 					<span
@@ -94,6 +104,7 @@ const defaultProps = {
 	disabled: false,
 	type: "text",
 	optional: false,
+	hideLabel: false,
 }
 
 TextInput.defaultProps = { ...defaultProps }

--- a/src/core/components/text-input/stories.tsx
+++ b/src/core/components/text-input/stories.tsx
@@ -48,6 +48,26 @@ optionalLight.story = {
 	name: `optional light`,
 }
 
+const hideLabel = () => {
+	const [state, setState] = useState("")
+	return (
+		<ThemeProvider theme={textInputDefault}>
+			<div css={constrainedWith}>
+				<TextInput
+					label="First name"
+					hideLabel={true}
+					value={state}
+					onChange={(event) => setState(event.target.value)}
+				/>
+			</div>
+		</ThemeProvider>
+	)
+}
+
+hideLabel.story = {
+	name: `visually hide label light`,
+}
+
 const supportingTextLight = () => {
 	const [state, setState] = useState("")
 	return (
@@ -215,6 +235,7 @@ controlled.story = {
 export {
 	defaultLight,
 	optionalLight,
+	hideLabel,
 	supportingTextLight,
 	widthsLight,
 	errorWithMessageLight,


### PR DESCRIPTION
## What is the purpose of this change?

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

## What does this change?

<!--
Give an overview of the changes you have made.
-->

This PR adds the `hideLabel`-prop to diffrent components. Labels hidden by `hideLabel` are not visible, but still readable by screen readers.

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->


* Closes #555 