### PR TITLE
Disallow pointer events on the checkbox tick to prevent Selenium test issues

### DIFF
--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -120,6 +120,11 @@ export const tick = ({
 		*/
 		top: 14px;
 		left: 9px;
+		/*
+			this prevents simulated click events to the checkbox, eg from Selenium tests
+			from being intercepted by the tick
+		*/
+		pointer-events: none;
 
 		/* the checkmark ✓ */
 		&:after,


### PR DESCRIPTION
## What is the purpose of this change?

This fixes #663. Our Selenium tests on support-frontend were failing on the checkbox component, as the simulated click event on the checkbox input was intercepted by the span element that provides the animated tick. Adding a `pointer-events: none` rule to this span fixes the issue without causing any visual regressions.

The issue doesn't affect the radio buttons, despite also having an animated overlay, as in that component it's provided by a pseudo-element. 

## What does this change?

-   Added a `pointer-events: none` rule to the `tick` styles, and an explanatory comment

## Checklist

### Cross browser and device testing

-   [x] Tested with touch screen device
