### PR TITLE
Update Footer Copyright To 2021

### DIFF
--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -58,7 +58,7 @@ const Footer = ({
 			<small
 				css={[copyright, showBackToTop ? copyrightExtraPadding : ""]}
 			>
-				&copy; 2020 Guardian News and Media Limited or its affiliated
+				&copy; 2021 Guardian News and Media Limited or its affiliated
 				companies. All rights reserved.
 			</small>
 		</footer>


### PR DESCRIPTION
## What is the purpose of this change?

It's 2021.

## What does this change?

- Updated the copyright notice to 2021.
