### PR TITLE
feat(button): remove unused props showIcon

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -247,7 +247,6 @@ const defaultLinkButtonProps = {
 	size: "default",
 	iconSide: "left",
 	hideLabel: false,
-	showIcon: false,
 }
 
 Button.defaultProps = { ...defaultButtonProps }


### PR DESCRIPTION
## What is the purpose of this change?

Fixes #556

## What does this change?

It seems that the prop `showIcon` is not used and was passed directly to a dom element.
As suggested, I remove this prop.

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
