### PR TITLE
Tag prereleases as beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
 		"release:major:all": "yarn build:all && yarn validate && yarn verbump:major:all && yarn publish:release",
 		"release:minor:all": "yarn build:all && yarn validate && yarn verbump:minor:all && yarn publish:release",
 		"release:patch:all": "yarn build:all && yarn validate && yarn verbump:patch:all && yarn publish:release",
-		"release:prerelease:all": "yarn build:all && yarn validate && yarn publish:release",
-		"release:prerelease-bump:all": "yarn build:all && yarn validate && yarn verbump:prerelease:all && yarn publish:release"
+		"release:prerelease:all": "yarn build:all && yarn validate && yarn publish:release && yarn tag:beta:all",
+		"release:prerelease-bump:all": "yarn build:all && yarn validate && yarn verbump:prerelease:all && yarn publish:release && yarn tag:beta:all",
+		"tag:beta:all": "ts-node ./scripts/tag-beta-all"
 	},
 	"private": true,
 	"workspaces": [

--- a/scripts/package-names.ts
+++ b/scripts/package-names.ts
@@ -1,0 +1,54 @@
+import { join } from "path"
+import { readdir, stat } from "fs"
+import { promisify } from "util"
+
+const readdirP = promisify(readdir)
+const statP = promisify(stat)
+
+const coreComponents = join(__dirname, "../src/core/components")
+const editorialComponents = join(__dirname, "../src/editorial/web/components")
+
+const isDirectory = (path: string) =>
+	statP(path).then((stats) => stats.isDirectory())
+
+export const getComponentPackageNames = () =>
+	Promise.all([
+		readdirP(coreComponents)
+			.then((componentDirs) =>
+				Promise.all(
+					componentDirs.map((componentDirName) =>
+						isDirectory(
+							`${coreComponents}/${componentDirName}`,
+						).then((isDir) => {
+							if (!isDir) return
+
+							return `@guardian/src-${componentDirName}`
+						}),
+					),
+				),
+			)
+			.then((paths) => Promise.resolve(paths.filter((path) => !!path))),
+		readdirP(editorialComponents)
+			.then((componentDirs) =>
+				Promise.all(
+					componentDirs.map((componentDirName) =>
+						isDirectory(
+							`${editorialComponents}/${componentDirName}`,
+						).then((isDir) => {
+							if (!isDir) return
+
+							return `@guardian/src-ed-${componentDirName}`
+						}),
+					),
+				),
+			)
+			.then((paths) => Promise.resolve(paths.filter((path) => !!path))),
+	]).then(([corePaths, editorialPaths]) => [...corePaths, ...editorialPaths])
+
+export const packageNames = {
+	foundations: "@guardian/src-foundations",
+	svgs: "@guardian/src-svgs",
+	icons: "@guardian/src-icons",
+	brand: "@guardian/src-brand",
+	helpers: "@guardian/src-helpers",
+}

--- a/scripts/tag-beta-all.ts
+++ b/scripts/tag-beta-all.ts
@@ -1,0 +1,25 @@
+import execa from "execa"
+import { version } from "../package.json"
+import { packageNames, getComponentPackageNames } from "./package-names"
+
+const tag = (packageName: string) => {
+	return execa("yarn", ["tag", "add", `${packageName}@${version}`, "beta"], {
+		stdio: "inherit",
+	})
+}
+
+const { foundations, svgs, icons, brand, helpers } = packageNames
+
+const packages = getComponentPackageNames().then((ps) =>
+	ps.concat([foundations, svgs, icons, brand, helpers]),
+)
+
+packages.then((ps) => {
+	ps.forEach((packageName) => {
+		if (!packageName) return
+
+		tag(packageName).catch((err) =>
+			console.log("Error tagging packages:", err),
+		)
+	})
+})


### PR DESCRIPTION
## What is the purpose of this change?

Currently if a prerelease is the latest release and a project attempts to add a Source package as a dependency, by default the project will get the prerelease. This might not be what the project maintainer wants or expects.

We should implement a mechanism that ensures prereleases receive a beta tag so that they will not be installed automatically.

See [related Client Side Infra discussion](https://github.com/orgs/guardian/teams/client-side-infra/discussions/16)

## What does this change?

-   Add a beta tagging script

See [`yarn tag` docs](https://classic.yarnpkg.com/en/docs/cli/tag/)
