### PR TITLE
Fix for eslint-config-prettier v8

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,8 +5,7 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:jsx-a11y/strict",
-    "prettier/@typescript-eslint",
-    "prettier/react"
+    "prettier"
   ],
   "rules": {
     "prettier/prettier": "error",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-typescript": "^7.9.0",
     "@emotion/babel-preset-css-prop": "^11.0.0",
     "@emotion/react": "^11.1.2",
-    "@guardian/prettier": "^0.4.2",
+    "@guardian/prettier": "^0.5.0",
     "@storybook/addon-backgrounds": "^6.1.21",
     "@storybook/addon-viewport": "^6.1.21",
     "@storybook/react": "^6.1.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,10 +2071,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/prettier@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.4.2.tgz#2d08a8a50aad3911a88c9b53f92a37748694d551"
-  integrity sha512-f8MCY/s3rLNonqxITsqnqrPRt0r6hEyW6rGKqDexTt88fEQnA3BMtAlN2hqjuNfrOa9EQexEknZugRVdIpbijQ==
+"@guardian/prettier@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.5.0.tgz#d8ea25cc396f31bd4baedb8f6d7d3727a9af1fa7"
+  integrity sha512-IYXMdqW6vg9mVnAXbbWCm0R9AZfWlAjfJ668TnCx3ypX5/u4AYAXdOfrWWX+uWvFvs3Ulub+E8vEm+eUkxi6rQ==
 
 "@icons/material@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
## What is the purpose of this change?

This change is required following the bump of `eslint-config-prettier` to `8.X`*. 

## What does this change?

-   Bump `@guardian/prettier` to `^0.5.0`
-   Update the `eslint` config to extend from `prettier` instead of `prettier/@typescript-eslint` and `prettier/react`*


* [eslint-config-prettier CHANGELOG](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21)


