### PR TITLE
Add key to link contents spacer to remove key warnings

### DIFF
--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -3,6 +3,7 @@ import React, {
 	ReactNode,
 	AnchorHTMLAttributes,
 	ButtonHTMLAttributes,
+	Fragment,
 } from 'react';
 import { SerializedStyles } from '@emotion/react';
 import { LinkTheme } from '@guardian/src-foundations/themes';
@@ -52,7 +53,9 @@ const linkContents = ({
 	iconSide: IconSide;
 }) => {
 	// a bit of underlined space; the icon sits on top
-	const spacer = <>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</>;
+	const spacer = (
+		<Fragment key="spacer">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</Fragment>
+	);
 	const linkContents = [children];
 
 	if (iconSvg) {


### PR DESCRIPTION
## What is the purpose of this change?

This change fixes the `Warning: Each child in a list should have a unique "key" prop` warning for the `Link` and `ButtonLink ` components. This warning can be seen in the console for the `link/text-and-icon-button-links` and `link/text-and-icon` stories.

## What does this change?

-   Update the spacer created in the `linkContents` function to use the long-hand for `Fragment`
-   Add a key to remove the warning about all elements in a list requiring keys

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
