### PR TITLE
feat(footer): make back to top button not escaping footer

### DIFF
--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -7,6 +7,7 @@ import {
 	links,
 	backToTop,
 	backToTopIcon,
+	linksWrapper,
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
 import { SvgChevronUpSingle } from "@guardian/src-icons"
@@ -38,8 +39,10 @@ const Footer = ({
 			css={(theme) => [footer(theme.footer && theme), cssOverrides]}
 			{...props}
 		>
-			<div css={(theme) => links(theme.footer && theme)}>
-				{children}
+			<div css={linksWrapper(showBackToTop)}>
+				<div css={(theme) => links(theme.footer && theme)}>
+					{children}
+				</div>
 				{showBackToTop ? backToTopLink : ""}
 			</div>
 			<small

--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -8,6 +8,8 @@ import {
 	backToTop,
 	backToTopIcon,
 	linksWrapper,
+	linksWrapperSpace,
+	linksWrapperSpaceWithBackToTop,
 } from "./styles"
 import { Props } from "@guardian/src-helpers"
 import { SvgChevronUpSingle } from "@guardian/src-icons"
@@ -39,7 +41,7 @@ const Footer = ({
 			css={(theme) => [footer(theme.footer && theme), cssOverrides]}
 			{...props}
 		>
-			<div css={linksWrapper(showBackToTop)}>
+			<div css={[linksWrapper, showBackToTop ? linksWrapperSpaceWithBackToTop : linksWrapperSpace]}>
 				<div css={(theme) => links(theme.footer && theme)}>
 					{children}
 				</div>

--- a/src/core/components/footer/styles.ts
+++ b/src/core/components/footer/styles.ts
@@ -18,20 +18,24 @@ export const footer = ({
 	}
 `
 
-const getMarginBottom = (initialSpace: number, withBackToTop: boolean) => {
-	if (!withBackToTop) {
-		return initialSpace;
-	}
-
-	return initialSpace - height.ctaMedium / 2
-}
-export const linksWrapper = (withBackToTop: boolean) => css`
+export const linksWrapper = css`
 	display: flex;
 	align-items: center;
-	margin-bottom: ${getMarginBottom(space[6], withBackToTop)}px;
+`
 
+export const linksWrapperSpace = css`
+    margin-bottom: ${space[6]}px;
 	${from.desktop} {
-		margin-bottom: ${getMarginBottom(space[1], withBackToTop)}px;
+		margin-bottom: ${space[1]}px;
+	}
+`
+
+const backToTopSpace = (initial: number) => initial - height.ctaMedium / 2
+
+export const linksWrapperSpaceWithBackToTop = css`
+    margin-bottom: ${backToTopSpace(space[6])}px;
+	${from.desktop} {
+		margin-bottom: ${backToTopSpace(space[1])}px;
 	}
 `
 

--- a/src/core/components/footer/styles.ts
+++ b/src/core/components/footer/styles.ts
@@ -18,11 +18,28 @@ export const footer = ({
 	}
 `
 
+const getMarginBottom = (initialSpace: number, withBackToTop: boolean) => {
+	if (!withBackToTop) {
+		return initialSpace;
+	}
+
+	return initialSpace - height.ctaMedium / 2
+}
+export const linksWrapper = (withBackToTop: boolean) => css`
+	display: flex;
+	align-items: center;
+	margin-bottom: ${getMarginBottom(space[6], withBackToTop)}px;
+
+	${from.desktop} {
+		margin-bottom: ${getMarginBottom(space[1], withBackToTop)}px;
+	}
+`
+
 export const links = ({ footer }: { footer: FooterTheme } = footerBrand) => css`
-	position: relative;
 	border-style: solid;
 	border-color: ${footer.border};
 	border-width: 0 0 1px 0;
+	flex: 1 1 auto;
 
 	/* TODO: viewport-specific layout for when footer supports content */
 	/* border-width: 1px 0 1px 0;
@@ -35,11 +52,6 @@ export const links = ({ footer }: { footer: FooterTheme } = footerBrand) => css`
 export const copyright = css`
 	${textSans.xsmall()};
 	display: block;
-	margin-top: ${space[6]}px;
-
-	${from.desktop} {
-		margin-top: ${space[1]}px;
-	}
 `
 
 // ensure copyright text doesn't get too close to back to top link
@@ -55,9 +67,6 @@ export const backToTop = ({
 	display: flex;
 	align-items: center;
 	height: ${height.ctaMedium}px;
-	position: absolute;
-	top: -${height.ctaMedium / 2}px;
-	right: 0;
 	padding-left: ${space[2]}px;
 
 	${textSans.small({ fontWeight: "bold" })};


### PR DESCRIPTION
## What is the purpose of this change?

Fixes #550 

## What does this change?

Back to top button is no longer escaping the footer area and it's now including inside it.

## Screenshots

**Before**
![image](https://user-images.githubusercontent.com/7687610/95490869-24fae200-0999-11eb-9566-9fbe7215b835.png)


**After**
![image](https://user-images.githubusercontent.com/7687610/95491004-54a9ea00-0999-11eb-8a04-b3f5487aa692.png)


## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

-   [x] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

### Known issues

<!--
If there are known issues, please specify them here
-->
