### PR TITLE
Import columns type from tiles component

### DIFF
--- a/src/core/components/layout/components/tiles/styles.ts
+++ b/src/core/components/layout/components/tiles/styles.ts
@@ -1,5 +1,5 @@
 import { css, SerializedStyles } from "@emotion/core"
-import { Columns } from "@guardian/src-choice-card"
+import { Columns } from "./tiles"
 import { from, until } from "@guardian/src-foundations/mq"
 import { space } from "@guardian/src-foundations"
 

--- a/src/core/components/layout/components/tiles/tiles.tsx
+++ b/src/core/components/layout/components/tiles/tiles.tsx
@@ -14,7 +14,7 @@ import {
 } from "../tiles/styles"
 import { Breakpoint } from "@guardian/src-foundations/mq"
 
-type Columns = 2 | 3 | 4 | 5
+export type Columns = 2 | 3 | 4 | 5
 
 type GridBreakpoint = Extract<
 	Breakpoint,


### PR DESCRIPTION
## What is the purpose of this change?

The `Columns` type in Tiles is currently imported from Choice Card. This creates an undesirable cross-package dependency, leading to compilation failure in projects that don't explicitly depend on both Layout and Choice Card packages.

We should import `Columns` from the Tiles module instead.

## What does this change?

-   Export `Columns` from the Tiles module
-   Import `Columns` into Tiles styles from the Tiles module