### PR TITLE
use guardian/actions-setup-node

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,9 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - uses: guardian/actions-setup-node@main
       - name: build
         run: |
           yarn

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,9 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - uses: guardian/actions-setup-node@main
       - run: |
           yarn
           yarn ci:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - uses: guardian/actions-setup-node@main
       - name: build
         run: |
           yarn


### PR DESCRIPTION
## What is the purpose of this change?

simpler workflow config, one place to manage node versions

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-  uses https://github.com/guardian/actions-setup-node to manage node in github actions

