### PR TITLE
Use eslint-plugin-jsx-a11y

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,15 +1,16 @@
 {
 	"parser": "@typescript-eslint/parser",
-	"plugins": ["@typescript-eslint", "react"],
+	"plugins": ["@typescript-eslint", "react", "jsx-a11y"],
 	"extends": [
 		"plugin:@typescript-eslint/recommended",
 		"plugin:react/recommended",
+		"plugin:jsx-a11y/recommended",
 		"prettier/@typescript-eslint",
 		"prettier/react"
 	],
 	"rules": {
 		"@typescript-eslint/explicit-module-boundary-types": "off",
-		"@typescript-eslint/no-unused-vars" : "off"
+		"@typescript-eslint/no-unused-vars": "off"
 	},
 	"parserOptions": {
 		"ecmaFeatures": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"emotion-theming": "^10.0.27",
 		"eslint": "^7.10.0",
 		"eslint-config-prettier": "^6.12.0",
+		"eslint-plugin-jsx-a11y": "^6.3.1",
 		"eslint-plugin-prettier": "^3.1.4",
 		"eslint-plugin-react": "^7.21.2",
 		"execa": "^4.0.3",

--- a/src/core/components/checkbox/index.tsx
+++ b/src/core/components/checkbox/index.tsx
@@ -47,7 +47,11 @@ const CheckboxGroup = ({
 	children,
 	...props
 }: CheckboxGroupProps) => {
-	const legend = label ? <Legend text={label} supporting={supporting} hideLabel={hideLabel} /> : ""
+	const legend = label ? (
+		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
+	) : (
+		""
+	)
 
 	const message =
 		typeof error === "string" ? (
@@ -155,6 +159,7 @@ const Checkbox = ({
 	const box = (
 		<>
 			<input
+				type="checkbox"
 				css={(theme) => [
 					checkbox(theme.checkbox && theme),
 					error ? errorCheckbox(theme.checkbox && theme) : "",
@@ -196,8 +201,8 @@ const Checkbox = ({
 					<SupportingText>{supporting}</SupportingText>
 				</div>
 			) : (
-					<LabelText>{labelContent}</LabelText>
-				)}
+				<LabelText>{labelContent}</LabelText>
+			)}
 		</label>
 	)
 
@@ -206,13 +211,12 @@ const Checkbox = ({
 
 const checkboxDefaultProps = {
 	disabled: false,
-	type: "checkbox",
 	indeterminate: false,
 	error: false,
 }
 
 const checkboxGroupDefaultProps = {
-	hideLabel: false
+	hideLabel: false,
 }
 
 Checkbox.defaultProps = { ...checkboxDefaultProps }

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -3,7 +3,7 @@ import React, {
 	ReactElement,
 	useState,
 	InputHTMLAttributes,
-	ChangeEventHandler
+	ChangeEventHandler,
 } from "react"
 import { SerializedStyles } from "@emotion/core"
 import {
@@ -69,7 +69,13 @@ const ChoiceCardGroup = ({
 			)}
 			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
 			{typeof error === "string" && <InlineError>{error}</InlineError>}
-			<div css={columns ? [gridContainer, gridColumns[columns] ] : flexContainer}>
+			<div
+				css={
+					columns
+						? [gridContainer, gridColumns[columns]]
+						: flexContainer
+				}
+			>
 				{React.Children.map(children, (child) => {
 					return React.cloneElement(
 						child,
@@ -126,6 +132,7 @@ const ChoiceCard = ({
 
 	return (
 		<>
+			{/* eslint-disable-next-line jsx-a11y/role-supports-aria-props*/}
 			<input
 				css={(theme) => [
 					input(theme.choiceCard && theme),

--- a/src/core/components/footer/stories/with-children.tsx
+++ b/src/core/components/footer/stories/with-children.tsx
@@ -97,22 +97,22 @@ const footerContents = (
 		</p>
 		<ul css={ul}>
 			<li css={[li, link1]}>
-				<a css={anchor} href="#">
+				<a css={anchor} href="/">
 					Privacy policy
 				</a>
 			</li>
 			<li css={[li, link2]}>
-				<a css={anchor} href="#">
+				<a css={anchor} href="/">
 					Contact us
 				</a>
 			</li>
 			<li css={[li, link3]}>
-				<a css={anchor} href="#">
+				<a css={anchor} href="/">
 					Frequently asked questions
 				</a>
 			</li>
 			<li css={[li, link4]}>
-				<a css={anchor} href="#">
+				<a css={anchor} href="/">
 					Terms &amp; conditions
 				</a>
 			</li>

--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -13,7 +13,6 @@ import {
 	supportingText,
 	horizontal,
 	vertical,
-	errorRadio,
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
 
@@ -50,15 +49,24 @@ const RadioGroup = ({
 	children,
 	...props
 }: RadioGroupProps) => {
-	const legend = label ? <Legend text={label} supporting={supporting} hideLabel={hideLabel} /> : ""
+	const legend = label ? (
+		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
+	) : (
+		""
+	)
 	const message = error && (
 		<InlineError id={id ? descriptionId(id) : ""}>{error}</InlineError>
 	)
 
 	return (
 		<fieldset
+			aria-invalid={!!error}
 			id={id}
-			css={[fieldset, orientationStyles[orientation], cssOverrides]}
+			css={(theme) => [
+				fieldset(theme.radio && theme),
+				orientationStyles[orientation],
+				cssOverrides,
+			]}
 			{...props}
 		>
 			{legend}
@@ -67,7 +75,6 @@ const RadioGroup = ({
 				return React.cloneElement(
 					child,
 					Object.assign(
-						error ? { error: true } : {},
 						error && id
 							? { "aria-describedby": descriptionId(id) }
 							: {},
@@ -115,7 +122,6 @@ interface RadioProps extends InputHTMLAttributes<HTMLInputElement>, Props {
 	defaultChecked?: boolean
 	label?: ReactNode
 	supporting?: ReactNode
-	error: boolean
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 }
 
@@ -126,7 +132,6 @@ const Radio = ({
 	checked,
 	defaultChecked,
 	cssOverrides,
-	error,
 	...props
 }: RadioProps) => {
 	const isChecked = (): boolean => {
@@ -138,13 +143,9 @@ const Radio = ({
 	}
 	const radioControl = (
 		<input
-			css={(theme) => [
-				radio(theme.radio && theme),
-				error ? errorRadio(theme.radio && theme) : "",
-				cssOverrides,
-			]}
+			type="radio"
+			css={(theme) => [radio(theme.radio && theme), cssOverrides]}
 			value={value}
-			aria-invalid={error}
 			aria-checked={isChecked()}
 			defaultChecked={defaultChecked != null ? defaultChecked : undefined}
 			checked={checked != null ? isChecked() : undefined}
@@ -180,13 +181,11 @@ const Radio = ({
 
 const radioGroupDefaultProps = {
 	orientation: "vertical",
-	hideLabel: false
+	hideLabel: false,
 }
 
 const radioDefaultProps = {
 	disabled: false,
-	type: "radio",
-	error: false,
 }
 
 Radio.defaultProps = { ...radioDefaultProps }

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -5,7 +5,9 @@ import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
 import { RadioTheme, radioDefault } from "@guardian/src-foundations/themes"
 
-export const fieldset = css`
+export const fieldset = ({
+	radio,
+}: { radio: RadioTheme } = radioDefault) => css`
 	display: flex;
 	justify-content: flex-start;
 
@@ -13,6 +15,10 @@ export const fieldset = css`
 	border: 0;
 	padding: 0;
 	margin: 0;
+
+	&[aria-invalid="true"] input {
+		border: 4px solid ${radio.borderError};
+	}
 `
 
 export const label = ({ radio }: { radio: RadioTheme } = radioDefault) => css`
@@ -128,10 +134,4 @@ export const horizontal = css`
 `
 export const vertical = css`
 	flex-direction: column;
-`
-
-export const errorRadio = ({
-	radio,
-}: { radio: RadioTheme } = radioDefault) => css`
-	border: 4px solid ${radio.borderError};
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,6 +2071,14 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.4.tgz#73d12ba819e365fcf7fd152aed56d6df97d21c83"
@@ -2084,6 +2092,13 @@
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
   dependencies:
     regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.3.1", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6":
   version "7.8.0"
@@ -4201,6 +4216,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -4339,6 +4362,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 ast-types@0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.3.tgz#c20757fe72ee71278ea0ff3d87e5c2ca30d9edf8"
@@ -4421,6 +4449,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axe-core@^3.5.4:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
+  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
+
 axios@0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
@@ -4428,6 +4461,11 @@ axios@0.19.0:
   dependencies:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
+
+axobject-query@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
+  integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
@@ -5753,6 +5791,11 @@ core-js-pure@3.1.4, core-js-pure@^3.0.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
+core-js-pure@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -6031,6 +6074,11 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+
+damerau-levenshtein@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
+  integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -6475,6 +6523,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.0.0.tgz#48a2309cc8a1d2e9d23bc6a67c39b63032e76ea4"
+  integrity sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -6684,6 +6737,23 @@ eslint-config-prettier@^6.12.0:
   integrity sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==
   dependencies:
     get-stdin "^6.0.0"
+
+eslint-plugin-jsx-a11y@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz#99ef7e97f567cc6a5b8dd5ab95a94a67058a2660"
+  integrity sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    aria-query "^4.2.2"
+    array-includes "^3.1.1"
+    ast-types-flow "^0.0.7"
+    axe-core "^3.5.4"
+    axobject-query "^2.1.2"
+    damerau-levenshtein "^1.0.6"
+    emoji-regex "^9.0.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1"
+    language-tags "^1.0.5"
 
 eslint-plugin-prettier@^3.1.4:
   version "3.1.4"
@@ -9768,6 +9838,18 @@ known-css-properties@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.19.0.tgz#5d92b7fa16c72d971bda9b7fe295bdf61836ee5b"
   integrity sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==
+
+language-subtag-registry@~0.3.2:
+  version "0.3.20"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz#a00a37121894f224f763268e431c55556b0c0755"
+  integrity sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
+  dependencies:
+    language-subtag-registry "~0.3.2"
 
 lazy-cache@^0.2.3:
   version "0.2.7"


### PR DESCRIPTION
## What is the purpose of this change?

[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y) statically analyses JSX and flags invalid or potentially inaccessible HTML to the developer. This helps to keep Source components accessible.

We can investigate replacing recommended ruleset with the strict ruleset at a later date.

## What does this change?

-   Install eslint-plugin-jsx-a11y
-   Configure plugin with the recommended ruleset
-   Fix accessibility issues in Radio, Checkbox, ChoiceCard and Footer components


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

