### PR TITLE
Use src-label in text area

### DIFF
--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -1,24 +1,10 @@
-import React, { ReactNode, InputHTMLAttributes } from "react"
-import { SerializedStyles, css } from "@emotion/core"
+import React, { InputHTMLAttributes } from "react"
+import { SerializedStyles } from "@emotion/core"
 import { InlineError } from "@guardian/src-user-feedback"
-import {
-	widthFluid,
-	textArea,
-	label,
-	errorInput,
-	optionalLabel,
-	supportingText,
-} from "./styles"
+import { Label } from "@guardian/src-label"
+import { widthFluid, textArea, errorInput } from "./styles"
 import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
-
-const visuallyHidden = css`
-	${_visuallyHidden}
-`
-
-const SupportingText = ({ children }: { children: ReactNode }) => {
-	return <div css={supportingText}>{children}</div>
-}
 
 interface TextAreaProps
 	extends InputHTMLAttributes<HTMLTextAreaElement>,
@@ -61,12 +47,12 @@ const TextArea = ({
 	}
 
 	return (
-		<label>
-			<div css={[label, hideLabel ? visuallyHidden : ""]}>
-				{labelText}{" "}
-				{optional ? <span css={optionalLabel}>Optional</span> : ""}
-			</div>
-			{supporting ? <SupportingText>{supporting}</SupportingText> : ""}
+		<Label
+			text={labelText}
+			supporting={supporting}
+			optional={optional}
+			hideLabel={hideLabel}
+		>
 			{error && <InlineError>{error}</InlineError>}
 			<textarea
 				css={[
@@ -82,7 +68,7 @@ const TextArea = ({
 				className={getClassName()}
 				{...props}
 			/>
-		</label>
+		</Label>
 	)
 }
 

--- a/src/core/components/text-area/styles.ts
+++ b/src/core/components/text-area/styles.ts
@@ -45,21 +45,3 @@ export const textArea = css`
 export const widthFluid = css`
 	width: 100%;
 `
-
-export const label = css`
-	${textSans.medium({ fontWeight: "bold", lineHeight: "regular" })};
-	color: ${text.inputLabel};
-	margin-bottom: ${space[1]}px;
-`
-
-export const optionalLabel = css`
-	${textSans.small()};
-	color: ${text.inputLabelSupporting};
-	font-style: italic;
-`
-
-export const supportingText = css`
-	${textSans.small()};
-	color: ${text.inputLabelSupporting};
-	margin-bottom: ${space[1]}px;
-`


### PR DESCRIPTION
## What is the purpose of this change?

We now have the reusable `@guardian/src-label` component, meaning the label defined in `@guardian/src-textarea` is redundant.

We should swap out textarea's label for the reusable component

## What does this change?

-   swap out textarea's label for the reusable label component

There should be no visual or API differences
