### PR TITLE
Fix storybook padding hacks

### DIFF
--- a/src/core/components/layout/columns.stories.tsx
+++ b/src/core/components/layout/columns.stories.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
 import { Columns } from './index';
-
-const gridStoryWrapper = (storyFn: () => JSX.Element) => {
-	// override 8px margin applied globally to every preview body
-	return <div style={{ margin: '0 -8px' }}>{storyFn()}</div>;
-};
 
 export default {
 	title: 'Columns',
 	component: Columns,
-	decorators: [gridStoryWrapper],
 };
 
 export * from './stories/columns/default';

--- a/src/core/components/layout/container.stories.tsx
+++ b/src/core/components/layout/container.stories.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
 import { Container } from './index';
-
-const gridStoryWrapper = (storyFn: () => JSX.Element) => {
-	// override 8px margin applied globally to every preview body
-	return <div style={{ margin: '0 -8px' }}>{storyFn()}</div>;
-};
 
 export default {
 	title: 'Container',
 	component: Container,
-	decorators: [gridStoryWrapper],
 };
 
 export * from './stories/container/default';

--- a/src/core/components/layout/inline.stories.tsx
+++ b/src/core/components/layout/inline.stories.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
 import { Inline } from './index';
-
-const gridStoryWrapper = (storyFn: () => JSX.Element) => {
-	// override 8px margin applied globally to every preview body
-	return <div style={{ margin: '0 -8px' }}>{storyFn()}</div>;
-};
 
 export default {
 	title: 'Inline',
 	component: Inline,
-	decorators: [gridStoryWrapper],
 };
 
 export * from './stories/inline/default';

--- a/src/core/components/layout/stack.stories.tsx
+++ b/src/core/components/layout/stack.stories.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
 import { Stack } from './index';
-
-const gridStoryWrapper = (storyFn: () => JSX.Element) => {
-	// override 8px margin applied globally to every preview body
-	return <div style={{ margin: '0 -8px' }}>{storyFn()}</div>;
-};
 
 export default {
 	title: 'Stack',
 	component: Stack,
-	decorators: [gridStoryWrapper],
 };
 
 export * from './stories/stack/default';

--- a/src/core/components/layout/stories/columns/collapse-below.tsx
+++ b/src/core/components/layout/stories/columns/collapse-below.tsx
@@ -31,5 +31,6 @@ collapseBelowTablet.story = {
 	name: 'collapse below tablet',
 	parameters: {
 		viewport: { defaultViewport: 'phablet' },
+		layout: 'fullscreen',
 	},
 };

--- a/src/core/components/layout/stories/columns/with-width.tsx
+++ b/src/core/components/layout/stories/columns/with-width.tsx
@@ -89,6 +89,7 @@ withWidthDesktop.story = {
 	name: 'with width desktop',
 	parameters: {
 		viewport: { defaultViewport: 'desktop' },
+		layout: 'fullscreen',
 	},
 };
 
@@ -98,5 +99,6 @@ withWidthTablet.story = {
 	name: 'with width tablet',
 	parameters: {
 		viewport: { defaultViewport: 'tablet' },
+		layout: 'fullscreen',
 	},
 };

--- a/src/core/components/layout/tiles.stories.tsx
+++ b/src/core/components/layout/tiles.stories.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
 import { Tiles } from './index';
-
-const gridStoryWrapper = (storyFn: () => JSX.Element) => {
-	// override 8px margin applied globally to every preview body
-	return <div style={{ margin: '0 -8px' }}>{storyFn()}</div>;
-};
 
 export default {
 	title: 'Tiles',
 	component: Tiles,
-	decorators: [gridStoryWrapper],
 };
 
 export * from './stories/tiles/default';


### PR DESCRIPTION
## What is the purpose of this change?

In some stories, we've added negative margins to override margins that Storybook adds to the body. 

The underlying problem was fixed in SB v6, but we still need to specify some stories to be `fullscreen` to remove [excess padding](https://github.com/storybookjs/storybook/issues/12109) that adds horizontal scrollbars to layout component stories with responsive viewports.

## What does this change?

-   Remove negative margins
-   Apply [`fullscreen` layout](https://github.com/storybookjs/storybook/issues/12109#issuecomment-773590980) to stories that need it

