### PR TITLE
Introduce Editorial package

### DIFF
--- a/src/editorial/web/.babelrc.js
+++ b/src/editorial/web/.babelrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+	presets: [
+		"@babel/preset-env",
+		"@babel/preset-typescript",
+		"@babel/preset-react",
+		"@emotion/babel-preset-css-prop",
+	],
+}

--- a/src/editorial/web/README.md
+++ b/src/editorial/web/README.md
@@ -1,0 +1,24 @@
+# Editorial System
+
+## Install
+
+```sh
+$ yarn add @guardian/editorial
+```
+
+```sh
+$ npm install @guardian/editorial
+```
+
+## Use
+
+```tsx
+import { Lines } from "@guardian/editorial"
+
+const Section = () => (
+    <>
+        <Lines count={8} />
+        <Lines effect="squiggly" />
+    </>
+)
+```

--- a/src/editorial/web/index.tsx
+++ b/src/editorial/web/index.tsx
@@ -1,0 +1,1 @@
+export { Lines } from "./components/lines"

--- a/src/editorial/web/package.json
+++ b/src/editorial/web/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@guardian/editorial",
+    "version": "3.1.0-rc.0",
+    "license": "Apache-2.0",
+    "main": "dist/editorial.js",
+    "module": "dist/editorial.esm.js",
+    "scripts": {
+        "build": "yarn clean && rollup --config",
+        "clean": "rm -rf dist",
+        "prepublish": "yarn build",
+        "publish:public": "yarn publish --access public",
+        "verbump:major": "yarn version --major --no-git-tag-version",
+        "verbump:minor": "yarn version --minor --no-git-tag-version",
+        "verbump:preminor": "yarn version --preminor --preid rc --no-git-tag-version",
+        "verbump:premajor": "yarn version --premajor --preid rc --no-git-tag-version",
+        "verbump:patch": "yarn version --patch --no-git-tag-version",
+        "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.10.0",
+        "@babel/preset-react": "^7.10.0",
+        "@babel/preset-typescript": "^7.9.0",
+        "@emotion/babel-preset-css-prop": "^11.0.0",
+        "@guardian/src-foundations": "^3.1.0-rc.0",
+        "rollup": "^1.17.0",
+        "rollup-plugin-babel": "^4.3.3",
+        "rollup-plugin-commonjs": "^10.0.2",
+        "rollup-plugin-node-resolve": "^5.2.0"
+    },
+    "files": [
+        "dist/*.js",
+        "components/**",
+        "index.tsx"
+    ],
+    "peerDependencies": {
+        "@emotion/react": "^11.1.2",
+        "@guardian/src-foundations": "^3.1.0-rc.0",
+        "react": "^17.0.1"
+    }
+}

--- a/src/editorial/web/rollup.config.js
+++ b/src/editorial/web/rollup.config.js
@@ -1,0 +1,32 @@
+import babel from "rollup-plugin-babel"
+import resolve from "rollup-plugin-node-resolve"
+import commonjs from "rollup-plugin-commonjs"
+import {
+	cjsPaths,
+	submodulePaths,
+} from "../../../scripts/foundations-submodules"
+
+const extensions = [".ts", ".tsx"]
+
+module.exports = {
+	input: "index.tsx",
+	output: [
+		{
+			file: "dist/editorial.js",
+			format: "cjs",
+			paths: cjsPaths,
+		},
+		{
+			file: "dist/editorial.esm.js",
+			format: "esm",
+		},
+	],
+	external: [
+		"react",
+		"@emotion/react",
+		"@emotion/css",
+		"@guardian/src-foundations",
+		...submodulePaths,
+	],
+	plugins: [babel({ extensions }), resolve({ extensions }), commonjs()],
+}


### PR DESCRIPTION
## What is the purpose of this change?

One question that we frequently ask ourselves:

> How can we continue to **grow the system**, given the differences in the needs of the teams we support and their audiences?

We can start to address this by creating space for teams to **solve their own problems**, while **providing guidance** on strategy, architecture and best practice.

We should provide space within the Source repo for Editorial platform teams to introduce and build on components that deliver value across teams. These components may not always be appropriate for non-Editorial usage, so we should provide signposting to help other teams understand the intention here.

## What does this change?

Introduces an Editorial package for sharing editorial components across platforms (e.g. dotcom-rendering and apps-rendering)

