### PR TITLE
Choice card updates

### DIFF
--- a/src/core/components/choice-card/README.md
+++ b/src/core/components/choice-card/README.md
@@ -70,6 +70,12 @@ Additional text that appears below the `label`
 If true, users may select more than one choice card (checkbox behaviour). By default, users
 may only select a single choice card (radio button behaviour).
 
+### `columns`
+
+**`number`**
+
+To render a grid of choice cards, specify the number of columns. If this prop is not set, cards will appear on a single line.
+
 ### `error`
 
 **`string`**
@@ -103,13 +109,6 @@ An icon that appears inside the button, alongside text
 Whether choice card is checked. This is necessary when using the [controlled approach](https://reactjs.org/docs/forms.html#controlled-components) to form state management.
 
 **Note:** if you pass the `checked` prop, you **must** also pass an `onChange` handler, or the field will be rendered as read-only.
-
-### `columns`
-
-**`number`**
-
-To render a grid of choice cards, specify the number of columns. If this prop is not set, cards will appear on a single line.
-
 
 ## Supported themes
 

--- a/src/core/components/choice-card/stories/with-columns.tsx
+++ b/src/core/components/choice-card/stories/with-columns.tsx
@@ -1,7 +1,5 @@
-import React, { useState } from "react"
+import React from "react"
 import { css } from "@emotion/core"
-import { textSans } from "@guardian/src-foundations/typography"
-import { text } from "@guardian/src-foundations/palette"
 import { space } from "@guardian/src-foundations"
 import { ChoiceCardGroup, ChoiceCard } from "../index"
 
@@ -13,60 +11,35 @@ const spaced = css`
 	margin-bottom: ${space[3]}px;
 `
 
-const message = css`
-	${textSans.medium()};
-	color: ${text.primary};
-`
-
 export const singleStateControlledWithColumns = () => {
-	const [selected, setSelected] = useState<string | null>("green")
-
 	return (
 		<div css={medium}>
 			<div css={spaced}>
-				<ChoiceCardGroup name="colours" columns={2}>
-					<ChoiceCard
-						value="red"
-						label="Red"
-						id="default-red"
-						checked={selected === "red"}
-						onChange={() => setSelected("red")}
-					/>
+				<ChoiceCardGroup name="colours" columns={3}>
+					<ChoiceCard value="red" label="Red" id="default-red" />
 					<ChoiceCard
 						value="green"
 						label="Green"
 						id="default-green"
-						checked={selected === "green"}
-						onChange={() => setSelected("green")}
+						defaultChecked={true}
 					/>
-					<ChoiceCard
-						value="blue"
-						label="Blue"
-						id="default-blue"
-						checked={selected === "blue"}
-						onChange={() => setSelected("blue")}
-					/>
+					<ChoiceCard value="blue" label="Blue" id="default-blue" />
 					<ChoiceCard
 						value="orange"
 						label="Orange"
 						id="default-orange"
-						checked={selected === "orange"}
-						onChange={() => setSelected("orange")}
 					/>
 					<ChoiceCard
 						value="yellow"
 						label="Yellow"
 						id="default-yellow"
-						checked={selected === "yellow"}
-						onChange={() => setSelected("yellow")}
 					/>
 				</ChoiceCardGroup>
 			</div>
-			<span css={message}>{selected} is selected</span>
 		</div>
 	)
 }
 
 singleStateControlledWithColumns.story = {
-	name: `single state controlled with columns example`,
+	name: `single state with columns`,
 }


### PR DESCRIPTION
## What is the purpose of this change?

Polish up the documentation of Choice Cards to make it clearer (and actually correct!)

## What does this change?

-   Move `columns` prop to `ChoiceCardGroup` in README 
-   Simplify the `columns` story

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**


![Screenshot 2020-11-03 at 10 56 31](https://user-images.githubusercontent.com/5931528/97976909-43e76b00-1dc3-11eb-8cdb-dc667740aab1.png)

**After**

![Screenshot 2020-11-03 at 10 56 38](https://user-images.githubusercontent.com/5931528/97976910-44800180-1dc3-11eb-8138-36874c52832e.png)


