### PR TITLE
`darkModeCss` Helper

### DIFF
--- a/src/core/helpers/README.md
+++ b/src/core/helpers/README.md
@@ -1,3 +1,37 @@
 # Helpers
 
 Shared helper functions and types used across all components.
+
+## Dark Mode
+
+This package exports a `darkModeCss` function, which is a variant of the standard Emotion `css` function. It can be used to wrap template string styles in a dark mode media query. The signature is as follows:
+
+```ts
+(supportsDarkMode: boolean) => (styles: TemplateStringsArray, ...placeholders: string[]) => SerializedStyles
+```
+
+The first parameter allows the caller to choose whether they want these dark mode styles included - if set to `false` they won't be. The rest of the parameters turned this into a [template literal "tag"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates), which allows it to operate on template strings in the same way as the `css` function.
+
+### Example
+
+```tsx
+import { Props, darkModeCss } from '@guardian/src-helpers';
+
+const styles = (supportsDarkMode: boolean): SerializedStyles => css`
+  background-color: white;
+  color: black;
+
+  ${darkModeCss(supportsDarkMode)`
+    background-color: black;
+    color: white;
+  `}
+`;
+
+interface HelloProps extends Props {
+  name: string;
+}
+
+const HelloProps = ({ name, supportsDarkMode = false }) => (
+  <p css={styles(supportsDarkMode)}>Hello {name}</p>
+);
+```

--- a/src/core/helpers/darkMode.ts
+++ b/src/core/helpers/darkMode.ts
@@ -1,0 +1,26 @@
+// ----- Imports ----- //
+
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+
+// ----- Functions ----- //
+
+const darkModeCss = (supportsDarkMode: boolean) => (
+  styles: TemplateStringsArray,
+  ...placeholders: string[]
+): SerializedStyles =>
+  supportsDarkMode
+    ? css`
+        @media (prefers-color-scheme: dark) {
+          ${styles
+            .map(
+              (style, i) => `${style}${placeholders[i] ? placeholders[i] : ""}`
+            )
+            .join("")}
+        }
+      `
+    : css``;
+
+// ----- Exports ----- //
+
+export { darkModeCss };

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -1,2 +1,3 @@
 export { storybookBackgrounds } from './storybook-bg';
 export * from './types';
+export { darkModeCss } from './darkMode';

--- a/src/core/helpers/package.json
+++ b/src/core/helpers/package.json
@@ -35,5 +35,8 @@
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "typescript": "^4.1.3"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11.1.2"
   }
 }

--- a/src/core/helpers/types.ts
+++ b/src/core/helpers/types.ts
@@ -5,4 +5,5 @@ export type ThemeName = 'default' | 'brand' | 'brandAlt';
 export interface Props {
 	className?: string;
 	cssOverrides?: SerializedStyles | SerializedStyles[];
+	supportsDarkMode?: boolean;
 }


### PR DESCRIPTION
## What is the purpose of this change?

It introduces the `darkModeCss` helper, currently found in [`image-rendering`](https://github.com/guardian/image-rendering/blob/8e15e909cae8654a6e111abcb88dcc3986a54b81/src/lib.ts), to `src-helpers`. It's a variant of the standard Emotion `css` function, and can be used to wrap template string styles in a dark mode media query. The signature is as follows:

```ts
(supportsDarkMode: boolean) => (styles: TemplateStringsArray, ...placeholders: string[]) => SerializedStyles
```

The first parameter allows the caller to choose whether they want these dark mode styles included - if set to `false` they won't be. The rest of the parameters turned this into a [template literal "tag"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates), which allows it to operate on template strings in the same way as the `css` function.

### Example

```tsx
import { Props, darkModeCss } from '@guardian/src-helpers';

const styles = (supportsDarkMode: boolean): SerializedStyles => css`
  background-color: white;
  color: black;

  ${darkModeCss(supportsDarkMode)`
    background-color: black;
    color: white;
  `}
`;

interface HelloProps extends Props {
  name: string;
}

const HelloProps = ({ name, supportsDarkMode = false }) => (
  <p css={styles(supportsDarkMode)}>Hello {name}</p>
);
```

## What does this change?

- Added `darkModeCss` function
- Added `@emotion/react` as peer dep
- Added `supportsDarkMode` as optional Source-wide prop
- Added docs to `src-helpers` README

## Checklist

### Documentation

-   [x] Full API surface area is documented in the README
-   [ ] Examples in Storybook (not sure if this is needed since this isn't a component?)

May need to include this documentation in the main docs site?
