### PR TITLE
fix(Button): remove React warnings about missing key

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -104,7 +104,7 @@ const buttonContents = ({
 
 	if (iconSvg) {
 		if (!hideLabel) {
-			contents.push(<div className="src-button-space" />)
+			contents.push(<div key="space" className="src-button-space" />)
 		}
 		contents.push(React.cloneElement(iconSvg, { key: "svg" }))
 	}


### PR DESCRIPTION
## What is the purpose of this change?

Fixes #558 

## What does this change?

This PR adds a missing key on the space div, inside the Button component, as the button renders an array (children and other component), each rendered element should have an key. I named this key `space` but feel free to suggest a better name :wink:.

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

