### PR TITLE
Delete dynamo 400

### DIFF
--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -112,11 +112,5 @@ export const specialReport = {
 	300: colors.grays[12],
 	400: colors.grays[13],
 	500: colors.grays[14],
-	800: colors.grays[16],
-}
-
-// Deprecated - please do not use
-// TODO: remove in v3.0.0
-export const dynamo = {
-	400: colors.grays[15],
+	800: colors.grays[15],
 }

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -123,7 +123,6 @@ const colors = {
 		"#3F464A", //specialReport-300
 		"#63717A", //specialReport-400
 		"#ABC2C9", //specialReport-500
-		"#33393D", //dynamo-400
 		"#EFF1F2", //specialReport-800
 	],
 }


### PR DESCRIPTION
## What is the purpose of this change?

Following deprecation in #486, this colour should no longer be used and should therefore be deleted.

## What does this change?

-   Delete dynamo.400 from global palette
-   Delete `#33393d` from theme

