### PR TITLE
Use new JSX transform for button

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,9 @@
 		"prettier/prettier": "error",
 		"@typescript-eslint/explicit-module-boundary-types": "off",
 		"@typescript-eslint/no-unused-vars": "off",
-		"jsx-a11y/label-has-for": "off"
+		"jsx-a11y/label-has-for": "off",
+		"react/jsx-uses-react": "off",
+		"react/react-in-jsx-scope": "off"
 	},
 	"parserOptions": {
 		"ecmaFeatures": {

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,17 @@
 module.exports = {
 	stories: [`../src/**/*stories.tsx`],
 	addons: ["@storybook/addon-backgrounds", "@storybook/addon-viewport"],
+	babel: async (options) => ({
+		...options,
+		presets: [
+			...options.presets,
+			[
+				"@babel/preset-react",
+				{
+					runtime: "automatic",
+				},
+				"preset-react-jsx-transform", // Must provide a name to avoid clashing
+			],
+		],
+	}),
 }

--- a/src/core/components/button/.babelrc.js
+++ b/src/core/components/button/.babelrc.js
@@ -2,7 +2,12 @@ module.exports = {
 	presets: [
 		"@babel/preset-env",
 		"@babel/preset-typescript",
-		"@babel/preset-react",
+		[
+			"@babel/preset-react",
+			{
+				runtime: "automatic",
+			},
+		],
 		"@emotion/babel-preset-css-prop",
 	],
 }

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -1,9 +1,10 @@
 ///<reference types="@emotion/react/types/css-prop" />
-import React, {
+import {
 	ReactElement,
 	ReactNode,
 	ButtonHTMLAttributes,
 	AnchorHTMLAttributes,
+	cloneElement,
 } from "react";
 import { css } from "@emotion/react";
 import { SerializedStyles } from "@emotion/react";
@@ -111,7 +112,7 @@ const buttonContents = ({
 		if (!hideLabel) {
 			contents.push(<div key="space" className="src-button-space" />);
 		}
-		contents.push(React.cloneElement(iconSvg, { key: "svg" }));
+		contents.push(cloneElement(iconSvg, { key: "svg" }));
 	}
 	if (hideLabel) {
 		return (

--- a/src/core/components/button/rollup.config.js
+++ b/src/core/components/button/rollup.config.js
@@ -23,6 +23,7 @@ module.exports = {
 	],
 	external: [
 		"react",
+		"react/jsx-runtime",
 		"@emotion/react",
 		"@emotion/css",
 		"@guardian/src-foundations",

--- a/src/core/components/button/stories/icon-only-buttons.tsx
+++ b/src/core/components/button/stories/icon-only-buttons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { SvgCross } from "@guardian/src-icons";
 import { space } from "@guardian/src-foundations";

--- a/src/core/components/button/stories/icon-only-link-buttons.tsx
+++ b/src/core/components/button/stories/icon-only-link-buttons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { SvgCross } from "@guardian/src-icons";
 import { space } from "@guardian/src-foundations";

--- a/src/core/components/button/stories/priority-buttons.tsx
+++ b/src/core/components/button/stories/priority-buttons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { storybookBackgrounds } from "@guardian/src-helpers";
 import { space } from "@guardian/src-foundations";

--- a/src/core/components/button/stories/priority-link-buttons.tsx
+++ b/src/core/components/button/stories/priority-link-buttons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { space } from "@guardian/src-foundations";

--- a/src/core/components/button/stories/sizes.tsx
+++ b/src/core/components/button/stories/sizes.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { space } from "@guardian/src-foundations";
 import { Button } from "../index";

--- a/src/core/components/button/stories/text-and-icon-buttons.tsx
+++ b/src/core/components/button/stories/text-and-icon-buttons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { SvgCheckmark } from "@guardian/src-icons";
 import { space } from "@guardian/src-foundations";

--- a/src/core/components/button/stories/text-and-icon-link-buttons-with-nudge.tsx
+++ b/src/core/components/button/stories/text-and-icon-link-buttons-with-nudge.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { space } from "@guardian/src-foundations";

--- a/src/core/components/button/stories/text-and-icon-link-buttons.tsx
+++ b/src/core/components/button/stories/text-and-icon-link-buttons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { css } from "@emotion/react";
 import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { space } from "@guardian/src-foundations";


### PR DESCRIPTION
## What is the purpose of this change?

This PR updates source to make use of the [new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) available in React 17.

## What does this change?

- Update `babelrc` files* to set the runtime to `automatic`
- Update rollup config files* to include `react/jsx-runtime` as an external
- Update storybook config to set the runtime to `automatic`
- Update eslint config so that it doesn't flag the lack of `React` import
- Remove `import React from "react"` everywhere

**\* This has only been done for the button component so far**

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
