### PR TITLE
Upgrade all packages to v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 > -   :globe_with_meridians: [Accessibility improvement]
 > -   :page_with_curl: [Documentation]
 
+## 12 February 2021
+
+**`@guardian/src-accordion 3.2.0`**
+
+-   :sparkles: [3be8c40](https://github.com/guardian/source/commit/3be8c408677139765ea15dcc37c90396bcdbacf1) add optional onClick prop to accordion row (thanks @i-hardy)
+-   :sparkles: [8a27ee2](https://github.com/guardian/source/commit/8a27ee2df8b09e7d855eaa9e84b03483dd7490dc) add type attribute to accordion button and allow passing cssOverrides prop (thanks @i-hardy)
+-   :page_with_curl: [ace06c7](https://github.com/guardian/source/commit/ace06c7bfe27709e9db77e3380a7b63a1641149e) document onClick prop in README (thanks @i-hardy)
+
 ## 28 January 2021
 
 **`@guardian/editorial 3.1.0`**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "source",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [

--- a/src/core/brand/package.json
+++ b/src/core/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-brand",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -38,15 +38,15 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
-    "@guardian/src-helpers": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
+    "@guardian/src-helpers": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-node-resolve": "^5.2.0",
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/accordion/package.json
+++ b/src/core/components/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-accordion",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -27,7 +27,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -35,8 +35,8 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
-    "@guardian/src-link": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
+    "@guardian/src-link": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-button",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -27,7 +27,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -35,8 +35,8 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
-    "@guardian/src-icons": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
+    "@guardian/src-icons": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/checkbox/package.json
+++ b/src/core/components/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-checkbox",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,9 +26,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-label": "^3.2.0-rc.0",
-    "@guardian/src-user-feedback": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-label": "^3.2.0",
+    "@guardian/src-user-feedback": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -36,7 +36,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-choice-card",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,9 +26,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-label": "^3.2.0-rc.0",
-    "@guardian/src-user-feedback": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-label": "^3.2.0",
+    "@guardian/src-user-feedback": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -36,8 +36,8 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
-    "@guardian/src-icons": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
+    "@guardian/src-icons": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/footer/package.json
+++ b/src/core/components/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-footer",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,7 +26,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -34,7 +34,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/label/package.json
+++ b/src/core/components/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-label",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,7 +26,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -34,7 +34,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/layout/package.json
+++ b/src/core/components/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-layout",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,7 +26,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -34,7 +34,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-link",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,7 +26,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -34,8 +34,8 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
-    "@guardian/src-icons": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
+    "@guardian/src-icons": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-radio",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,9 +26,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-label": "^3.2.0-rc.0",
-    "@guardian/src-user-feedback": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-label": "^3.2.0",
+    "@guardian/src-user-feedback": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -36,7 +36,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/select/package.json
+++ b/src/core/components/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-select",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,10 +26,10 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-icons": "^3.2.0-rc.0",
-    "@guardian/src-label": "^3.2.0-rc.0",
-    "@guardian/src-user-feedback": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-icons": "^3.2.0",
+    "@guardian/src-label": "^3.2.0",
+    "@guardian/src-user-feedback": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -37,7 +37,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/text-area/package.json
+++ b/src/core/components/text-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-text-area",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,8 +26,8 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-user-feedback": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-user-feedback": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -35,7 +35,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/text-input/package.json
+++ b/src/core/components/text-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-text-input",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,9 +26,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-label": "^3.2.0-rc.0",
-    "@guardian/src-user-feedback": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-label": "^3.2.0",
+    "@guardian/src-user-feedback": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -36,7 +36,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/user-feedback/package.json
+++ b/src/core/components/user-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-user-feedback",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,8 +26,8 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0",
-    "@guardian/src-icons": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0",
+    "@guardian/src-icons": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -35,7 +35,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-foundations",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"

--- a/src/core/helpers/package.json
+++ b/src/core/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-helpers",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -26,14 +26,14 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-foundations": "^3.2.0-rc.0"
+    "@guardian/src-foundations": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.10.0",
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",

--- a/src/core/icons/package.json
+++ b/src/core/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-icons",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -69,8 +69,8 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
-    "@guardian/src-helpers": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
+    "@guardian/src-helpers": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/src/editorial/web/components/lines/package.json
+++ b/src/editorial/web/components/lines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-ed-lines",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -28,7 +28,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.0-rc.0"
+    "@guardian/src-helpers": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
@@ -36,7 +36,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }

--- a/src/editorial/web/package.json
+++ b/src/editorial/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/editorial",
-  "version": "3.2.0-rc.0",
+  "version": "3.2.0",
   "license": "Apache-2.0",
   "main": "dist/editorial.js",
   "module": "dist/editorial.esm.js",
@@ -27,7 +27,7 @@
     "@babel/preset-react": "^7.10.0",
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.2",
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.0-rc.0",
+    "@guardian/src-foundations": "^3.2.0",
     "react": "^17.0.1"
   }
 }


### PR DESCRIPTION

**`@guardian/src-accordion 3.2.0`**
--
- :sparkles: [3be8c40](https://github.com/guardian/source/commit/3be8c408677139765ea15dcc37c90396bcdbacf1) add optional onClick prop to accordion row (thanks @i-hardy)
- :sparkles: [8a27ee2](https://github.com/guardian/source/commit/8a27ee2df8b09e7d855eaa9e84b03483dd7490dc) add type attribute to accordion button and allow passing cssOverrides prop (thanks @i-hardy)
- :page_with_curl: [ace06c7](https://github.com/guardian/source/commit/ace06c7bfe27709e9db77e3380a7b63a1641149e) document onClick prop in README (thanks @i-hardy)

