### PR TITLE
create @guardian/src-foundations/* submodules

### DIFF
--- a/src/core/brand/package.json
+++ b/src/core/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-brand",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/accordion/package.json
+++ b/src/core/components/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-accordion",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,8 +38,8 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
-    "@guardian/src-icons": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
+    "@guardian/src-icons": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/button/package.json
+++ b/src/core/components/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-button",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/checkbox/package.json
+++ b/src/core/components/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-checkbox",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,9 +30,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-label": "^3.2.1-rc.0",
-    "@guardian/src-user-feedback": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-label": "^3.2.1-rc.1",
+    "@guardian/src-user-feedback": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/choice-card/package.json
+++ b/src/core/components/choice-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-choice-card",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,9 +30,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-label": "^3.2.1-rc.0",
-    "@guardian/src-user-feedback": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-label": "^3.2.1-rc.1",
+    "@guardian/src-user-feedback": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/footer/package.json
+++ b/src/core/components/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-footer",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/label/package.json
+++ b/src/core/components/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-label",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/layout/package.json
+++ b/src/core/components/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-layout",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-link",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/radio/package.json
+++ b/src/core/components/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-radio",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,9 +30,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-label": "^3.2.1-rc.0",
-    "@guardian/src-user-feedback": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-label": "^3.2.1-rc.1",
+    "@guardian/src-user-feedback": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/select/package.json
+++ b/src/core/components/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-select",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,10 +30,10 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-icons": "^3.2.1-rc.0",
-    "@guardian/src-label": "^3.2.1-rc.0",
-    "@guardian/src-user-feedback": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-icons": "^3.2.1-rc.1",
+    "@guardian/src-label": "^3.2.1-rc.1",
+    "@guardian/src-user-feedback": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/text-area/package.json
+++ b/src/core/components/text-area/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-text-area",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,8 +30,8 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-user-feedback": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-user-feedback": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/text-input/package.json
+++ b/src/core/components/text-input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-text-input",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,9 +30,9 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-label": "^3.2.1-rc.0",
-    "@guardian/src-user-feedback": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-label": "^3.2.1-rc.1",
+    "@guardian/src-user-feedback": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/user-feedback/package.json
+++ b/src/core/components/user-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-user-feedback",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,8 +30,8 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0",
-    "@guardian/src-icons": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1",
+    "@guardian/src-icons": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/core/foundations/accessibility/package.json
+++ b/src/core/foundations/accessibility/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/accessibility",
+  "module": "../dist/esm/accessibility",
+  "types": "../dist/types/accessibility",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/mq/package.json
+++ b/src/core/foundations/mq/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/mq",
+  "module": "../dist/esm/mq",
+  "types": "../dist/types/mq",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -12,7 +12,14 @@
   "files": [
     "dist/esm",
     "dist/cjs",
-    "dist/types"
+    "dist/types",
+    "accessibility/package.json",
+    "mq/package.json",
+    "palette/package.json",
+    "size/package.json",
+    "themes/package.json",
+    "typography/obj/package.json",
+    "utils/package.json"
   ],
   "scripts": {
     "build": "npm-run-all clean --parallel build:*",

--- a/src/core/foundations/package.json
+++ b/src/core/foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-foundations",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"

--- a/src/core/foundations/palette/package.json
+++ b/src/core/foundations/palette/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/palette",
+  "module": "../dist/esm/palette",
+  "types": "../dist/types/palette",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/size/package.json
+++ b/src/core/foundations/size/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/size",
+  "module": "../dist/esm/size",
+  "types": "../dist/types/size",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/themes/package.json
+++ b/src/core/foundations/themes/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/themes",
+  "module": "../dist/esm/themes",
+  "types": "../dist/types/themes",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/typography/obj/package.json
+++ b/src/core/foundations/typography/obj/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../../dist/cjs/typography/obj",
+  "module": "../../dist/esm/typography/obj",
+  "types": "../../dist/types/typography/obj",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/typography/package.json
+++ b/src/core/foundations/typography/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/typography",
+  "module": "../dist/esm/typography",
+  "types": "../dist/types/typography",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/foundations/utils/package.json
+++ b/src/core/foundations/utils/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../dist/cjs/utils",
+  "module": "../dist/esm/utils",
+  "types": "../dist/types/utils",
+  "what is this?": "this is a hack to get @guardian/src-foundations/* submodules working with dist till v4"
+}

--- a/src/core/helpers/package.json
+++ b/src/core/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-helpers",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-foundations": "^3.2.1-rc.0"
+    "@guardian/src-foundations": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",

--- a/src/core/icons/package.json
+++ b/src/core/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-icons",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"

--- a/src/editorial/web/components/lines/package.json
+++ b/src/editorial/web/components/lines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/src-ed-lines",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"
@@ -30,7 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/src-helpers": "^3.2.1-rc.0"
+    "@guardian/src-helpers": "^3.2.1-rc.1"
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }

--- a/src/editorial/web/package.json
+++ b/src/editorial/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/editorial",
-  "version": "3.2.1-rc.0",
+  "version": "3.2.1-rc.1",
   "license": "Apache-2.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/src-foundations": "^3.2.1-rc.0",
+    "@guardian/src-foundations": "^3.2.1-rc.1",
     "react": "^17.0.1"
   }
 }


### PR DESCRIPTION
## What is the purpose of this change?

- create `@guardian/src-foundations/*` submodules so that existing imports work with the `dist` directory
- it's a temporary fix until v4 is in main

## What does this change?

- adds placeholder `package.json` files for the sub-module imports in `@guardian/src-foundations/*` and publishes them

