### PR TITLE
Add JSX a11y strict rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,13 +4,14 @@
 	"extends": [
 		"plugin:@typescript-eslint/recommended",
 		"plugin:react/recommended",
-		"plugin:jsx-a11y/recommended",
+		"plugin:jsx-a11y/strict",
 		"prettier/@typescript-eslint",
 		"prettier/react"
 	],
 	"rules": {
 		"@typescript-eslint/explicit-module-boundary-types": "off",
-		"@typescript-eslint/no-unused-vars": "off"
+		"@typescript-eslint/no-unused-vars": "off",
+		"jsx-a11y/label-has-for": "off"
 	},
 	"parserOptions": {
 		"ecmaFeatures": {


### PR DESCRIPTION
## What is the purpose of this change?

JSX a11y strict rules add an [extra layer of accessibility checks](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#difference-between-recommended-and-strict-mode) to our JSX. Really it just prevents us from overriding or diminishing the strictness of recommended rules.

## What does this change?

- Replaces the `plugin:jsx-a11y/recommended` plugin with `plugin:jsx-a11y/strict`.
- Disables the deprecated [`jsx-a11y/label-has-for`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) rule

