### PR TITLE
Add columns component

### DIFF
--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -1,6 +1,6 @@
 # `Layout`
 
-📣 For more context and visual guides relating to `Layout` usage on the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/41be19-grids)
+📣 For more context and visual guides relating to `Layout` usage on the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/309077-layout-components)
 
 ## Install
 
@@ -9,6 +9,8 @@ $ yarn add @guardian/src-layout
 ```
 
 ## Container
+
+Centres the page content and applies a width that corresponds to the grid at the current breakpoint.
 
 ```tsx
 import { Container } from "@guardian/src-layout"
@@ -30,6 +32,8 @@ Whether to show a border to the left and right of the Container
 
 ## Stack
 
+Children will be stacked one on top of the other.
+
 ```tsx
 import { Stack } from "@guardian/src-layout"
 
@@ -49,3 +53,39 @@ const Wrapper = () => (
 **`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
 
 Units of space between stack items (one unit is 4px)
+
+## Columns
+
+Columns will be arranged side by side on a single row, with the specified width.
+
+Use Columns in conjunction with Container to help the columns align neatly with [the Guardian's grids](https://www.theguardian.design/2a1e5182b/p/41be19-grids).
+
+```tsx
+import { Container, Columns, Column } from "@guardian/src-layout"
+
+const Wrapper = () => (
+    <Container>
+        <Columns collapseBelow={tablet}>
+            <Column width={1 / 4}>1/4</Column>
+            <Column width={1 / 4}>1/4</Column>
+            <Column>*</Column>
+        </Columns>
+    </Container>
+)
+```
+
+### Columns Props
+
+#### `collapseBelow`
+
+**`Breakpoint`**
+
+Columns will be stacked one on top of the other at viewport widths lower than the specified breakpoint
+
+### Column Props
+
+#### `width`
+
+**`number`**
+
+Fraction of the parent container's width that the column will occupy. If no value is provided, the column width will be fluid (i.e. take up remaining space, divided between all fluid columns)

--- a/src/core/components/layout/columns.stories.tsx
+++ b/src/core/components/layout/columns.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react"
+import { Columns } from "./index"
+
+const gridStoryWrapper = (storyFn: () => JSX.Element) => {
+	// override 8px margin applied globally to every preview body
+	return <div style={{ margin: "0 -8px" }}>{storyFn()}</div>
+}
+
+export default {
+	title: "Columns",
+	component: Columns,
+	decorators: [gridStoryWrapper],
+}
+
+export * from "./stories/columns/collapse-below"
+export * from "./stories/columns/default"
+export * from "./stories/columns/with-width"

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -1,0 +1,93 @@
+import React, { HTMLAttributes, ReactNode } from "react"
+import { SerializedStyles } from "@emotion/core"
+import {
+	columns,
+	column,
+	collapseBelowTabletColumns,
+	collapseBelowDesktopColumns,
+	collapseBelowLeftColColumns,
+	collapseBelowWideColumns,
+	collapseBelowTablet,
+	collapseBelowDesktop,
+	collapseBelowleftCol,
+	collapseBelowWide,
+} from "./styles"
+import { Breakpoint } from "@guardian/src-foundations/mq"
+import { Props } from "@guardian/src-helpers"
+
+type GridBreakpoint = Extract<
+	Breakpoint,
+	"mobile" | "tablet" | "desktop" | "leftCol" | "wide"
+>
+
+type CollapseBreakpoint = Extract<
+	GridBreakpoint,
+	"tablet" | "desktop" | "leftCol" | "wide"
+>
+
+interface ColumnsProps extends HTMLAttributes<HTMLDivElement>, Props {
+	collapseBelow?: CollapseBreakpoint
+	cssOverrides?: SerializedStyles | SerializedStyles[]
+	children: ReactNode
+}
+
+const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
+	tablet: collapseBelowTablet,
+	desktop: collapseBelowDesktop,
+	leftCol: collapseBelowleftCol,
+	wide: collapseBelowWide,
+}
+
+const collapseBelowColumnsMap: {
+	[key in CollapseBreakpoint]: SerializedStyles
+} = {
+	tablet: collapseBelowTabletColumns,
+	desktop: collapseBelowDesktopColumns,
+	leftCol: collapseBelowLeftColColumns,
+	wide: collapseBelowWideColumns,
+}
+
+const Columns = ({
+	collapseBelow,
+	cssOverrides,
+	children,
+	...props
+}: ColumnsProps) => {
+	return (
+		<div
+			css={[
+				columns,
+				collapseBelow ? collapseBelowColumnsMap[collapseBelow] : "",
+				collapseBelow ? collapseBelowMap[collapseBelow] : "",
+				cssOverrides,
+			]}
+			{...props}
+		>
+			{children}
+		</div>
+	)
+}
+
+interface ColumnProps extends HTMLAttributes<HTMLDivElement>, Props {
+	width?: number
+	cssOverrides?: SerializedStyles | SerializedStyles[]
+	children: ReactNode
+}
+
+const Column = ({
+	width = 0,
+	cssOverrides,
+	children,
+	...props
+}: ColumnProps) => {
+	return (
+		<div css={[column(width), cssOverrides]} {...props}>
+			{children}
+		</div>
+	)
+}
+
+Columns.defaultProps = {}
+Column.defaultProps = {}
+
+export { Columns, Column }

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -1,0 +1,100 @@
+import { css } from "@emotion/core"
+import { space } from "@guardian/src-foundations"
+import { until } from "@guardian/src-foundations/mq"
+
+export const columns = css`
+	box-sizing: border-box;
+	display: flex;
+	& > * + * {
+		margin-left: ${space[5]}px;
+	}
+`
+
+const collapseBelowSpacing = css`
+	display: block;
+	& > * + * {
+		margin-left: 0;
+	}
+	& > * {
+		margin-bottom: ${space[5]}px;
+	}
+`
+
+export const collapseBelowTabletColumns = css`
+	${until.tablet} {
+		${collapseBelowSpacing}
+	}
+`
+export const collapseBelowDesktopColumns = css`
+	${until.desktop} {
+		${collapseBelowSpacing}
+	}
+`
+export const collapseBelowLeftColColumns = css`
+	${until.leftCol} {
+		${collapseBelowSpacing}
+	}
+`
+export const collapseBelowWideColumns = css`
+	${until.wide} {
+		${collapseBelowSpacing}
+	}
+`
+
+const collapseBelowWidth = css`
+	width: 100% !important;
+`
+
+export const collapseBelowTablet = css`
+	& > * {
+		${until.tablet} {
+			${collapseBelowWidth}
+		}
+	}
+`
+export const collapseBelowDesktop = css`
+	& > * {
+		${until.desktop} {
+			${collapseBelowWidth}
+		}
+	}
+`
+export const collapseBelowleftCol = css`
+	& > * {
+		${until.leftCol} {
+			${collapseBelowWidth}
+		}
+	}
+`
+export const collapseBelowWide = css`
+	& > * {
+		${until.wide} {
+			${collapseBelowWidth}
+		}
+	}
+`
+
+export const column = (width: number) => css`
+	box-sizing: border-box;
+	/* If a width is specified, don't allow column to grow. Use the width property */
+	flex: ${width ? "0 0 auto" : 1};
+	/*
+		A set of Columns has n columns and n-1 gutters:
+		|    |g|    |g|    |g|    |
+		This means if we take a simple fraction of the width of the set of Columns,
+		our Column will stop part-way through a gutter:
+		|    |g|    |g|    |g|    |
+		|====50%=====|====50%=====|
+		To calculate width of a Column correctly, we must add an imaginary extra gutter
+		and take a fraction of the whole:
+		|    |g|    |g|    |g|    |g|
+		|=====50%=====||====50%=====|
+		This will create a Column which is x columns and x gutters wide. We really want the
+		Column to be x columns and x-1 gutters, so we must subtract a gutter at the end:
+		|    |g|    |g|    |g|    |g|
+		|====50%====| |====50%====|
+	 */
+	${width
+		? `width: calc((100% + ${space[5]}px) * ${width} - ${space[5]}px);`
+		: ""}
+`

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -1,2 +1,3 @@
+export { Columns, Column } from "./components/columns/columns"
 export { Container } from "./components/container/container"
 export { Stack } from "./components/stack/stack"

--- a/src/core/components/layout/stories/columns/collapse-below.tsx
+++ b/src/core/components/layout/stories/columns/collapse-below.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { Container, Columns, Column } from "../../index"
+import { sport } from "@guardian/src-foundations/palette"
+import { css } from "@emotion/core"
+
+const contents = css`
+	text-align: center;
+	background-color: ${sport[600]};
+`
+
+export const collapseBelowTablet = () => (
+	<Container border={true}>
+		<Columns collapseBelow="tablet">
+			<Column>
+				<div css={contents}>1</div>
+			</Column>
+			<Column>
+				<div css={contents}>2</div>
+			</Column>
+			<Column>
+				<div css={contents}>3</div>
+			</Column>
+			<Column>
+				<div css={contents}>4</div>
+			</Column>
+		</Columns>
+	</Container>
+)
+
+collapseBelowTablet.story = {
+	name: "collapse below tablet",
+	parameters: {
+		viewport: { defaultViewport: "phablet" },
+	},
+}

--- a/src/core/components/layout/stories/columns/default.tsx
+++ b/src/core/components/layout/stories/columns/default.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { Container, Columns, Column } from "../../index"
+import { sport } from "@guardian/src-foundations/palette"
+import { css } from "@emotion/core"
+
+const contents = css`
+	text-align: center;
+	background-color: ${sport[600]};
+`
+
+export const containerDefault = () => (
+	<Container border={true}>
+		<Columns>
+			<Column>
+				<div css={contents}>1</div>
+			</Column>
+			<Column>
+				<div css={contents}>2</div>
+			</Column>
+			<Column>
+				<div css={contents}>3</div>
+			</Column>
+			<Column>
+				<div css={contents}>4</div>
+			</Column>
+		</Columns>
+	</Container>
+)
+
+containerDefault.story = {
+	name: "default",
+}
+
+export const longText = () => (
+	<Container border={true}>
+		<Columns>
+			<Column>
+				<div css={contents}>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut
+					faucibus nibh erat, eget rutrum ligula vehicula sit amet.
+					Etiam scelerisque dapibus pulvinar. Integer non accumsan
+					justo. Duis et vehicula risus. Nulla ligula eros, consequat
+					sodales lectus eget, eleifend venenatis neque. Vivamus
+					interdum, mi sit amet blandit laoreet, ligula eros efficitur
+					quam, eu pellentesque risus tortor vitae tellus. Duis et
+					lectus vitae tortor placerat consequat. Vestibulum sed
+					efficitur mi, sed suscipit urna.
+				</div>
+			</Column>
+			<Column>
+				<div css={contents}>
+					Interdum et malesuada fames ac ante ipsum primis in
+					faucibus. Nulla facilisi. Phasellus id aliquam odio. Aliquam
+					tempus eu enim in fermentum. Donec ut velit vel purus rutrum
+					vulputate ut scelerisque lacus. Vestibulum ante ipsum primis
+					in faucibus orci luctus et ultrices posuere cubilia curae;
+					Maecenas sodales lacinia porta. Suspendisse consequat
+					egestas dui, non tempus diam laoreet vitae.{" "}
+				</div>
+			</Column>
+			<Column>
+				<div css={contents}>
+					{" "}
+					Pellentesque id ornare turpis. Aliquam laoreet aliquet
+					pharetra. Donec nec erat ac libero interdum sollicitudin.
+					Nullam imperdiet ut dolor non cursus. Integer et ante
+					fringilla, luctus magna nec, consequat est. Nam viverra,
+					lectus non pellentesque hendrerit, sem nulla commodo urna,
+					ut aliquam odio eros eu justo. Nullam sem mi, rhoncus sed
+					nunc at, blandit scelerisque neque. Donec mattis arcu
+					accumsan orci luctus, eget ultricies neque accumsan. Duis
+					fringilla elit feugiat justo maximus, id volutpat lacus
+					congue. Fusce ornare imperdiet cursus. Sed in turpis est.
+					Nam id ultrices leo. Nullam bibendum quis neque sit amet
+					lacinia. Aenean ac arcu enim.{" "}
+				</div>
+			</Column>
+			<Column>
+				<div css={contents}>
+					Nunc nec dapibus quam. Praesent nec neque vel velit mollis
+					tempor. Suspendisse justo eros, pharetra et elit sit amet,
+					hendrerit laoreet dui. Curabitur ut libero nibh. Duis
+					finibus sollicitudin tortor, ac viverra urna commodo et.
+					Aliquam tempus, turpis vel dictum condimentum, dolor nisl
+					consequat sem, et posuere metus diam vel erat. Sed sagittis
+					nisi sed nisl lobortis ornare. Donec facilisis euismod ante,
+					a interdum urna scelerisque et. Donec convallis odio orci,
+					efficitur maximus metus rutrum in. Curabitur laoreet dui sed
+					mi tempor tincidunt. Nunc finibus ligula at arcu aliquet,
+					maximus commodo lectus dignissim.{" "}
+				</div>
+			</Column>
+		</Columns>
+	</Container>
+)
+
+longText.story = {
+	name: "with long text",
+}

--- a/src/core/components/layout/stories/columns/with-width.tsx
+++ b/src/core/components/layout/stories/columns/with-width.tsx
@@ -1,0 +1,102 @@
+import React from "react"
+import { Container, Columns, Column } from "../../index"
+import { textSans } from "@guardian/src-foundations/typography"
+import { sport } from "@guardian/src-foundations/palette"
+import { space } from "@guardian/src-foundations"
+import { css } from "@emotion/core"
+
+const contents = css`
+	${textSans.medium()};
+	text-align: center;
+	background-color: ${sport[600]};
+`
+
+const spaceOut = css`
+	& > * + * {
+		margin-top: ${space[5]}px !important;
+	}
+`
+
+const example = (
+	<div css={spaceOut}>
+		<Container>
+			<Columns>
+				<Column width={1 / 4}>
+					<div css={contents}>1 / 4</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+			</Columns>
+		</Container>
+
+		<Container>
+			<Columns>
+				<Column width={1 / 3}>
+					<div css={contents}>1 / 3</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+			</Columns>
+		</Container>
+
+		<Container>
+			<Columns>
+				<Column width={1 / 2}>
+					<div css={contents}>1 / 2</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+			</Columns>
+		</Container>
+
+		<Container>
+			<Columns>
+				<Column width={3 / 4}>
+					<div css={contents}>3 / 4</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+				<Column>
+					<div css={contents}>*</div>
+				</Column>
+			</Columns>
+		</Container>
+	</div>
+)
+
+export const withWidth = () => <>{example}</>
+
+withWidth.story = {
+	name: "with width",
+}
+
+export const withWidthDesktop = () => <>{example}</>
+
+withWidthDesktop.story = {
+	name: "with width desktop",
+	parameters: {
+		viewport: { defaultViewport: "desktop" },
+	},
+}
+
+export const withWidthTablet = () => <>{example}</>
+
+withWidthTablet.story = {
+	name: "with width tablet",
+	parameters: {
+		viewport: { defaultViewport: "tablet" },
+	},
+}


### PR DESCRIPTION
## What is the purpose of this change?

Columns will be arranged side by side on a single row, with the specified width.

```tsx
<Columns collapseBelow={tablet}>
  <Column width={1/4}></Column>
  <Column width={1/4}></Column>
  <Column></Column>
</Columns>
```

`width`: If no value is provided, the column width will be fluid (i.e. take up remaining space, divided between all fluid columns).
`collapseBelow`: columns will be stacked one on top of the other at viewport widths lower than the specified breakpoint

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Add Column and Columns components
-   Add stories

## Screenshots

<img width="726" alt="Screenshot 2020-10-05 at 14 50 28" src="https://user-images.githubusercontent.com/5931528/95087865-24084d00-071a-11eb-8e45-34e452fcc82b.png">

## Checklist

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook
