### PR TITLE
Configurable column spacing

### DIFF
--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -82,6 +82,12 @@ const Wrapper = () => (
 
 Columns will be stacked one on top of the other at viewport widths lower than the specified breakpoint
 
+#### `spaceY`
+
+**`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
+
+Units of space between columns vertically when collapsed (one unit is 4px)
+
 ### Column Props
 
 #### `width`

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -25,10 +25,13 @@ type CollapseBreakpoint = Extract<
 	'tablet' | 'desktop' | 'leftCol' | 'wide'
 >;
 
+export type ColumnsSpaceY = 1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24;
+
 interface ColumnsProps extends HTMLAttributes<HTMLDivElement>, Props {
 	collapseBelow?: CollapseBreakpoint;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 	children: ReactNode;
+	spaceY?: ColumnsSpaceY;
 }
 
 const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
@@ -39,7 +42,7 @@ const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
 };
 
 const collapseBelowColumnsMap: {
-	[key in CollapseBreakpoint]: SerializedStyles;
+	[key in CollapseBreakpoint]: (number: ColumnsSpaceY) => SerializedStyles;
 } = {
 	tablet: collapseBelowTabletColumns,
 	desktop: collapseBelowDesktopColumns,
@@ -51,13 +54,16 @@ const Columns = ({
 	collapseBelow,
 	cssOverrides,
 	children,
+	spaceY,
 	...props
 }: ColumnsProps) => {
 	return (
 		<div
 			css={[
 				columns,
-				collapseBelow ? collapseBelowColumnsMap[collapseBelow] : '',
+				collapseBelow
+					? collapseBelowColumnsMap[collapseBelow](spaceY || 5)
+					: '',
 				collapseBelow ? collapseBelowMap[collapseBelow] : '',
 				cssOverrides,
 			]}

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -42,7 +42,7 @@ const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
 };
 
 const collapseBelowColumnsMap: {
-	[key in CollapseBreakpoint]: (spaceY: ColumnsSpaceY) => SerializedStyles;
+	[key in CollapseBreakpoint]: (spaceY?: ColumnsSpaceY) => SerializedStyles;
 } = {
 	tablet: collapseBelowTabletColumns,
 	desktop: collapseBelowDesktopColumns,
@@ -54,7 +54,7 @@ const Columns = ({
 	collapseBelow,
 	cssOverrides,
 	children,
-	spaceY = 5,
+	spaceY,
 	...props
 }: ColumnsProps) => {
 	return (

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -54,7 +54,7 @@ const Columns = ({
 	collapseBelow,
 	cssOverrides,
 	children,
-	spaceY,
+	spaceY = 5,
 	...props
 }: ColumnsProps) => {
 	return (
@@ -62,7 +62,7 @@ const Columns = ({
 			css={[
 				columns,
 				collapseBelow
-					? collapseBelowColumnsMap[collapseBelow](spaceY || 5)
+					? collapseBelowColumnsMap[collapseBelow](spaceY)
 					: '',
 				collapseBelow ? collapseBelowMap[collapseBelow] : '',
 				cssOverrides,

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -42,7 +42,7 @@ const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
 };
 
 const collapseBelowColumnsMap: {
-	[key in CollapseBreakpoint]: (number: ColumnsSpaceY) => SerializedStyles;
+	[key in CollapseBreakpoint]: (spaceY: ColumnsSpaceY) => SerializedStyles;
 } = {
 	tablet: collapseBelowTabletColumns,
 	desktop: collapseBelowDesktopColumns,

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -7,10 +7,11 @@ import {
 	collapseBelowDesktop,
 	collapseBelowleftCol,
 	collapseBelowWide,
-	collapseBelowColumns,
 	setWidth,
 	setSpan,
 	flexGrow,
+	collapseBelowColumnsCSS,
+	collapseBelowSpaceY,
 } from './styles';
 import { Breakpoint } from '@guardian/src-foundations/mq';
 import { Props } from '@guardian/src-helpers';
@@ -41,6 +42,15 @@ const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
 	wide: collapseBelowWide,
 };
 
+const collapseBelowColumnsMap: {
+	[key in CollapseBreakpoint]: SerializedStyles;
+} = {
+	tablet: collapseBelowColumnsCSS('tablet'),
+	desktop: collapseBelowColumnsCSS('desktop'),
+	leftCol: collapseBelowColumnsCSS('leftCol'),
+	wide: collapseBelowColumnsCSS('wide'),
+};
+
 const Columns = ({
 	collapseBelow,
 	cssOverrides,
@@ -52,10 +62,9 @@ const Columns = ({
 		<div
 			css={[
 				columns,
-				collapseBelow
-					? collapseBelowColumns(collapseBelow, spaceY)
-					: '',
+				collapseBelow ? collapseBelowColumnsMap[collapseBelow] : '',
 				collapseBelow ? collapseBelowMap[collapseBelow] : '',
+				spaceY ? collapseBelowSpaceY[spaceY] : '',
 				cssOverrides,
 			]}
 			{...props}

--- a/src/core/components/layout/components/columns/columns.tsx
+++ b/src/core/components/layout/components/columns/columns.tsx
@@ -3,14 +3,11 @@ import { SerializedStyles } from '@emotion/react';
 import {
 	columns,
 	column,
-	collapseBelowTabletColumns,
-	collapseBelowDesktopColumns,
-	collapseBelowLeftColColumns,
-	collapseBelowWideColumns,
 	collapseBelowTablet,
 	collapseBelowDesktop,
 	collapseBelowleftCol,
 	collapseBelowWide,
+	collapseBelowColumns,
 } from './styles';
 import { Breakpoint } from '@guardian/src-foundations/mq';
 import { Props } from '@guardian/src-helpers';
@@ -20,7 +17,7 @@ type GridBreakpoint = Extract<
 	'mobile' | 'tablet' | 'desktop' | 'leftCol' | 'wide'
 >;
 
-type CollapseBreakpoint = Extract<
+export type CollapseBreakpoint = Extract<
 	GridBreakpoint,
 	'tablet' | 'desktop' | 'leftCol' | 'wide'
 >;
@@ -41,15 +38,6 @@ const collapseBelowMap: { [key in CollapseBreakpoint]: SerializedStyles } = {
 	wide: collapseBelowWide,
 };
 
-const collapseBelowColumnsMap: {
-	[key in CollapseBreakpoint]: (spaceY?: ColumnsSpaceY) => SerializedStyles;
-} = {
-	tablet: collapseBelowTabletColumns,
-	desktop: collapseBelowDesktopColumns,
-	leftCol: collapseBelowLeftColColumns,
-	wide: collapseBelowWideColumns,
-};
-
 const Columns = ({
 	collapseBelow,
 	cssOverrides,
@@ -62,7 +50,7 @@ const Columns = ({
 			css={[
 				columns,
 				collapseBelow
-					? collapseBelowColumnsMap[collapseBelow](spaceY)
+					? collapseBelowColumns(collapseBelow, spaceY)
 					: '',
 				collapseBelow ? collapseBelowMap[collapseBelow] : '',
 				cssOverrides,

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Breakpoint, from, until } from '@guardian/src-foundations/mq';
-import { ColumnsSpaceY } from './columns';
+import { CollapseBreakpoint, ColumnsSpaceY } from './columns';
 
 export const columns = css`
 	box-sizing: border-box;
@@ -22,23 +22,11 @@ const collapseBelowSpacing = (spaceY?: ColumnsSpaceY) => css`
 	}
 `;
 
-export const collapseBelowTabletColumns = (spaceY?: ColumnsSpaceY) => css`
-	${until.tablet} {
-		${collapseBelowSpacing(spaceY)}
-	}
-`;
-export const collapseBelowDesktopColumns = (spaceY?: ColumnsSpaceY) => css`
-	${until.desktop} {
-		${collapseBelowSpacing(spaceY)}
-	}
-`;
-export const collapseBelowLeftColColumns = (spaceY?: ColumnsSpaceY) => css`
-	${until.leftCol} {
-		${collapseBelowSpacing(spaceY)}
-	}
-`;
-export const collapseBelowWideColumns = (spaceY?: ColumnsSpaceY) => css`
-	${until.wide} {
+export const collapseBelowColumns = (
+	breakpoint: CollapseBreakpoint,
+	spaceY?: ColumnsSpaceY,
+) => css`
+	${until[breakpoint]} {
 		${collapseBelowSpacing(spaceY)}
 	}
 `;

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -14,32 +14,32 @@ export const columns = css`
 	}
 `;
 
-const collapseBelowSpacing = (number: ColumnsSpaceY) => css`
+const collapseBelowSpacing = (spaceY: ColumnsSpaceY) => css`
 	display: block;
 	& > * {
 		margin-right: 0;
-		margin-bottom: ${space[number]}px;
+		margin-bottom: ${space[spaceY]}px;
 	}
 `;
 
-export const collapseBelowTabletColumns = (number: ColumnsSpaceY) => css`
+export const collapseBelowTabletColumns = (spaceY: ColumnsSpaceY) => css`
 	${until.tablet} {
-		${collapseBelowSpacing(number)}
+		${collapseBelowSpacing(spaceY)}
 	}
 `;
-export const collapseBelowDesktopColumns = (number: ColumnsSpaceY) => css`
+export const collapseBelowDesktopColumns = (spaceY: ColumnsSpaceY) => css`
 	${until.desktop} {
-		${collapseBelowSpacing(number)}
+		${collapseBelowSpacing(spaceY)}
 	}
 `;
-export const collapseBelowLeftColColumns = (number: ColumnsSpaceY) => css`
+export const collapseBelowLeftColColumns = (spaceY: ColumnsSpaceY) => css`
 	${until.leftCol} {
-		${collapseBelowSpacing(number)}
+		${collapseBelowSpacing(spaceY)}
 	}
 `;
-export const collapseBelowWideColumns = (number: ColumnsSpaceY) => css`
+export const collapseBelowWideColumns = (spaceY: ColumnsSpaceY) => css`
 	${until.wide} {
-		${collapseBelowSpacing(number)}
+		${collapseBelowSpacing(spaceY)}
 	}
 `;
 

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -14,30 +14,30 @@ export const columns = css`
 	}
 `;
 
-const collapseBelowSpacing = (spaceY: ColumnsSpaceY) => css`
+const collapseBelowSpacing = (spaceY?: ColumnsSpaceY) => css`
 	display: block;
 	& > * {
 		margin-right: 0;
-		margin-bottom: ${space[spaceY]}px;
+		${spaceY ? `margin-bottom: ${space[spaceY]}px;` : ''}
 	}
 `;
 
-export const collapseBelowTabletColumns = (spaceY: ColumnsSpaceY) => css`
+export const collapseBelowTabletColumns = (spaceY?: ColumnsSpaceY) => css`
 	${until.tablet} {
 		${collapseBelowSpacing(spaceY)}
 	}
 `;
-export const collapseBelowDesktopColumns = (spaceY: ColumnsSpaceY) => css`
+export const collapseBelowDesktopColumns = (spaceY?: ColumnsSpaceY) => css`
 	${until.desktop} {
 		${collapseBelowSpacing(spaceY)}
 	}
 `;
-export const collapseBelowLeftColColumns = (spaceY: ColumnsSpaceY) => css`
+export const collapseBelowLeftColColumns = (spaceY?: ColumnsSpaceY) => css`
 	${until.leftCol} {
 		${collapseBelowSpacing(spaceY)}
 	}
 `;
-export const collapseBelowWideColumns = (spaceY: ColumnsSpaceY) => css`
+export const collapseBelowWideColumns = (spaceY?: ColumnsSpaceY) => css`
 	${until.wide} {
 		${collapseBelowSpacing(spaceY)}
 	}

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
 import { Breakpoint, from, until } from '@guardian/src-foundations/mq';
+import { ColumnsSpaceY } from './columns';
 
 export const columns = css`
 	box-sizing: border-box;
@@ -13,32 +14,32 @@ export const columns = css`
 	}
 `;
 
-const collapseBelowSpacing = css`
+const collapseBelowSpacing = (number: ColumnsSpaceY) => css`
 	display: block;
 	& > * {
 		margin-right: 0;
-		margin-bottom: ${space[5]}px;
+		margin-bottom: ${space[number]}px;
 	}
 `;
 
-export const collapseBelowTabletColumns = css`
+export const collapseBelowTabletColumns = (number: ColumnsSpaceY) => css`
 	${until.tablet} {
-		${collapseBelowSpacing}
+		${collapseBelowSpacing(number)}
 	}
 `;
-export const collapseBelowDesktopColumns = css`
+export const collapseBelowDesktopColumns = (number: ColumnsSpaceY) => css`
 	${until.desktop} {
-		${collapseBelowSpacing}
+		${collapseBelowSpacing(number)}
 	}
 `;
-export const collapseBelowLeftColColumns = css`
+export const collapseBelowLeftColColumns = (number: ColumnsSpaceY) => css`
 	${until.leftCol} {
-		${collapseBelowSpacing}
+		${collapseBelowSpacing(number)}
 	}
 `;
-export const collapseBelowWideColumns = css`
+export const collapseBelowWideColumns = (number: ColumnsSpaceY) => css`
 	${until.wide} {
-		${collapseBelowSpacing}
+		${collapseBelowSpacing(number)}
 	}
 `;
 

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -1,7 +1,7 @@
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { space } from '@guardian/src-foundations';
-import { CollapseBreakpoint, ColumnsSpaceY } from './columns';
 import { Breakpoint, from, until, between } from '@guardian/src-foundations/mq';
+import { ColumnsSpaceY } from './columns';
 
 type ColumnBreakpoint = {
 	totalColumns: number;
@@ -17,23 +17,44 @@ export const columns = css`
 	}
 `;
 
-const collapseBelowSpacing = (spaceY?: ColumnsSpaceY) => css`
-	display: block;
-	margin-right: 0;
-	& > * {
+export const collapseBelowColumnsCSS = (breakpoint: Breakpoint) => css`
+	${until[breakpoint]} {
+		display: block;
 		margin-right: 0;
-		${spaceY ? `margin-bottom: ${space[spaceY]}px;` : ''}
+		& > * {
+			margin-right: 0;
+		}
 	}
 `;
 
-export const collapseBelowColumns = (
-	breakpoint: CollapseBreakpoint,
-	spaceY?: ColumnsSpaceY,
-) => css`
-	${until[breakpoint]} {
-		${collapseBelowSpacing(spaceY)}
+const collapseBelowSpaceYCSS = (spaceY: ColumnsSpaceY) => css`
+	margin-bottom: ${-space[spaceY]}px;
+	& > * {
+		margin-bottom: ${space[spaceY]}px;
 	}
 `;
+
+export const collapseBelowSpaceY: {
+	1: SerializedStyles;
+	2: SerializedStyles;
+	3: SerializedStyles;
+	4: SerializedStyles;
+	5: SerializedStyles;
+	6: SerializedStyles;
+	9: SerializedStyles;
+	12: SerializedStyles;
+	24: SerializedStyles;
+} = {
+	1: collapseBelowSpaceYCSS(1),
+	2: collapseBelowSpaceYCSS(2),
+	3: collapseBelowSpaceYCSS(3),
+	4: collapseBelowSpaceYCSS(4),
+	5: collapseBelowSpaceYCSS(5),
+	6: collapseBelowSpaceYCSS(6),
+	9: collapseBelowSpaceYCSS(9),
+	12: collapseBelowSpaceYCSS(12),
+	24: collapseBelowSpaceYCSS(24),
+};
 
 const collapseBelowWidth = css`
 	width: 100% !important;

--- a/src/core/components/layout/components/columns/styles.ts
+++ b/src/core/components/layout/components/columns/styles.ts
@@ -35,15 +35,7 @@ const collapseBelowSpaceYCSS = (spaceY: ColumnsSpaceY) => css`
 `;
 
 export const collapseBelowSpaceY: {
-	1: SerializedStyles;
-	2: SerializedStyles;
-	3: SerializedStyles;
-	4: SerializedStyles;
-	5: SerializedStyles;
-	6: SerializedStyles;
-	9: SerializedStyles;
-	12: SerializedStyles;
-	24: SerializedStyles;
+	[key in ColumnsSpaceY]: SerializedStyles;
 } = {
 	1: collapseBelowSpaceYCSS(1),
 	2: collapseBelowSpaceYCSS(2),

--- a/src/core/components/layout/stories/columns/collapse-below.tsx
+++ b/src/core/components/layout/stories/columns/collapse-below.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { Container, Columns, Column } from '../../index';
 import { sport } from '@guardian/src-foundations/palette';
 import { css } from '@emotion/react';
+import { ColumnsSpaceY } from '../../components/columns/columns';
+
+const defaultStoryOptions = {
+	parameters: {
+		viewport: { defaultViewport: 'phablet' },
+		layout: 'fullscreen',
+	},
+};
 
 const contents = css`
 	text-align: center;
@@ -28,9 +36,97 @@ export const collapseBelowTablet = () => (
 );
 
 collapseBelowTablet.story = {
-	name: 'collapse below tablet',
-	parameters: {
-		viewport: { defaultViewport: 'phablet' },
-		layout: 'fullscreen',
-	},
+	...defaultStoryOptions,
+	name: 'collapse below tablet with default spacing',
+};
+
+const collapseBelowTabletWithSpace = (space: ColumnsSpaceY) => (
+	<Container border={true}>
+		<Columns collapseBelow="tablet" spaceY={space}>
+			<Column>
+				<div css={contents}>1</div>
+			</Column>
+			<Column>
+				<div css={contents}>2</div>
+			</Column>
+			<Column>
+				<div css={contents}>3</div>
+			</Column>
+			<Column>
+				<div css={contents}>4</div>
+			</Column>
+		</Columns>
+	</Container>
+);
+
+export const collapseBelowTabletWithSpace1 = () =>
+	collapseBelowTabletWithSpace(1);
+
+collapseBelowTabletWithSpace1.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 1',
+};
+
+export const collapseBelowTabletWithSpace2 = () =>
+	collapseBelowTabletWithSpace(2);
+
+collapseBelowTabletWithSpace2.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 2',
+};
+
+export const collapseBelowTabletWithSpace3 = () =>
+	collapseBelowTabletWithSpace(3);
+
+collapseBelowTabletWithSpace3.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 3',
+};
+
+export const collapseBelowTabletWithSpace4 = () =>
+	collapseBelowTabletWithSpace(4);
+
+collapseBelowTabletWithSpace4.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 4',
+};
+
+export const collapseBelowTabletWithSpace5 = () =>
+	collapseBelowTabletWithSpace(5);
+
+collapseBelowTabletWithSpace5.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 5',
+};
+
+export const collapseBelowTabletWithSpace6 = () =>
+	collapseBelowTabletWithSpace(6);
+
+collapseBelowTabletWithSpace6.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 6',
+};
+
+export const collapseBelowTabletWithSpace9 = () =>
+	collapseBelowTabletWithSpace(9);
+
+collapseBelowTabletWithSpace9.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 9',
+};
+
+export const collapseBelowTabletWithSpace12 = () =>
+	collapseBelowTabletWithSpace(12);
+
+collapseBelowTabletWithSpace12.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 12',
+};
+
+export const collapseBelowTabletWithSpace24 = () =>
+	collapseBelowTabletWithSpace(24);
+
+collapseBelowTabletWithSpace24.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with space 24',
 };

--- a/src/core/components/layout/stories/columns/collapse-below.tsx
+++ b/src/core/components/layout/stories/columns/collapse-below.tsx
@@ -16,31 +16,7 @@ const contents = css`
 	background-color: ${sport[600]};
 `;
 
-export const collapseBelowTablet = () => (
-	<Container border={true}>
-		<Columns collapseBelow="tablet">
-			<Column>
-				<div css={contents}>1</div>
-			</Column>
-			<Column>
-				<div css={contents}>2</div>
-			</Column>
-			<Column>
-				<div css={contents}>3</div>
-			</Column>
-			<Column>
-				<div css={contents}>4</div>
-			</Column>
-		</Columns>
-	</Container>
-);
-
-collapseBelowTablet.story = {
-	...defaultStoryOptions,
-	name: 'collapse below tablet with default spacing',
-};
-
-const collapseBelowTabletWithSpace = (space: ColumnsSpaceY) => (
+const collapseBelowTabletWithSpace = (space?: ColumnsSpaceY) => (
 	<Container border={true}>
 		<Columns collapseBelow="tablet" spaceY={space}>
 			<Column>
@@ -58,6 +34,13 @@ const collapseBelowTabletWithSpace = (space: ColumnsSpaceY) => (
 		</Columns>
 	</Container>
 );
+
+export const collapseBelowTablet = () => collapseBelowTabletWithSpace();
+
+collapseBelowTablet.story = {
+	...defaultStoryOptions,
+	name: 'collapse below tablet with no spacing',
+};
 
 export const collapseBelowTabletWithSpace1 = () =>
 	collapseBelowTabletWithSpace(1);


### PR DESCRIPTION
## What is the purpose of this change?

It's possible to collapse columns into a stack below a certain breakpoint using the collapseBelow prop. This PR also makes the vertical space between collapsed columns configurable, similar to how the Stack component works.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Add the `spaceY` prop to the `Columns` component
-   Updating the styling to provide the requested spacing

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

**After**

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

The docs site will need to be updated to add the new Prop

### Known issues

<!--
If there are known issues, please specify them here
-->
