### PR TITLE
Pass props from accordion component to root element

### DIFF
--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -29,9 +29,13 @@ interface AccordionProps extends Props {
 	children: ReactElement[]
 }
 
-const Accordion = ({ hideToggleLabel = false, children }: AccordionProps) => {
+const Accordion = ({
+	hideToggleLabel = false,
+	children,
+	...props
+}: AccordionProps) => {
 	return (
-		<div css={(theme) => accordion(theme.accordion && theme)}>
+		<div css={(theme) => accordion(theme.accordion && theme)} {...props}>
 			{React.Children.map(children, (child) => {
 				return React.cloneElement(child, { hideToggleLabel })
 			})}
@@ -49,9 +53,10 @@ const NoJsRow = ({
 	label,
 	hideToggleLabel = false,
 	children,
+	...props
 }: AccordionRowProps) => {
 	return (
-		<div css={(theme) => accordionRow(theme.accordion && theme)}>
+		<div css={(theme) => accordionRow(theme.accordion && theme)} {...props}>
 			<label>
 				<input type="checkbox" css={noJsInput} role="button" />
 				<div


### PR DESCRIPTION
## What is the purpose of this change?

Accordions should receive any props that a div might receive. Those props should be passed to the root element of the accordion. This is the way every other Source component works, so it makes sense for Accordion to work this way too

## What does this change?

-   Accordion and AccordionRow props should extend those of the HTMLDivElement
-   Props should be passed to the root element for each component

