### PR TITLE
Auto-generate IDs for form fields / fieldsets without IDs

### DIFF
--- a/src/core/components/checkbox/index.tsx
+++ b/src/core/components/checkbox/index.tsx
@@ -1,7 +1,10 @@
 import React, { ReactNode, InputHTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/core"
 import { InlineError } from "@guardian/src-user-feedback"
-import { descriptionId } from "@guardian/src-foundations/accessibility"
+import {
+	descriptionId,
+	generateSourceId,
+} from "@guardian/src-foundations/accessibility"
 import { Legend } from "@guardian/src-label"
 import {
 	fieldset,
@@ -24,8 +27,6 @@ export {
 } from "@guardian/src-foundations/themes"
 
 interface CheckboxGroupProps extends Props {
-	// TODO: this is required when an error is passed to correctly set aria-describedby
-	// We should introduce a way of generating element IDs when they are not explicitly passed
 	id?: string
 	name: string
 	label?: string
@@ -47,6 +48,7 @@ const CheckboxGroup = ({
 	children,
 	...props
 }: CheckboxGroupProps) => {
+	const groupId = id || generateSourceId()
 	const legend = label ? (
 		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
 	) : (
@@ -55,22 +57,24 @@ const CheckboxGroup = ({
 
 	const message =
 		typeof error === "string" ? (
-			<InlineError id={id ? descriptionId(id) : ""}>{error}</InlineError>
+			<InlineError id={descriptionId(groupId)}>{error}</InlineError>
 		) : (
 			""
 		)
 
 	return (
-		<fieldset css={[fieldset, cssOverrides]} id={id} {...props}>
+		<fieldset css={[fieldset, cssOverrides]} id={groupId} {...props}>
 			{legend}
 			{message}
 			{React.Children.map(children, (child) => {
 				return React.cloneElement(
 					child,
 					Object.assign(
-						error ? { error: true } : {},
-						error && id
-							? { "aria-describedby": descriptionId(id) }
+						error
+							? {
+									error: true,
+									"aria-describedby": descriptionId(groupId),
+							  }
 							: {},
 						{
 							name,

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -22,12 +22,17 @@ import {
 } from "./styles"
 import { InlineError } from "@guardian/src-user-feedback"
 import { Props } from "@guardian/src-helpers"
+import {
+	descriptionId,
+	generateSourceId,
+} from "@guardian/src-foundations/accessibility"
 
 export { choiceCardDefault } from "@guardian/src-foundations/themes"
 
 export type Columns = 2 | 3 | 4 | 5
 
 interface ChoiceCardGroupProps extends Props {
+	id?: string
 	name: string
 	label?: string
 	supporting?: string
@@ -39,6 +44,7 @@ interface ChoiceCardGroupProps extends Props {
 }
 
 const ChoiceCardGroup = ({
+	id,
 	name,
 	label,
 	supporting,
@@ -49,10 +55,13 @@ const ChoiceCardGroup = ({
 	children,
 	...props
 }: ChoiceCardGroupProps) => {
+	const groupId = id || generateSourceId()
 	return (
-		<fieldset css={[fieldset, cssOverrides]} {...props}>
+		<fieldset css={[fieldset, cssOverrides]} id={groupId} {...props}>
 			{label ? <Legend text={label} supporting={supporting} /> : ""}
-			{typeof error === "string" && <InlineError>{error}</InlineError>}
+			{typeof error === "string" && (
+				<InlineError id={descriptionId(groupId)}>{error}</InlineError>
+			)}
 			<div
 				css={
 					columns
@@ -65,9 +74,16 @@ const ChoiceCardGroup = ({
 						child,
 						Object.assign(
 							{
-								error: !!error,
 								type: multi ? "checkbox" : "radio",
 							},
+							error
+								? {
+										error: true,
+										"aria-describedby": descriptionId(
+											groupId,
+										),
+								  }
+								: {},
 							{
 								name,
 							},

--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -2,7 +2,10 @@ import React, { ReactNode, InputHTMLAttributes } from "react"
 import { SerializedStyles } from "@emotion/core"
 import { Legend } from "@guardian/src-label"
 import { InlineError } from "@guardian/src-user-feedback"
-import { descriptionId } from "@guardian/src-foundations/accessibility"
+import {
+	descriptionId,
+	generateSourceId,
+} from "@guardian/src-foundations/accessibility"
 import {
 	fieldset,
 	label,
@@ -49,19 +52,20 @@ const RadioGroup = ({
 	children,
 	...props
 }: RadioGroupProps) => {
+	const groupId = id || generateSourceId()
 	const legend = label ? (
 		<Legend text={label} supporting={supporting} hideLabel={hideLabel} />
 	) : (
 		""
 	)
 	const message = error && (
-		<InlineError id={id ? descriptionId(id) : ""}>{error}</InlineError>
+		<InlineError id={descriptionId(groupId)}>{error}</InlineError>
 	)
 
 	return (
 		<fieldset
 			aria-invalid={!!error}
-			id={id}
+			id={groupId}
 			css={(theme) => [
 				fieldset(theme.radio && theme),
 				orientationStyles[orientation],
@@ -75,8 +79,10 @@ const RadioGroup = ({
 				return React.cloneElement(
 					child,
 					Object.assign(
-						error && id
-							? { "aria-describedby": descriptionId(id) }
+						error
+							? {
+									"aria-describedby": descriptionId(groupId),
+							  }
 							: {},
 						{
 							name,

--- a/src/core/components/select/index.tsx
+++ b/src/core/components/select/index.tsx
@@ -13,10 +13,15 @@ import {
 import { Props } from "@guardian/src-helpers"
 import { SvgChevronDownSingle } from "@guardian/src-icons"
 
-import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
+import {
+	visuallyHidden as _visuallyHidden,
+	descriptionId,
+	generateSourceId,
+} from "@guardian/src-foundations/accessibility"
 export { selectDefault } from "@guardian/src-foundations/themes"
 
 interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement>, Props {
+	id?: string
 	label: string
 	optional: boolean
 	hideLabel: boolean
@@ -28,6 +33,7 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement>, Props {
 }
 
 const Select = ({
+	id,
 	label: labelText,
 	optional,
 	hideLabel,
@@ -38,6 +44,7 @@ const Select = ({
 	children,
 	...props
 }: SelectProps) => {
+	const selectId = id || generateSourceId()
 	return (
 		<Label
 			text={labelText}
@@ -45,8 +52,14 @@ const Select = ({
 			supporting={supporting}
 			hideLabel={hideLabel}
 		>
-			{error && <InlineError>{error}</InlineError>}
-			{!error && success && <InlineSuccess>{success}</InlineSuccess>}
+			{error && (
+				<InlineError id={descriptionId(selectId)}>{error}</InlineError>
+			)}
+			{!error && success && (
+				<InlineSuccess id={descriptionId(selectId)}>
+					{success}
+				</InlineSuccess>
+			)}
 			<div
 				css={(theme) => [
 					selectWrapper(theme.select && theme),
@@ -67,6 +80,10 @@ const Select = ({
 					]}
 					aria-required={!optional}
 					aria-invalid={!!error}
+					aria-describedby={
+						error || success ? descriptionId(selectId) : ""
+					}
+					id={selectId}
 					{...props}
 				>
 					{children}

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -3,12 +3,17 @@ import { SerializedStyles } from "@emotion/core"
 import { InlineError } from "@guardian/src-user-feedback"
 import { Label } from "@guardian/src-label"
 import { widthFluid, textArea, errorInput } from "./styles"
-import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
+import {
+	visuallyHidden as _visuallyHidden,
+	descriptionId,
+	generateSourceId,
+} from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
 
 interface TextAreaProps
 	extends InputHTMLAttributes<HTMLTextAreaElement>,
 		Props {
+	id?: string
 	value?: string
 	label: string
 	optional: boolean
@@ -21,6 +26,7 @@ interface TextAreaProps
 }
 
 const TextArea = ({
+	id,
 	label: labelText,
 	optional,
 	hideLabel,
@@ -32,6 +38,7 @@ const TextArea = ({
 	value,
 	...props
 }: TextAreaProps) => {
+	const textAreaId = id || generateSourceId()
 	const getClassName = () => {
 		const HAS_VALUE_CLASS = "src-has-value"
 
@@ -53,7 +60,11 @@ const TextArea = ({
 			optional={optional}
 			hideLabel={hideLabel}
 		>
-			{error && <InlineError>{error}</InlineError>}
+			{error && (
+				<InlineError id={descriptionId(textAreaId)}>
+					{error}
+				</InlineError>
+			)}
 			<textarea
 				css={[
 					widthFluid,
@@ -61,8 +72,10 @@ const TextArea = ({
 					error ? errorInput : "",
 					cssOverrides,
 				]}
+				id={textAreaId}
 				aria-required={!optional}
 				aria-invalid={!!error}
+				aria-describedby={error ? descriptionId(textAreaId) : ""}
 				required={!optional}
 				rows={rows}
 				className={getClassName()}

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -11,7 +11,11 @@ import {
 	errorInput,
 	successInput,
 } from "./styles"
-import { visuallyHidden as _visuallyHidden } from "@guardian/src-foundations/accessibility"
+import {
+	visuallyHidden as _visuallyHidden,
+	descriptionId,
+	generateSourceId,
+} from "@guardian/src-foundations/accessibility"
 import { Props } from "@guardian/src-helpers"
 
 export { textInputDefault } from "@guardian/src-foundations/themes"
@@ -26,6 +30,7 @@ const widths: {
 }
 
 interface TextInputProps extends InputHTMLAttributes<HTMLInputElement>, Props {
+	id?: string
 	label: string
 	optional: boolean
 	hideLabel: boolean
@@ -37,6 +42,7 @@ interface TextInputProps extends InputHTMLAttributes<HTMLInputElement>, Props {
 }
 
 const TextInput = ({
+	id,
 	label: labelText,
 	optional,
 	hideLabel,
@@ -47,6 +53,7 @@ const TextInput = ({
 	cssOverrides,
 	...props
 }: TextInputProps) => {
+	const textInputId = id || generateSourceId()
 	return (
 		<Label
 			text={labelText}
@@ -54,8 +61,16 @@ const TextInput = ({
 			hideLabel={hideLabel}
 			supporting={supporting}
 		>
-			{error && <InlineError>{error}</InlineError>}
-			{!error && success && <InlineSuccess>{success}</InlineSuccess>}
+			{error && (
+				<InlineError id={descriptionId(textInputId)}>
+					{error}
+				</InlineError>
+			)}
+			{!error && success && (
+				<InlineSuccess id={descriptionId(textInputId)}>
+					{success}
+				</InlineSuccess>
+			)}
 			<input
 				css={(theme) => [
 					width ? widths[width] : widthFluid,
@@ -66,8 +81,12 @@ const TextInput = ({
 						: "",
 					cssOverrides,
 				]}
+				id={textInputId}
 				aria-required={!optional}
 				aria-invalid={!!error}
+				aria-describedby={
+					error || success ? descriptionId(textInputId) : ""
+				}
 				required={!optional}
 				{...props}
 			/>

--- a/src/core/foundations/src/accessibility/index.ts
+++ b/src/core/foundations/src/accessibility/index.ts
@@ -18,4 +18,8 @@ const focusHalo = `
 
 const descriptionId = (id: string) => `${id}_description`
 
-export { visuallyHidden, focusHalo, descriptionId }
+let sourceIdIndex = 0
+
+const generateSourceId = () => `src-component-${sourceIdIndex++}`
+
+export { visuallyHidden, focusHalo, descriptionId, generateSourceId }


### PR DESCRIPTION
## What is the purpose of this change?

All form fields or fieldsets that could potentially show an error message need an ID. This allows us to associate an error or success message with the respective form field or fieldset using `aria-describedby`.

Since we don't want to force consumers to always add an ID, missing IDs will be autogenerated by a new function in Foundations.

## What does this change?

- Define `generateSourceId`, a function that generates an ID for an element
- Associate error message with text input, autogenerating ID if necessary
- Associate error message with text area, autogenerating ID if necessary
- Associate error message with text select, autogenerating ID if necessary
- Associate error message with choice card group
- Auto-generate missing ID for checkbox group
- Auto-generate missing ID for radio group

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
