### PR TITLE
Supporting hiding above and below breakpoints

### DIFF
--- a/src/core/components/layout/components/hide/hide.tsx
+++ b/src/core/components/layout/components/hide/hide.tsx
@@ -21,6 +21,7 @@ const Hide = ({ children, above, below }: HideProps) => {
 	}
 	if (above) {
 		whenToHide = css`
+			${whenToHide}
 			${from[above]} {
 				display: none;
 			}

--- a/src/core/components/layout/stories/hide/default.tsx
+++ b/src/core/components/layout/stories/hide/default.tsx
@@ -33,3 +33,17 @@ export const above = () => (
 above.story = {
 	name: 'above',
 };
+
+export const between = () => (
+	<Container>
+		<Hide below="tablet" above="leftCol">
+			<div css={contents}>
+				Will only appear between desktop and leftCol
+			</div>
+		</Hide>
+	</Container>
+);
+
+between.story = {
+	name: 'between',
+};


### PR DESCRIPTION
## What is the purpose of this change?

Currently it's only possible to hide a component above a certain breakpoint or below a certain breakpoint. It's not possible to do both at the same time.

## What does this change?

-   Compose below and above css to support both props at the same time

## Screenshots

![2021-02-16 08 59 24](https://user-images.githubusercontent.com/5931528/108040528-52d1f080-7035-11eb-8945-ea8aa8280373.gif)

