### PR TITLE
Make label and supporting text hideable

### DIFF
--- a/src/core/components/label/README.md
+++ b/src/core/components/label/README.md
@@ -56,6 +56,12 @@ Additional text that appears below the label
 
 Adds the word "Optional" after the label.
 
+### `hideLabel`
+
+**`boolean`** _= "false"_
+
+Visually hides the label.
+
 ## Supported themes
 
 ### Standard

--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -13,6 +13,7 @@ interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement>, Props {
 	text: string
 	supporting?: string
 	optional: boolean
+	hideLabel?: boolean
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 	children?: ReactNode
 }
@@ -24,14 +25,32 @@ interface LegendProps extends HTMLAttributes<HTMLLegendElement>, Props {
 	cssOverrides?: SerializedStyles | SerializedStyles[]
 }
 
-const SupportingText = ({ children }: { children: ReactNode }) => {
+const SupportingText = ({
+	hideLabel,
+	children,
+}: {
+	hideLabel?: boolean
+	children: ReactNode
+}) => {
 	return (
-		<p css={(theme) => supportingText(theme.label && theme)}>{children}</p>
+		<p
+			css={(theme) => [
+				supportingText(theme.label && theme),
+				hideLabel ? visuallyHidden : "",
+			]}
+		>
+			{children}
+		</p>
 	)
 }
 
-const Text = ({ text, optional }: LabelProps) => (
-	<span css={(theme) => labelText(theme.label && theme)}>
+const Text = ({ text, optional, hideLabel }: LabelProps) => (
+	<span
+		css={(theme) => [
+			labelText(theme.label && theme),
+			hideLabel ? visuallyHidden : "",
+		]}
+	>
 		{text}{" "}
 		{optional ? (
 			<span css={(theme) => optionalText(theme.label && theme)}>
@@ -53,17 +72,16 @@ const Legend = ({
 }: LegendProps) => {
 	return (
 		<>
-			<legend
-				css={[
-					legend,
-					hideLabel ? visuallyHidden : undefined,
-					cssOverrides,
-				]}
-				{...props}
-			>
-				<Text text={text} optional={optional} />
+			<legend css={[legend, cssOverrides]} {...props}>
+				<Text text={text} optional={optional} hideLabel={hideLabel} />
 			</legend>
-			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
+			{supporting ? (
+				<SupportingText hideLabel={hideLabel}>
+					{supporting}
+				</SupportingText>
+			) : (
+				""
+			)}
 		</>
 	)
 }
@@ -72,14 +90,21 @@ const Label = ({
 	text,
 	supporting,
 	optional,
+	hideLabel,
 	cssOverrides,
 	children,
 	...props
 }: LabelProps) => {
 	return (
 		<label css={cssOverrides} {...props}>
-			<Text text={text} optional={optional} />
-			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
+			<Text hideLabel={hideLabel} text={text} optional={optional} />
+			{supporting ? (
+				<SupportingText hideLabel={hideLabel}>
+					{supporting}
+				</SupportingText>
+			) : (
+				""
+			)}
 			{children}
 		</label>
 	)


### PR DESCRIPTION
## What is the purpose of this change?

Currently labels are not hideable whereas legends are. We should bring labels into line with legends

Also supporting text is never hidden, even when the `hideLabel` prop is passed. We should ensure that `hideLabel` hides supporting text too

## What does this change?

-   Allow Label component to accept `hideLabel` prop
-   Pass `hideLabel` to Text and SupportingText helper components 

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before - an unhideable label**

![Screenshot 2020-12-04 at 11 43 47](https://user-images.githubusercontent.com/5931528/101160153-7e446200-3626-11eb-99bf-2888a2b8767e.png)


**After - label now hidden**

![Screenshot 2020-12-04 at 11 45 53](https://user-images.githubusercontent.com/5931528/101160162-81d7e900-3626-11eb-91f9-e2a64b22715b.png)


**Before - supporting text didn't hide**

![Screenshot 2020-12-04 at 11 52 16](https://user-images.githubusercontent.com/5931528/101160653-4db0f800-3627-11eb-9b88-b3379b9f1165.png)


**After - supporting text be gone**

![Screenshot 2020-12-04 at 11 50 48](https://user-images.githubusercontent.com/5931528/101160667-51447f00-3627-11eb-99aa-2f01a439898f.png)




## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

