### PR TITLE
Add editorial dir to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "workspaces": [
     "src/core/*",
     "src/core/components/*",
+    "src/editorial/web/*",
     "src/editorial/web/components/*"
   ],
   "scripts": {


### PR DESCRIPTION
## What is the purpose of this change?

Editorial is now a standalone package, it also needs to be a workspace from yarn's perspective

## What does this change?

-   Add editorial directory to the workspaces lists

