### PR TITLE
Inline link icon story

### DIFF
--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -51,20 +51,16 @@ const linkContents = ({
 	iconSvg?: ReactElement
 	iconSide: IconSide
 }) => {
-	// a bit of underlined space; the icon sits on top
-	const spacer = <>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</>
 	const linkContents = [children]
 
 	if (iconSvg) {
 		if (iconSide === "left") {
 			linkContents.unshift(
 				React.cloneElement(iconSvg, { key: "svg" }),
-				spacer,
 			)
 		} else {
 			linkContents.push(
 				React.cloneElement(iconSvg, { key: "svg" }),
-				spacer,
 			)
 		}
 	}

--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -51,16 +51,20 @@ const linkContents = ({
 	iconSvg?: ReactElement
 	iconSide: IconSide
 }) => {
+	// a bit of underlined space; the icon sits on top
+	const spacer = <>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</>
 	const linkContents = [children]
 
 	if (iconSvg) {
 		if (iconSide === "left") {
 			linkContents.unshift(
-				React.cloneElement(iconSvg, { key: "svg" }),
+				spacer,
+				React.cloneElement(iconSvg, { key: "svg" })
 			)
 		} else {
 			linkContents.push(
-				React.cloneElement(iconSvg, { key: "svg" }),
+				spacer,
+				React.cloneElement(iconSvg, { key: "svg" })
 			)
 		}
 	}

--- a/src/core/components/link/stories.tsx
+++ b/src/core/components/link/stories.tsx
@@ -1,5 +1,6 @@
 export * from "./stories/inline-button-link"
 export * from "./stories/inline-link"
+export * from "./stories/inline-link-icon"
 export * from "./stories/priority-button-links"
 export * from "./stories/priority-links"
 export * from "./stories/subdued-links"

--- a/src/core/components/link/stories/inline-link-icon.tsx
+++ b/src/core/components/link/stories/inline-link-icon.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { css } from "@emotion/core"
+import { ThemeProvider } from "emotion-theming"
+import { textSans } from "@guardian/src-foundations/typography"
+import { Link, linkDefault } from "../index"
+import { SvgArrowRightStraight } from "@guardian/src-icons"
+
+const text = css`
+	${textSans.medium()}
+`
+
+export const inlineLinkIcon = () => (
+	<ThemeProvider theme={linkDefault}>
+		<p css={text}>
+			You can <Link iconSide="right" icon={<SvgArrowRightStraight />} subdued={true} href="#">read more</Link> about our services
+		</p>
+	</ThemeProvider>
+)
+inlineLinkIcon.story = { name: "inline link icon" }

--- a/src/core/components/link/stories/inline-link-icon.tsx
+++ b/src/core/components/link/stories/inline-link-icon.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/core"
 import { ThemeProvider } from "emotion-theming"
 import { textSans } from "@guardian/src-foundations/typography"
 import { Link, linkDefault } from "../index"
-import { SvgArrowRightStraight, SvgCamera, SvgChevronRightSingle, SvgChevronLeftSingle } from "@guardian/src-icons"
+import { SvgArrowRightStraight, SvgExternal, SvgChevronRightSingle, SvgChevronLeftSingle } from "@guardian/src-icons"
 
 const text = css`
 	${textSans.medium()}
@@ -15,7 +15,7 @@ export const inlineLinkIcon = () => (
 			You can <Link iconSide="right" icon={<SvgArrowRightStraight />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
 		</p>
 		<p css={text}>
-			You can <Link iconSide="left" icon={<SvgCamera />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
+			You can <Link iconSide="left" icon={<SvgExternal />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
 		</p>
 		<p css={text}>
 			Some more text here to test different wrapping points. You can <Link iconSide="right" icon={<SvgChevronRightSingle />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services

--- a/src/core/components/link/stories/inline-link-icon.tsx
+++ b/src/core/components/link/stories/inline-link-icon.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/core"
 import { ThemeProvider } from "emotion-theming"
 import { textSans } from "@guardian/src-foundations/typography"
 import { Link, linkDefault } from "../index"
-import { SvgArrowRightStraight, SvgCamera } from "@guardian/src-icons"
+import { SvgArrowRightStraight, SvgCamera, SvgChevronRightSingle, SvgChevronLeftSingle } from "@guardian/src-icons"
 
 const text = css`
 	${textSans.medium()}
@@ -16,6 +16,12 @@ export const inlineLinkIcon = () => (
 		</p>
 		<p css={text}>
 			You can <Link iconSide="left" icon={<SvgCamera />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
+		</p>
+		<p css={text}>
+			Some more text here to test different wrapping points. You can <Link iconSide="right" icon={<SvgChevronRightSingle />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
+		</p>
+		<p css={text}>
+		Some more text here to test different wrapping points. You can <Link iconSide="left" icon={<SvgChevronLeftSingle />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
 		</p>
 	</ThemeProvider>
 )

--- a/src/core/components/link/stories/inline-link-icon.tsx
+++ b/src/core/components/link/stories/inline-link-icon.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/core"
 import { ThemeProvider } from "emotion-theming"
 import { textSans } from "@guardian/src-foundations/typography"
 import { Link, linkDefault } from "../index"
-import { SvgArrowRightStraight } from "@guardian/src-icons"
+import { SvgArrowRightStraight, SvgCamera } from "@guardian/src-icons"
 
 const text = css`
 	${textSans.medium()}
@@ -12,7 +12,10 @@ const text = css`
 export const inlineLinkIcon = () => (
 	<ThemeProvider theme={linkDefault}>
 		<p css={text}>
-			You can <Link iconSide="right" icon={<SvgArrowRightStraight />} subdued={true} href="#">read more</Link> about our services
+			You can <Link iconSide="right" icon={<SvgArrowRightStraight />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
+		</p>
+		<p css={text}>
+			You can <Link iconSide="left" icon={<SvgCamera />} subdued={true} href="#">click this link to read more and find out all the important information</Link> about our services
 		</p>
 	</ThemeProvider>
 )

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -53,7 +53,12 @@ export const subdued = css`
 export const icon = css`
 	svg {
 		fill: currentColor;
-		vertical-align: text-top;
+		/*
+		TODO: hardcoded bottom margin to vertically align
+		icons with text. This needs to be revisited when
+		the rules of icon spacing have been formalised
+		 */
+		margin-bottom: -3px;
 		width: ${width.iconXsmall}px;
 		height: auto;
 	}

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -53,7 +53,7 @@ export const subdued = css`
 export const icon = css`
 	svg {
 		fill: currentColor;
-		vertical-align: middle;
+		vertical-align: text-top;
 		width: ${width.iconXsmall}px;
 		height: auto;
 	}

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -61,12 +61,13 @@ export const icon = css`
 
 export const iconRight = css`
 	svg {
-		margin-left: ${space[1]}px;
+		margin-left: -${space[5]}px;
 	}
 `
 
 export const iconLeft = css`
 	svg {
+		margin-left: -${space[6]}px;
 		margin-right: ${space[1]}px;
 	}
 `

--- a/src/core/components/link/styles.ts
+++ b/src/core/components/link/styles.ts
@@ -3,6 +3,7 @@ import { width } from "@guardian/src-foundations/size"
 import { linkDefault, LinkTheme } from "@guardian/src-foundations/themes"
 import { textSans } from "@guardian/src-foundations/typography"
 import { focusHalo } from "@guardian/src-foundations/accessibility"
+import { space } from "@guardian/src-foundations"
 
 export const link = css`
 	position: relative;
@@ -50,14 +51,9 @@ export const subdued = css`
 `
 
 export const icon = css`
-	/*
-	FIXME: This makes icons sit vertically centred, but breaks links with long
-	text descriptions onto a separate line to surrounding text
-	 */
-	display: inline-flex;
 	svg {
 		fill: currentColor;
-		position: absolute;
+		vertical-align: middle;
 		width: ${width.iconXsmall}px;
 		height: auto;
 	}
@@ -65,12 +61,12 @@ export const icon = css`
 
 export const iconRight = css`
 	svg {
-		right: 0;
+		margin-left: ${space[1]}px;
 	}
 `
 
 export const iconLeft = css`
 	svg {
-		left: 0;
+		margin-right: ${space[1]}px;
 	}
 `


### PR DESCRIPTION
## What is the purpose of this change?
Fixes https://github.com/guardian/source/issues/471 by removing `inline-flex` styles.

## What does this change?
-   Adds story for inline `Link` component with a left and right icon

## Screenshots
| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/96140379-c7661880-0ef7-11eb-8471-56f083cebdf6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11618797/96262015-1a53d480-0fb9-11eb-86bb-6e7b455b3588.png" width="300" /> |
