### PR TITLE
Simplify responsive hiding of columns

### DIFF
--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -5,17 +5,18 @@ import { Breakpoint, from, until } from '@guardian/src-foundations/mq';
 export const columns = css`
 	box-sizing: border-box;
 	display: flex;
-	& > * + * {
-		margin-left: ${space[5]}px;
+	& > :last-of-type {
+		margin-right: 0;
+	}
+	& > * {
+		margin-right: ${space[5]}px;
 	}
 `;
 
 const collapseBelowSpacing = css`
 	display: block;
-	& > * + * {
-		margin-left: 0;
-	}
 	& > * {
+		margin-right: 0;
 		margin-bottom: ${space[5]}px;
 	}
 `;
@@ -93,22 +94,15 @@ export const collapseBelowWide = css`
 const calculateWidth = (width: number) => {
 	if (width === 0) {
 		return css`
-			width: 0;
-
-			/* Hide the column from screen readers */
-			visibility: hidden;
-
-			/* offset the margin-left on the next sibling */
-			margin-right: ${-space[5]}px;
+			display: none;
 		`;
 	}
 
 	return css`
 		width: calc((100% + ${space[5]}px) * ${width} - ${space[5]}px);
 
-		/* Reset values that might have been set at a lower breakpoint */
-		visibility: visible;
-		margin-right: 0;
+		/* Reset value that might have been set at a lower breakpoint */
+		display: block;
 	`;
 };
 

--- a/src/core/components/layout/stories/columns/responsive.tsx
+++ b/src/core/components/layout/stories/columns/responsive.tsx
@@ -25,6 +25,7 @@ responsive.story = {
 	name: 'responsive columns',
 	parameters: {
 		viewport: { defaultViewport: 'tablet' },
+		layout: 'fullscreen',
 	},
 };
 
@@ -47,5 +48,6 @@ responsivelyHide.story = {
 	name: 'responsively hide columns',
 	parameters: {
 		viewport: { defaultViewport: 'tablet' },
+		layout: 'fullscreen',
 	},
 };


### PR DESCRIPTION
## What is the purpose of this change?

Responsive hiding of columns is complex, in part because the way we add gutters is convoluted and a bit backwards.

Instead of adding a left margin _before_ every column, we should add a right margin _after_ every column. This allows columns to sit in the normal flow when their siblings are hidden, rather than trying to botch in a negative margin.

## What does this change?

-   Add right margin after column rather than left margin before
-   Replace `visibility: hidden` and `width: 0` with `display: none`
- BONUS: make responsive hiding stories full screen 
