### PR TITLE
Make label text block level

### DIFF
--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -45,7 +45,7 @@ const SupportingText = ({
 }
 
 const Text = ({ text, optional, hideLabel }: LabelProps) => (
-	<span
+	<div
 		css={(theme) => [
 			labelText(theme.label && theme),
 			hideLabel ? visuallyHidden : "",
@@ -59,7 +59,7 @@ const Text = ({ text, optional, hideLabel }: LabelProps) => (
 		) : (
 			""
 		)}
-	</span>
+	</div>
 )
 
 const Legend = ({


### PR DESCRIPTION
## What is the purpose of this change?

Label text should be block level, not inline. This will ensure the label always appears on its own line

## What does this change?

-   Make label text appear in a div rather than a span

## Screenshots


**Before**

<img width="493" alt="Screenshot 2020-12-15 at 10 10 06" src="https://user-images.githubusercontent.com/5931528/102201240-ba48b400-3ebd-11eb-8a51-22bea3ff3e22.png">


**After**

<img width="386" alt="Screenshot 2020-12-15 at 10 08 40" src="https://user-images.githubusercontent.com/5931528/102201066-866d8e80-3ebd-11eb-9946-d7315151285f.png">


## Checklist

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

