### PR TITLE
Coloured Lines

### DIFF
--- a/src/editorial/web/components/lines/README.md
+++ b/src/editorial/web/components/lines/README.md
@@ -42,7 +42,7 @@ The appearance of the lines.
 
 How many lines appear.
 
-### `colour`
+### `color`
 
 **`string`** _= line.primary_
 

--- a/src/editorial/web/components/lines/README.md
+++ b/src/editorial/web/components/lines/README.md
@@ -23,6 +23,7 @@ const Section = () => (
     <>
         <Lines count={8} />
         <Lines effect="squiggly" />
+        <Lines count={4} effect="dotted" colour="blue" />
     </>
 );
 ```
@@ -40,3 +41,9 @@ The appearance of the lines.
 **`1 | 4 | 8`** _= 4_
 
 How many lines appear.
+
+### `colour`
+
+**`string`** _= line.primary_
+
+The colour of the lines

--- a/src/editorial/web/components/lines/dashed.ts
+++ b/src/editorial/web/components/lines/dashed.ts
@@ -1,5 +1,4 @@
 import { space } from '@guardian/src-foundations';
-import { line } from '@guardian/src-foundations/palette';
 import { LineCount } from '.';
 
 const thickness = 1;
@@ -10,12 +9,12 @@ const width = thickness + gapHorizontal;
 export const height = (count: LineCount): number =>
 	viewHeight * (count - 1) + thickness;
 
-const dashedSvg = (count: LineCount): string => {
+const dashedSvg = (count: LineCount, colour: string): string => {
 	return encodeURIComponent(`
 	<svg xmlns="http://www.w3.org/2000/svg"
 		width="${width}" height="${viewHeight}"
 		viewBox="0 0 ${width} ${viewHeight}"
-		stroke="${line.primary}"
+		stroke="${colour}"
 		stroke-width="${thickness}"
 	>
 		<path d="M0,${thickness / 2} h${thickness} " />
@@ -23,5 +22,5 @@ const dashedSvg = (count: LineCount): string => {
 	`);
 };
 
-export const dashedImage = (count: LineCount = 1): string =>
-	`data:image/svg+xml;utf-8,${dashedSvg(count)}`;
+export const dashedImage = (count: LineCount = 1, colour: string): string =>
+	`data:image/svg+xml;utf-8,${dashedSvg(count, colour)}`;

--- a/src/editorial/web/components/lines/dashed.ts
+++ b/src/editorial/web/components/lines/dashed.ts
@@ -9,12 +9,12 @@ const width = thickness + gapHorizontal;
 export const height = (count: LineCount): number =>
 	viewHeight * (count - 1) + thickness;
 
-const dashedSvg = (count: LineCount, colour: string): string => {
+const dashedSvg = (count: LineCount, color: string): string => {
 	return encodeURIComponent(`
 	<svg xmlns="http://www.w3.org/2000/svg"
 		width="${width}" height="${viewHeight}"
 		viewBox="0 0 ${width} ${viewHeight}"
-		stroke="${colour}"
+		stroke="${color}"
 		stroke-width="${thickness}"
 	>
 		<path d="M0,${thickness / 2} h${thickness} " />
@@ -22,5 +22,5 @@ const dashedSvg = (count: LineCount, colour: string): string => {
 	`);
 };
 
-export const dashedImage = (count: LineCount = 1, colour: string): string =>
-	`data:image/svg+xml;utf-8,${dashedSvg(count, colour)}`;
+export const dashedImage = (count: LineCount = 1, color: string): string =>
+	`data:image/svg+xml;utf-8,${dashedSvg(count, color)}`;

--- a/src/editorial/web/components/lines/dotted.ts
+++ b/src/editorial/web/components/lines/dotted.ts
@@ -5,7 +5,7 @@ const gridSize = 3;
 
 export const height = (count: LineCount): number => gridSize * count;
 
-const dottedSvg = (count: LineCount, colour: string): string => {
+const dottedSvg = (count: LineCount, color: string): string => {
 	const svg = [
 		`<svg xmlns="http://www.w3.org/2000/svg" ` +
 			`width="${gridSize}" height="${height(count)}" ` +
@@ -14,7 +14,7 @@ const dottedSvg = (count: LineCount, colour: string): string => {
 
 	for (let index = 1; index <= count; index++) {
 		svg.push(
-			`<circle fill="${colour}" ` +
+			`<circle fill="${color}" ` +
 				`cx="${gridSize / 2}" ` +
 				`cy="${gridSize * (index - 1 / 2)}" ` +
 				`r="${dotRadius}" />`,
@@ -25,5 +25,5 @@ const dottedSvg = (count: LineCount, colour: string): string => {
 	return encodeURIComponent(svg.join());
 };
 
-export const dottedImage = (count: LineCount, colour: string) =>
-	`data:image/svg+xml,${dottedSvg(count, colour)}`;
+export const dottedImage = (count: LineCount, color: string) =>
+	`data:image/svg+xml,${dottedSvg(count, color)}`;

--- a/src/editorial/web/components/lines/dotted.ts
+++ b/src/editorial/web/components/lines/dotted.ts
@@ -1,4 +1,3 @@
-import { line } from '@guardian/src-foundations/palette';
 import { LineCount } from '.';
 
 const dotRadius = 1;
@@ -6,7 +5,7 @@ const gridSize = 3;
 
 export const height = (count: LineCount): number => gridSize * count;
 
-const dottedSvg = (count: LineCount): string => {
+const dottedSvg = (count: LineCount, colour: string): string => {
 	const svg = [
 		`<svg xmlns="http://www.w3.org/2000/svg" ` +
 			`width="${gridSize}" height="${height(count)}" ` +
@@ -15,7 +14,7 @@ const dottedSvg = (count: LineCount): string => {
 
 	for (let index = 1; index <= count; index++) {
 		svg.push(
-			`<circle fill="${line.primary}" ` +
+			`<circle fill="${colour}" ` +
 				`cx="${gridSize / 2}" ` +
 				`cy="${gridSize * (index - 1 / 2)}" ` +
 				`r="${dotRadius}" />`,
@@ -26,5 +25,5 @@ const dottedSvg = (count: LineCount): string => {
 	return encodeURIComponent(svg.join());
 };
 
-export const dottedImage = (count: LineCount) =>
-	`data:image/svg+xml,${dottedSvg(count)}`;
+export const dottedImage = (count: LineCount, colour: string) =>
+	`data:image/svg+xml,${dottedSvg(count, colour)}`;

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -3,10 +3,7 @@ import {
 	straightLines,
 	squigglyLines,
 	dottedLines,
-	fourLines,
-	eightLines,
 	dashedLines,
-	oneLine,
 } from './styles';
 
 type LineEffectType = 'squiggly' | 'dotted' | 'straight' | 'dashed';
@@ -28,17 +25,6 @@ export const Lines = ({ effect = 'straight', count = 4 }: LinesProps) => {
 			return <div css={dashedLines(count)} />;
 		case 'straight':
 		default:
-			return (
-				<div
-					css={[
-						straightLines,
-						count === 1
-							? oneLine
-							: count === 4
-							? fourLines
-							: eightLines,
-					]}
-				/>
-			);
+			return <div css={[straightLines(count)]} />;
 	}
 };

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -14,23 +14,23 @@ export type LineCount = 1 | 4 | 8;
 export interface LinesProps extends Props {
 	effect?: LineEffectType;
 	count?: LineCount;
-	colour?: string;
+	color?: string;
 }
 
 export const Lines = ({
 	effect = 'straight',
 	count = 4,
-	colour = line.primary,
+	color = line.primary,
 }: LinesProps) => {
 	switch (effect) {
 		case 'squiggly':
-			return <div css={squigglyLines(count, colour)} />;
+			return <div css={squigglyLines(count, color)} />;
 		case 'dotted':
-			return <div css={dottedLines(count, colour)} />;
+			return <div css={dottedLines(count, color)} />;
 		case 'dashed':
-			return <div css={dashedLines(count, colour)} />;
+			return <div css={dashedLines(count, color)} />;
 		case 'straight':
 		default:
-			return <div css={straightLines(count, colour)} />;
+			return <div css={straightLines(count, color)} />;
 	}
 };

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -25,6 +25,6 @@ export const Lines = ({ effect = 'straight', count = 4 }: LinesProps) => {
 			return <div css={dashedLines(count)} />;
 		case 'straight':
 		default:
-			return <div css={[straightLines(count)]} />;
+			return <div css={straightLines(count)} />;
 	}
 };

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -1,4 +1,5 @@
 import { Props } from '@guardian/src-helpers';
+import { line } from '@guardian/src-foundations/palette';
 import {
 	straightLines,
 	squigglyLines,
@@ -13,18 +14,23 @@ export type LineCount = 1 | 4 | 8;
 export interface LinesProps extends Props {
 	effect?: LineEffectType;
 	count?: LineCount;
+	colour?: string;
 }
 
-export const Lines = ({ effect = 'straight', count = 4 }: LinesProps) => {
+export const Lines = ({
+	effect = 'straight',
+	count = 4,
+	colour = line.primary,
+}: LinesProps) => {
 	switch (effect) {
 		case 'squiggly':
-			return <div css={squigglyLines(count)} />;
+			return <div css={squigglyLines(count, colour)} />;
 		case 'dotted':
-			return <div css={dottedLines(count)} />;
+			return <div css={dottedLines(count, colour)} />;
 		case 'dashed':
-			return <div css={dashedLines(count)} />;
+			return <div css={dashedLines(count, colour)} />;
 		case 'straight':
 		default:
-			return <div css={straightLines(count)} />;
+			return <div css={straightLines(count, colour)} />;
 	}
 };

--- a/src/editorial/web/components/lines/index.tsx
+++ b/src/editorial/web/components/lines/index.tsx
@@ -19,22 +19,26 @@ export interface LinesProps extends Props {
 }
 
 export const Lines = ({ effect = 'straight', count = 4 }: LinesProps) => {
-	if (effect === 'squiggly') {
-		return <div css={squigglyLines(count)} />;
+	switch (effect) {
+		case 'squiggly':
+			return <div css={squigglyLines(count)} />;
+		case 'dotted':
+			return <div css={dottedLines(count)} />;
+		case 'dashed':
+			return <div css={dashedLines(count)} />;
+		case 'straight':
+		default:
+			return (
+				<div
+					css={[
+						straightLines,
+						count === 1
+							? oneLine
+							: count === 4
+							? fourLines
+							: eightLines,
+					]}
+				/>
+			);
 	}
-	if (effect === 'dotted') {
-		return <div css={dottedLines(count)} />;
-	}
-	if (effect === 'dashed') {
-		return <div css={dashedLines(count)} />;
-	}
-
-	return (
-		<div
-			css={[
-				straightLines,
-				count === 1 ? oneLine : count === 4 ? fourLines : eightLines,
-			]}
-		/>
-	);
 };

--- a/src/editorial/web/components/lines/squiggly.ts
+++ b/src/editorial/web/components/lines/squiggly.ts
@@ -1,4 +1,3 @@
-import { line } from '@guardian/src-foundations/palette';
 import { LineCount } from '.';
 
 const wavelength = 12;
@@ -19,7 +18,7 @@ const d = [
 	`t 12 0`,
 ].join(' ');
 
-const squigglySvg = (count: LineCount): string => {
+const squigglySvg = (count: LineCount, colour: string): string => {
 	const repeatedLines = [];
 	for (let index = 1; index < count; index++) {
 		repeatedLines.push(`<use y="${gap * index}" xlink:href="#squiggle" />`);
@@ -31,7 +30,7 @@ const squigglySvg = (count: LineCount): string => {
 	width="${wavelength}" height="${height(count)}"
 	viewBox="0 0 ${wavelength} ${height(count)}"
 >
-	<g stroke-width="${thickness}" stroke="${line.primary}" fill="none">
+	<g stroke-width="${thickness}" stroke="${colour}" fill="none">
 		<path id="squiggle" d="${d}" />
 		${repeatedLines.join()}
 	</g>
@@ -39,5 +38,5 @@ const squigglySvg = (count: LineCount): string => {
 `);
 };
 
-export const squigglyImage = (count: LineCount = 4): string =>
-	`data:image/svg+xml;utf-8,${squigglySvg(count)}`;
+export const squigglyImage = (count: LineCount = 4, colour: string): string =>
+	`data:image/svg+xml;utf-8,${squigglySvg(count, colour)}`;

--- a/src/editorial/web/components/lines/squiggly.ts
+++ b/src/editorial/web/components/lines/squiggly.ts
@@ -18,7 +18,7 @@ const d = [
 	`t 12 0`,
 ].join(' ');
 
-const squigglySvg = (count: LineCount, colour: string): string => {
+const squigglySvg = (count: LineCount, color: string): string => {
 	const repeatedLines = [];
 	for (let index = 1; index < count; index++) {
 		repeatedLines.push(`<use y="${gap * index}" xlink:href="#squiggle" />`);
@@ -30,7 +30,7 @@ const squigglySvg = (count: LineCount, colour: string): string => {
 	width="${wavelength}" height="${height(count)}"
 	viewBox="0 0 ${wavelength} ${height(count)}"
 >
-	<g stroke-width="${thickness}" stroke="${colour}" fill="none">
+	<g stroke-width="${thickness}" stroke="${color}" fill="none">
 		<path id="squiggle" d="${d}" />
 		${repeatedLines.join()}
 	</g>
@@ -38,5 +38,5 @@ const squigglySvg = (count: LineCount, colour: string): string => {
 `);
 };
 
-export const squigglyImage = (count: LineCount = 4, colour: string): string =>
-	`data:image/svg+xml;utf-8,${squigglySvg(count, colour)}`;
+export const squigglyImage = (count: LineCount = 4, color: string): string =>
+	`data:image/svg+xml;utf-8,${squigglySvg(count, color)}`;

--- a/src/editorial/web/components/lines/stories.tsx
+++ b/src/editorial/web/components/lines/stories.tsx
@@ -74,13 +74,13 @@ export const colouredLines = () => (
 	<Container>
 		<h2>Blue Lines</h2>
 		<h3>straight</h3>
-		<Lines effect="straight" colour="blue" />
+		<Lines effect="straight" color="blue" />
 		<h3>dotted</h3>
-		<Lines effect="dotted" colour="blue" />
+		<Lines effect="dotted" color="blue" />
 		<h3>squiggly</h3>
-		<Lines effect="squiggly" colour="blue" />
+		<Lines effect="squiggly" color="blue" />
 		<h3>dashed</h3>
-		<Lines effect="dashed" colour="blue" />
+		<Lines effect="dashed" color="blue" />
 	</Container>
 );
 colouredLines.story = { name: 'coloured lines' };

--- a/src/editorial/web/components/lines/stories.tsx
+++ b/src/editorial/web/components/lines/stories.tsx
@@ -69,3 +69,18 @@ export const dashedLines = () => (
 	</Container>
 );
 dashedLines.story = { name: 'dashed lines' };
+
+export const colouredLines = () => (
+	<Container>
+		<h2>Blue Lines</h2>
+		<h3>straight</h3>
+		<Lines effect="straight" colour="blue" />
+		<h3>dotted</h3>
+		<Lines effect="dotted" colour="blue" />
+		<h3>squiggly</h3>
+		<Lines effect="squiggly" colour="blue" />
+		<h3>dashed</h3>
+		<Lines effect="dashed" colour="blue" />
+	</Container>
+);
+colouredLines.story = { name: 'coloured lines' };

--- a/src/editorial/web/components/lines/styles.ts
+++ b/src/editorial/web/components/lines/styles.ts
@@ -7,12 +7,12 @@ import { LineCount } from '.';
 
 const lineGap = remSpace[1];
 
-export const straightLines = (count: LineCount, colour: string) => {
+export const straightLines = (count: LineCount, color: string) => {
 	const baseStyles = css`
 		background-image: repeating-linear-gradient(
 			to bottom,
-			${colour},
-			${colour} 1px,
+			${color},
+			${color} 1px,
 			transparent 1px,
 			transparent ${lineGap}
 		);
@@ -42,20 +42,20 @@ export const straightLines = (count: LineCount, colour: string) => {
 	}
 };
 
-export const squigglyLines = (count: LineCount, colour: string) => css`
-	background-image: url(${squigglyImage(count, colour)});
+export const squigglyLines = (count: LineCount, color: string) => css`
+	background-image: url(${squigglyImage(count, color)});
 	background-repeat: repeat-x;
 	background-position: left;
 	height: ${squigglyImageHeight(count)}px;
 `;
 
-export const dottedLines = (count: LineCount, colour: string) => css`
-	background-image: url(${dottedImage(count, colour)});
+export const dottedLines = (count: LineCount, color: string) => css`
+	background-image: url(${dottedImage(count, color)});
 	height: ${dottedImageHeight(count)}px;
 `;
 
-export const dashedLines = (count: LineCount, colour: string) => css`
-	background-image: url(${dashedImage(count, colour)});
+export const dashedLines = (count: LineCount, color: string) => css`
+	background-image: url(${dashedImage(count, color)});
 	background-repeat: repeat;
 	background-position: top center;
 	height: ${labsImageHeight(count)}px;

--- a/src/editorial/web/components/lines/styles.ts
+++ b/src/editorial/web/components/lines/styles.ts
@@ -2,18 +2,17 @@ import { css } from '@emotion/react';
 import { squigglyImage, height as squigglyImageHeight } from './squiggly';
 import { dottedImage, height as dottedImageHeight } from './dotted';
 import { dashedImage, height as labsImageHeight } from './dashed';
-import { line } from '@guardian/src-foundations/palette';
 import { remSpace } from '@guardian/src-foundations';
 import { LineCount } from '.';
 
 const lineGap = remSpace[1];
 
-export const straightLines = (count: LineCount) => {
+export const straightLines = (count: LineCount, colour: string) => {
 	const baseStyles = css`
 		background-image: repeating-linear-gradient(
 			to bottom,
-			${line.primary},
-			${line.primary} 1px,
+			${colour},
+			${colour} 1px,
 			transparent 1px,
 			transparent ${lineGap}
 		);
@@ -43,20 +42,20 @@ export const straightLines = (count: LineCount) => {
 	}
 };
 
-export const squigglyLines = (count: LineCount) => css`
-	background-image: url(${squigglyImage(count)});
+export const squigglyLines = (count: LineCount, colour: string) => css`
+	background-image: url(${squigglyImage(count, colour)});
 	background-repeat: repeat-x;
 	background-position: left;
 	height: ${squigglyImageHeight(count)}px;
 `;
 
-export const dottedLines = (count: LineCount) => css`
-	background-image: url(${dottedImage(count)});
+export const dottedLines = (count: LineCount, colour: string) => css`
+	background-image: url(${dottedImage(count, colour)});
 	height: ${dottedImageHeight(count)}px;
 `;
 
-export const dashedLines = (count: LineCount) => css`
-	background-image: url(${dashedImage(count)});
+export const dashedLines = (count: LineCount, colour: string) => css`
+	background-image: url(${dashedImage(count, colour)});
 	background-repeat: repeat;
 	background-position: top center;
 	height: ${labsImageHeight(count)}px;

--- a/src/editorial/web/components/lines/styles.ts
+++ b/src/editorial/web/components/lines/styles.ts
@@ -8,32 +8,40 @@ import { LineCount } from '.';
 
 const lineGap = remSpace[1];
 
-export const straightLines = css`
-	background-image: repeating-linear-gradient(
-		to bottom,
-		${line.primary},
-		${line.primary} 1px,
-		transparent 1px,
-		transparent ${lineGap}
-	);
-	background-repeat: repeat-x;
-	background-position: top;
-`;
+export const straightLines = (count: LineCount) => {
+	const baseStyles = css`
+		background-image: repeating-linear-gradient(
+			to bottom,
+			${line.primary},
+			${line.primary} 1px,
+			transparent 1px,
+			transparent ${lineGap}
+		);
+		background-repeat: repeat-x;
+		background-position: top;
+	`;
 
-export const oneLine = css`
-	background-size: 1px;
-	height: 1px;
-`;
-
-export const fourLines = css`
-	background-size: 1px calc(${lineGap} * 3 + 1px);
-	height: calc(${lineGap} * 3 + 1px);
-`;
-
-export const eightLines = css`
-	background-size: 1px calc(${lineGap} * 7 + 1px);
-	height: calc(${lineGap} * 7 + 1px);
-`;
+	switch (count) {
+		case 1:
+			return css`
+				${baseStyles};
+				background-size: 1px;
+				height: 1px;
+			`;
+		case 4:
+			return css`
+				${baseStyles};
+				background-size: 1px calc(${lineGap} * 3 + 1px);
+				height: calc(${lineGap} * 3 + 1px);
+			`;
+		case 8:
+			return css`
+				${baseStyles};
+				background-size: 1px calc(${lineGap} * 7 + 1px);
+				height: calc(${lineGap} * 7 + 1px);
+			`;
+	}
+};
 
 export const squigglyLines = (count: LineCount) => css`
 	background-image: url(${squigglyImage(count)});


### PR DESCRIPTION
## What is the purpose of this change?
Adds the `colour` prop to the `Lines` component so that we can change the colour of lines from the default grey `line.primary` to something more interesting

## Why?
Because sometimes, like for labs or special reports, that `line.primary` grey gets washed out against the light grey of the article background.

Also, there are some new designs coming out that have even wilder background colours that we want `Lines` to sit on top of and for that we need to set a custom colour to get that nice line pop.

![Screenshot 2021-03-31 at 09 15 24](https://user-images.githubusercontent.com/1336821/113112923-a5d8bf00-9201-11eb-9471-3551a3885dfc.jpg)

