### PR TITLE
Add font size: text sans 14px

### DIFF
--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -22,7 +22,7 @@
 // - Pushing a value onto the end of an array
 // - Exporting a new object or array
 
-const fontSizes = [12, 15, 17, 20, 24, 28, 34, 42, 50, 70]
+const fontSizes = [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70]
 
 const fonts = {
 	titlepiece: "GT Guardian Titlepiece, Georgia, serif",

--- a/src/core/foundations/src/typography/data.ts
+++ b/src/core/foundations/src/typography/data.ts
@@ -13,34 +13,35 @@ import {
 } from "./types"
 
 const titlepieceSizes: TitlepieceSizes = {
-	small: fontSizes[7], //42px
-	medium: fontSizes[8], //50px
-	large: fontSizes[9], //70px
+	small: fontSizes[8], //42px
+	medium: fontSizes[9], //50px
+	large: fontSizes[10], //70px
 }
 
 const headlineSizes: HeadlineSizes = {
-	xxxsmall: fontSizes[2], //17px
-	xxsmall: fontSizes[3], //20px
-	xsmall: fontSizes[4], //24px
-	small: fontSizes[5], //28px
-	medium: fontSizes[6], //34px
-	large: fontSizes[7], //42px
-	xlarge: fontSizes[8], //50px
+	xxxsmall: fontSizes[3], //17px
+	xxsmall: fontSizes[4], //20px
+	xsmall: fontSizes[5], //24px
+	small: fontSizes[6], //28px
+	medium: fontSizes[7], //34px
+	large: fontSizes[8], //42px
+	xlarge: fontSizes[9], //50px
 }
 
 const bodySizes: BodySizes = {
-	small: fontSizes[1], //15px
-	medium: fontSizes[2], //17px
+	small: fontSizes[2], //15px
+	medium: fontSizes[3], //17px
 }
 
 const textSansSizes: TextSansSizes = {
-	xsmall: fontSizes[0], //12px
-	small: fontSizes[1], //15px
-	medium: fontSizes[2], //17px
-	large: fontSizes[3], //20px
-	xlarge: fontSizes[4], //24px
-	xxlarge: fontSizes[5], //28px
-	xxxlarge: fontSizes[6], //34px
+	xxsmall: fontSizes[0], //12px
+	xsmall: fontSizes[1], //14px
+	small: fontSizes[2], //15px
+	medium: fontSizes[3], //17px
+	large: fontSizes[4], //20px
+	xlarge: fontSizes[5], //24px
+	xxlarge: fontSizes[6], //28px
+	xxxlarge: fontSizes[7], //34px
 }
 
 const fontSizeMapping: {


### PR DESCRIPTION
## What is the purpose of this change?

Text Sans has a new 14px font size for use in galleries and navigation.

## What does this change?

-   Add 14px to theme
-   Allow textSans to be set to 14px

⚠️  **Breaking change:** Calls to `textSans.xsmall(...)` will need to be replaced with `textSans.xxsmall(...)`
