### PR TITLE
fix type name clashes that apply in flat land

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -41,12 +41,12 @@ export {
 	buttonReaderRevenueBrandAlt,
 } from './themes';
 
-export type Priority = 'primary' | 'secondary' | 'tertiary' | 'subdued';
+export type ButtonPriority = 'primary' | 'secondary' | 'tertiary' | 'subdued';
 type IconSide = 'left' | 'right';
 type Size = 'default' | 'small' | 'xsmall';
 
 interface SharedButtonProps extends Props {
-	priority: Priority;
+	priority: ButtonPriority;
 	size: Size;
 	iconSide: IconSide;
 	icon?: ReactElement;
@@ -55,7 +55,7 @@ interface SharedButtonProps extends Props {
 }
 
 const priorities: {
-	[key in Priority]: ({
+	[key in ButtonPriority]: ({
 		button,
 	}: {
 		button: ButtonTheme;
@@ -155,7 +155,7 @@ const buttonStyles = ({
 interface ButtonProps
 	extends SharedButtonProps,
 		ButtonHTMLAttributes<HTMLButtonElement> {
-	priority: Priority;
+	priority: ButtonPriority;
 	size: Size;
 	icon?: ReactElement;
 	iconSide: IconSide;
@@ -198,7 +198,7 @@ const Button = ({
 interface LinkButtonProps
 	extends SharedButtonProps,
 		AnchorHTMLAttributes<HTMLAnchorElement> {
-	priority: Priority;
+	priority: ButtonPriority;
 	size: Size;
 	iconSide: IconSide;
 	icon?: ReactElement;

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -30,7 +30,7 @@ import {
 
 export { choiceCardDefault } from '@guardian/src-foundations/themes';
 
-export type Columns = 2 | 3 | 4 | 5;
+export type ChoiceCardColumns = 2 | 3 | 4 | 5;
 
 interface ChoiceCardGroupProps extends Props {
 	id?: string;
@@ -39,7 +39,7 @@ interface ChoiceCardGroupProps extends Props {
 	supporting?: string;
 	multi?: boolean;
 	error?: string;
-	columns?: Columns;
+	columns?: ChoiceCardColumns;
 	children: JSX.Element | JSX.Element[];
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 }

--- a/src/core/components/choice-card/styles.ts
+++ b/src/core/components/choice-card/styles.ts
@@ -7,7 +7,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { choiceCardDefault } from '@guardian/src-foundations/themes';
 import { width, height } from '@guardian/src-foundations/size';
 import { resets } from '@guardian/src-foundations/utils';
-import { Columns } from './index';
+import { ChoiceCardColumns } from './index';
 
 export const fieldset = css`
 	${resets.fieldset};
@@ -40,12 +40,12 @@ export const gridContainer = css`
 	}
 `;
 
-const gridColumnsStyle = (columns: Columns) => css`
+const gridColumnsStyle = (columns: ChoiceCardColumns) => css`
 	${from.mobileLandscape} {
 		grid-template-columns: repeat(${columns}, 1fr);
 	}
 `;
-export const gridColumns: { [key in Columns]: SerializedStyles } = {
+export const gridColumns: { [key in ChoiceCardColumns]: SerializedStyles } = {
 	2: gridColumnsStyle(2),
 	3: gridColumnsStyle(3),
 	4: gridColumnsStyle(4),

--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -25,12 +25,12 @@ export {
 	linkBrandAlt,
 } from '@guardian/src-foundations/themes';
 
-export type Priority = 'primary' | 'secondary';
+export type LinkPriority = 'primary' | 'secondary';
 
 type IconSide = 'left' | 'right';
 
 const priorities: {
-	[key in Priority]: ({ link }: { link: LinkTheme }) => SerializedStyles;
+	[key in LinkPriority]: ({ link }: { link: LinkTheme }) => SerializedStyles;
 } = {
 	primary,
 	secondary,
@@ -82,7 +82,7 @@ const linkStyles = ({
 	cssOverrides,
 }: {
 	isButton?: boolean;
-	priority: Priority;
+	priority: LinkPriority;
 	isSubdued: boolean;
 	iconSvg?: ReactElement;
 	iconSide: IconSide;
@@ -101,7 +101,7 @@ const linkStyles = ({
 };
 
 interface SharedLinkProps extends Props {
-	priority: Priority;
+	priority: LinkPriority;
 	subdued: boolean;
 	icon?: ReactElement;
 	iconSide: IconSide;
@@ -112,7 +112,7 @@ interface SharedLinkProps extends Props {
 interface LinkProps
 	extends AnchorHTMLAttributes<HTMLAnchorElement>,
 		SharedLinkProps {
-	priority: Priority;
+	priority: LinkPriority;
 	subdued: boolean;
 	icon?: ReactElement;
 	iconSide: IconSide;
@@ -148,7 +148,7 @@ const Link = ({
 interface ButtonLinkProps
 	extends ButtonHTMLAttributes<HTMLButtonElement>,
 		SharedLinkProps {
-	priority: Priority;
+	priority: LinkPriority;
 	subdued: boolean;
 	icon?: ReactElement;
 	iconSide: IconSide;


### PR DESCRIPTION
## What is the purpose of this change?

prevent type name clashes when we have a flat package

## What does this change?

- rename instances of types with same names
