### PR TITLE
Add hide component

### DIFF
--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -89,3 +89,36 @@ Columns will be stacked one on top of the other at viewport widths lower than th
 **`number`**
 
 Fraction of the parent container's width that the column will occupy. If no value is provided, the column width will be fluid (i.e. take up remaining space, divided between all fluid columns)
+
+## Hide
+
+Hide a component above or below a certain breakpoint
+
+```tsx
+import { Hide } from "@guardian/src-layout"
+
+const Wrapper = () => (
+    <>
+        <Hide above="tablet">
+            <MobileNavigation />
+        </Hide>
+        <Hide below="desktop">
+            <DesktopNavigation />
+        </Hide>
+    </>
+)
+```
+
+### Props
+
+#### `above`
+
+**`Breakpoint`**
+
+Contents will be hidden at viewport widths greater than the specified breakpoint
+
+#### `below`
+
+**`Breakpoint`**
+
+Contents will be hidden at viewport widths less than the specified breakpoint

--- a/src/core/components/layout/components/hide/hide.tsx
+++ b/src/core/components/layout/components/hide/hide.tsx
@@ -1,0 +1,36 @@
+import React, { HTMLAttributes, ReactNode } from "react"
+import { css } from "@emotion/core"
+import { Breakpoint } from "@guardian/src-foundations"
+import { from, until } from "@guardian/src-foundations/mq"
+import { Props } from "@guardian/src-helpers"
+
+interface HideProps extends HTMLAttributes<HTMLDivElement>, Props {
+	children: ReactNode
+	above?: Breakpoint
+	below?: Breakpoint
+}
+
+const Hide = ({ children, above, below }: HideProps) => {
+	let whenToHide
+	if (below) {
+		whenToHide = css`
+			${until[below]} {
+				display: none;
+			}
+		`
+	}
+	if (above) {
+		whenToHide = css`
+			${from[above]} {
+				display: none;
+			}
+		`
+	}
+
+	return <span css={whenToHide}>{children}</span>
+}
+const defaultProps = {}
+
+Hide.defaultProps = { ...defaultProps }
+
+export { Hide }

--- a/src/core/components/layout/hide.stories.tsx
+++ b/src/core/components/layout/hide.stories.tsx
@@ -1,0 +1,8 @@
+import { Hide } from "./index"
+
+export default {
+	title: "Hide",
+	component: Hide,
+}
+
+export * from "./stories/hide/default"

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -1,3 +1,4 @@
 export { Columns, Column } from "./components/columns/columns"
 export { Container } from "./components/container/container"
+export { Hide } from "./components/hide/hide"
 export { Stack } from "./components/stack/stack"

--- a/src/core/components/layout/stories/hide/default.tsx
+++ b/src/core/components/layout/stories/hide/default.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { Container, Hide } from "../../index"
+import { css } from "@emotion/core"
+import { sport } from "@guardian/src-foundations/palette"
+import { textSans } from "@guardian/src-foundations/typography"
+
+const contents = css`
+	${textSans.medium()};
+	text-align: center;
+	background-color: ${sport[600]};
+`
+
+export const below = () => (
+	<Container>
+		<Hide below="desktop">
+			<div css={contents}>Will not appear below desktop</div>
+		</Hide>
+	</Container>
+)
+
+below.story = {
+	name: "below",
+}
+
+export const above = () => (
+	<Container>
+		<Hide above="desktop">
+			<div css={contents}>Will not appear at desktop or above</div>
+		</Hide>
+	</Container>
+)
+
+above.story = {
+	name: "above",
+}


### PR DESCRIPTION
## What is the purpose of this change?

The Hide component hides its contents at viewport widths greater or less than the specified breakpoints. (see #526)

## What does this change?

-   Add a Hide component, stories and documentation

## Screenshots

![2020-10-07 10 54 13](https://user-images.githubusercontent.com/5931528/95316274-80d74500-088b-11eb-81ee-e792bf080b4b.gif)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)

### Responsiveness

-   [x] Tested at all breakpoints

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

