### PR TITLE
`src ed button`

### DIFF
--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -240,4 +240,4 @@ const LinkButton = ({
 	</a>
 );
 
-export { Button, LinkButton };
+export { Button, LinkButton, ButtonProps };

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -240,4 +240,4 @@ const LinkButton = ({
 	</a>
 );
 
-export { Button, LinkButton, ButtonProps };
+export { Button, LinkButton, ButtonProps, LinkButtonProps };

--- a/src/editorial/web/components/button/README.md
+++ b/src/editorial/web/components/button/README.md
@@ -1,0 +1,56 @@
+# Buttom
+
+This is the editorial version of the core `Button` coomponent. This editorial version
+requires the `format` prop and uses that to override `Button` styles based on
+`format.theme`
+
+## Install
+
+```sh
+$ yarn add @guardian/src-ed-button @guardian/src-foundations
+```
+
+or
+
+```sh
+$ npm i @guardian/src-ed-button @guardian/src-foundations
+```
+
+## Use
+
+```jsx
+import { Button } from '@guardian/src-ed-button';
+
+const SomeButtons = () => (
+    <Button
+        priority="primay"
+        onClick={() => {}}
+        format={{
+            display: Display.Standard,
+            design: Design.Article,
+            theme: Pillar.News,
+        }}
+    >
+        Click me
+    </Button>
+    <Button
+        priority="subdued"
+        size="small"
+        format={{
+            display: Display.Standard,
+            design: Design.Article,
+            theme: Special.Labs,
+        }}
+    >
+        Click me too
+    </Button>
+);
+```
+
+## `Button` Props
+
+In addition to all the standard `Button` props we also have
+
+### `format`
+
+See **`@guardian/types`**: https://github.com/guardian/types/blob/main/src/format.ts

--- a/src/editorial/web/components/button/README.md
+++ b/src/editorial/web/components/button/README.md
@@ -1,8 +1,10 @@
-# Buttom
+# Button
 
 This is the editorial version of the core `Button` coomponent. This editorial version
 requires the `format` prop and uses that to override `Button` styles based on
 `format.theme`
+
+Also exported is `LinkButton` which, like in core, offers a href version of the buttom
 
 ## Install
 
@@ -33,9 +35,10 @@ const SomeButtons = () => (
     >
         Click me
     </Button>
-    <Button
+    <LinkButton
         priority="subdued"
         size="small"
+        href="https://www.theguardian.com/uk"
         format={{
             display: Display.Standard,
             design: Design.Article,
@@ -43,14 +46,16 @@ const SomeButtons = () => (
         }}
     >
         Click me too
-    </Button>
+    </LinkButton>
 );
 ```
 
 ## `Button` Props
 
-In addition to all the standard `Button` props we also have
+In addition to all the standard `Button` and `LinkButton` props, we also have
 
 ### `format`
 
 See **`@guardian/types`**: https://github.com/guardian/types/blob/main/src/format.ts
+
+Which is what we use to decide the editorial styling overrides

--- a/src/editorial/web/components/button/index.tsx
+++ b/src/editorial/web/components/button/index.tsx
@@ -1,0 +1,237 @@
+import { css } from '@emotion/react';
+
+import { Design, Display, Format, Pillar, Special } from '@guardian/types';
+import {
+	Button as CoreButton,
+	ButtonProps,
+	ButtonPriority,
+} from '@guardian/src-button';
+import {
+	culture,
+	labs,
+	lifestyle,
+	news,
+	opinion,
+	specialReport,
+	sport,
+	neutral,
+} from '@guardian/src-foundations';
+
+export interface Props extends ButtonProps {
+	format?: Format;
+	priority?: ButtonPriority;
+	children: React.ReactNode;
+}
+
+const defaultFormat = {
+	display: Display.Standard,
+	design: Design.Article,
+	theme: Pillar.News,
+};
+
+const WHITE = neutral[100];
+
+const decideBackground = (format: Format, priority: ButtonPriority) => {
+	switch (priority) {
+		case 'primary':
+		case 'secondary':
+			switch (format.theme) {
+				case Pillar.News:
+					return css`
+						background-color: ${news[300]};
+						:hover {
+							background-color: ${news[400]};
+							border: 1px solid ${news[400]};
+						}
+					`;
+				case Pillar.Culture:
+					return css`
+						background-color: ${culture[300]};
+						:hover {
+							background-color: ${culture[400]};
+							border: 1px solid ${culture[400]};
+						}
+					`;
+				case Pillar.Lifestyle:
+					return css`
+						background-color: ${lifestyle[300]};
+						:hover {
+							background-color: ${lifestyle[400]};
+							border: 1px solid ${lifestyle[400]};
+						}
+					`;
+				case Pillar.Sport:
+					return css`
+						background-color: ${sport[300]};
+						:hover {
+							background-color: ${sport[400]};
+							border: 1px solid ${sport[400]};
+						}
+					`;
+				case Pillar.Opinion:
+					return css`
+						background-color: ${opinion[300]};
+						:hover {
+							background-color: ${opinion[400]};
+							border: 1px solid ${opinion[400]};
+						}
+					`;
+				case Special.Labs:
+					return css`
+						background-color: ${labs[300]};
+						:hover {
+							background-color: ${labs[400]};
+							border: 1px solid ${labs[400]};
+						}
+					`;
+				case Special.SpecialReport:
+					return css`
+						background-color: ${specialReport[300]};
+						:hover {
+							background-color: ${specialReport[400]};
+							border: 1px solid ${specialReport[400]};
+						}
+					`;
+			}
+		case 'subdued':
+		case 'tertiary':
+			return css`
+				background-color: transparent;
+			`;
+	}
+};
+
+const decideBorder = (format: Format, priority: ButtonPriority) => {
+	switch (priority) {
+		case 'primary':
+		case 'secondary':
+			switch (format.theme) {
+				case Pillar.News:
+					return css`
+						border: 1px solid ${news[300]};
+					`;
+				case Pillar.Culture:
+					return css`
+						border: 1px solid ${culture[300]};
+					`;
+				case Pillar.Lifestyle:
+					return css`
+						border: 1px solid ${lifestyle[300]};
+					`;
+				case Pillar.Sport:
+					return css`
+						border: 1px solid ${sport[300]};
+					`;
+				case Pillar.Opinion:
+					return css`
+						border: 1px solid ${opinion[300]};
+					`;
+				case Special.Labs:
+					return css`
+						border: 1px solid ${labs[300]};
+					`;
+				case Special.SpecialReport:
+					return css`
+						border: 1px solid ${specialReport[300]};
+					`;
+			}
+		case 'tertiary':
+			switch (format.theme) {
+				case Pillar.News:
+					return css`
+						border: 1px solid ${news[400]};
+					`;
+				case Pillar.Culture:
+					return css`
+						border: 1px solid ${culture[400]};
+					`;
+				case Pillar.Lifestyle:
+					return css`
+						border: 1px solid ${lifestyle[400]};
+					`;
+				case Pillar.Sport:
+					return css`
+						border: 1px solid ${sport[400]};
+					`;
+				case Pillar.Opinion:
+					return css`
+						border: 1px solid ${opinion[400]};
+					`;
+				case Special.Labs:
+					return css`
+						border: 1px solid ${labs[400]};
+					`;
+				case Special.SpecialReport:
+					return css`
+						border: 1px solid ${specialReport[400]};
+					`;
+			}
+		case 'subdued':
+			return css`
+				border: none;
+			`;
+	}
+};
+
+const decideFont = (format: Format, priority: ButtonPriority) => {
+	switch (priority) {
+		case 'primary':
+		case 'secondary':
+			return css`
+				color: ${WHITE};
+			`;
+		case 'subdued':
+		case 'tertiary':
+			switch (format.theme) {
+				case Pillar.News:
+					return css`
+						color: ${news[400]};
+					`;
+				case Pillar.Culture:
+					return css`
+						color: ${culture[400]};
+					`;
+				case Pillar.Lifestyle:
+					return css`
+						color: ${lifestyle[400]};
+					`;
+				case Pillar.Sport:
+					return css`
+						color: ${sport[400]};
+					`;
+				case Pillar.Opinion:
+					return css`
+						color: ${opinion[400]};
+					`;
+				case Special.Labs:
+					return css`
+						color: ${labs[400]};
+					`;
+				case Special.SpecialReport:
+					return css`
+						color: ${specialReport[400]};
+					`;
+			}
+	}
+};
+
+export const Button = ({
+	format = defaultFormat,
+	children,
+	priority = 'primary',
+	...props
+}: Props) => {
+	const backgroundOverrides = decideBackground(format, priority);
+	const borderOverrides = decideBorder(format, priority);
+	const fontOverrides = decideFont(format, priority);
+
+	return (
+		<CoreButton
+			priority={priority}
+			cssOverrides={[backgroundOverrides, borderOverrides, fontOverrides]}
+			{...props}
+		>
+			{children}
+		</CoreButton>
+	);
+};

--- a/src/editorial/web/components/button/index.tsx
+++ b/src/editorial/web/components/button/index.tsx
@@ -109,67 +109,10 @@ const decideBorder = (format: Format, priority: ButtonPriority) => {
 	switch (priority) {
 		case 'primary':
 		case 'secondary':
-			switch (format.theme) {
-				case Pillar.News:
-					return css`
-						border: 1px solid ${news[300]};
-					`;
-				case Pillar.Culture:
-					return css`
-						border: 1px solid ${culture[300]};
-					`;
-				case Pillar.Lifestyle:
-					return css`
-						border: 1px solid ${lifestyle[300]};
-					`;
-				case Pillar.Sport:
-					return css`
-						border: 1px solid ${sport[300]};
-					`;
-				case Pillar.Opinion:
-					return css`
-						border: 1px solid ${opinion[300]};
-					`;
-				case Special.Labs:
-					return css`
-						border: 1px solid ${labs[300]};
-					`;
-				case Special.SpecialReport:
-					return css`
-						border: 1px solid ${specialReport[300]};
-					`;
-			}
 		case 'tertiary':
-			switch (format.theme) {
-				case Pillar.News:
-					return css`
-						border: 1px solid ${news[400]};
-					`;
-				case Pillar.Culture:
-					return css`
-						border: 1px solid ${culture[400]};
-					`;
-				case Pillar.Lifestyle:
-					return css`
-						border: 1px solid ${lifestyle[400]};
-					`;
-				case Pillar.Sport:
-					return css`
-						border: 1px solid ${sport[400]};
-					`;
-				case Pillar.Opinion:
-					return css`
-						border: 1px solid ${opinion[400]};
-					`;
-				case Special.Labs:
-					return css`
-						border: 1px solid ${labs[400]};
-					`;
-				case Special.SpecialReport:
-					return css`
-						border: 1px solid ${specialReport[400]};
-					`;
-			}
+			return css`
+				border: 1px solid currentColor;
+			`;
 		case 'subdued':
 			return css`
 				border: none;

--- a/src/editorial/web/components/button/index.tsx
+++ b/src/editorial/web/components/button/index.tsx
@@ -21,14 +21,10 @@ import {
 
 export interface ButtonProps extends CoreButtonProps {
 	format?: Format;
-	priority?: ButtonPriority;
-	children: React.ReactNode;
 }
 
 export interface LinkButtonProps extends CoreLinkButtonProps {
 	format?: Format;
-	priority?: ButtonPriority;
-	children: React.ReactNode;
 }
 
 const defaultFormat = {

--- a/src/editorial/web/components/button/index.tsx
+++ b/src/editorial/web/components/button/index.tsx
@@ -3,7 +3,9 @@ import { css } from '@emotion/react';
 import { Design, Display, Format, Pillar, Special } from '@guardian/types';
 import {
 	Button as CoreButton,
-	ButtonProps,
+	ButtonProps as CoreButtonProps,
+	LinkButton as CoreLinkButton,
+	LinkButtonProps as CoreLinkButtonProps,
 	ButtonPriority,
 } from '@guardian/src-button';
 import {
@@ -17,7 +19,13 @@ import {
 	neutral,
 } from '@guardian/src-foundations';
 
-export interface Props extends ButtonProps {
+export interface ButtonProps extends CoreButtonProps {
+	format?: Format;
+	priority?: ButtonPriority;
+	children: React.ReactNode;
+}
+
+export interface LinkButtonProps extends CoreLinkButtonProps {
 	format?: Format;
 	priority?: ButtonPriority;
 	children: React.ReactNode;
@@ -220,7 +228,7 @@ export const Button = ({
 	children,
 	priority = 'primary',
 	...props
-}: Props) => {
+}: ButtonProps) => {
 	const backgroundOverrides = decideBackground(format, priority);
 	const borderOverrides = decideBorder(format, priority);
 	const fontOverrides = decideFont(format, priority);
@@ -233,5 +241,26 @@ export const Button = ({
 		>
 			{children}
 		</CoreButton>
+	);
+};
+
+export const LinkButton = ({
+	format = defaultFormat,
+	children,
+	priority = 'primary',
+	...props
+}: LinkButtonProps) => {
+	const backgroundOverrides = decideBackground(format, priority);
+	const borderOverrides = decideBorder(format, priority);
+	const fontOverrides = decideFont(format, priority);
+
+	return (
+		<CoreLinkButton
+			priority={priority}
+			cssOverrides={[backgroundOverrides, borderOverrides, fontOverrides]}
+			{...props}
+		>
+			{children}
+		</CoreLinkButton>
 	);
 };

--- a/src/editorial/web/components/button/package.json
+++ b/src/editorial/web/components/button/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "@guardian/editorial",
+  "name": "@guardian/src-ed-button",
   "version": "3.5.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/guardian/source.git"
+  },
   "license": "Apache-2.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -25,6 +29,10 @@
     "verbump:preminor": "yarn version --preminor --preid rc --no-git-tag-version",
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
+  "dependencies": {
+    "@guardian/src-button": "^3.5.0",
+    "@guardian/types": "^6.0.0"
+  },
   "devDependencies": {
     "npm-run-all": "^4.1.5",
     "typescript": "^4.1.3"
@@ -33,9 +41,5 @@
     "@emotion/react": "^11.1.2",
     "@guardian/src-foundations": "^3.5.0",
     "react": "^17.0.1"
-  },
-  "dependencies": {
-    "@guardian/src-button": "^3.5.0",
-    "@guardian/types": "^6.0.0"
   }
 }

--- a/src/editorial/web/components/button/stories.tsx
+++ b/src/editorial/web/components/button/stories.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Design, Display, Pillar, Special } from '@guardian/types';
 import React from 'react';
-import { Button } from './index';
+import { Button, LinkButton } from './index';
 
 export default {
 	title: 'Editorial/Button',
@@ -189,7 +189,7 @@ Secondary.story = { name: 'when secondary' };
 
 export const Tertiary = () => (
 	<Row>
-		<Button
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -199,8 +199,8 @@ export const Tertiary = () => (
 			}}
 		>
 			News
-		</Button>
-		<Button
+		</LinkButton>
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -210,8 +210,8 @@ export const Tertiary = () => (
 			}}
 		>
 			Sport
-		</Button>
-		<Button
+		</LinkButton>
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -221,8 +221,8 @@ export const Tertiary = () => (
 			}}
 		>
 			Culture
-		</Button>
-		<Button
+		</LinkButton>
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -232,8 +232,8 @@ export const Tertiary = () => (
 			}}
 		>
 			Lifestyle
-		</Button>
-		<Button
+		</LinkButton>
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -243,8 +243,8 @@ export const Tertiary = () => (
 			}}
 		>
 			Opinion
-		</Button>
-		<Button
+		</LinkButton>
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -254,8 +254,8 @@ export const Tertiary = () => (
 			}}
 		>
 			SpecialReport
-		</Button>
-		<Button
+		</LinkButton>
+		<LinkButton
 			priority="tertiary"
 			size="small"
 			format={{
@@ -265,7 +265,7 @@ export const Tertiary = () => (
 			}}
 		>
 			Labs
-		</Button>
+		</LinkButton>
 	</Row>
 );
 Tertiary.story = { name: 'when tertiary' };
@@ -375,7 +375,8 @@ Overrides.story = { name: 'with overrides overriden' };
 
 export const DefaultStory = () => (
 	<Row>
-		<Button>Default</Button>
+		<Button onClick={() => null}>Default</Button>
+		<LinkButton href="example.com">Default</LinkButton>
 	</Row>
 );
 DefaultStory.story = { name: 'with defaults' };

--- a/src/editorial/web/components/button/stories.tsx
+++ b/src/editorial/web/components/button/stories.tsx
@@ -1,0 +1,381 @@
+import { css } from '@emotion/react';
+import { Design, Display, Pillar, Special } from '@guardian/types';
+import React from 'react';
+import { Button } from './index';
+
+export default {
+	title: 'Editorial/Button',
+	component: Button,
+};
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			width: 800px;
+		`}
+	>
+		{children}
+	</div>
+);
+
+export const Primary = () => (
+	<Row>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+		>
+			News
+		</Button>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Sport,
+			}}
+		>
+			Sport
+		</Button>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Culture,
+			}}
+		>
+			Culture
+		</Button>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Lifestyle,
+			}}
+		>
+			Lifestyle
+		</Button>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Opinion,
+			}}
+		>
+			Opinion
+		</Button>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.SpecialReport,
+			}}
+		>
+			SpecialReport
+		</Button>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.Labs,
+			}}
+		>
+			Labs
+		</Button>
+	</Row>
+);
+Primary.story = { name: 'when primary' };
+
+export const Secondary = () => (
+	<Row>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+		>
+			News
+		</Button>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Sport,
+			}}
+		>
+			Sport
+		</Button>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Culture,
+			}}
+		>
+			Culture
+		</Button>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Lifestyle,
+			}}
+		>
+			Lifestyle
+		</Button>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Opinion,
+			}}
+		>
+			Opinion
+		</Button>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.SpecialReport,
+			}}
+		>
+			SpecialReport
+		</Button>
+		<Button
+			priority="secondary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.Labs,
+			}}
+		>
+			Labs
+		</Button>
+	</Row>
+);
+Secondary.story = { name: 'when secondary' };
+
+export const Tertiary = () => (
+	<Row>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+		>
+			News
+		</Button>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Sport,
+			}}
+		>
+			Sport
+		</Button>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Culture,
+			}}
+		>
+			Culture
+		</Button>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Lifestyle,
+			}}
+		>
+			Lifestyle
+		</Button>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Opinion,
+			}}
+		>
+			Opinion
+		</Button>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.SpecialReport,
+			}}
+		>
+			SpecialReport
+		</Button>
+		<Button
+			priority="tertiary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.Labs,
+			}}
+		>
+			Labs
+		</Button>
+	</Row>
+);
+Tertiary.story = { name: 'when tertiary' };
+
+export const Subdued = () => (
+	<Row>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+		>
+			News
+		</Button>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Sport,
+			}}
+		>
+			Sport
+		</Button>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Culture,
+			}}
+		>
+			Culture
+		</Button>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Lifestyle,
+			}}
+		>
+			Lifestyle
+		</Button>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.Opinion,
+			}}
+		>
+			Opinion
+		</Button>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.SpecialReport,
+			}}
+		>
+			SpecialReport
+		</Button>
+		<Button
+			priority="subdued"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Special.Labs,
+			}}
+		>
+			Labs
+		</Button>
+	</Row>
+);
+Subdued.story = { name: 'when subdued' };
+
+export const Overrides = () => (
+	<Row>
+		<Button
+			priority="primary"
+			size="small"
+			format={{
+				display: Display.Standard,
+				design: Design.Article,
+				theme: Pillar.News,
+			}}
+			cssOverrides={css`
+				background-color: pink;
+			`}
+		>
+			Pink News
+		</Button>
+	</Row>
+);
+Overrides.story = { name: 'with overrides overriden' };
+
+export const DefaultStory = () => (
+	<Row>
+		<Button>Default</Button>
+	</Row>
+);
+DefaultStory.story = { name: 'with defaults' };

--- a/src/editorial/web/components/button/tsconfig.json
+++ b/src/editorial/web/components/button/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["."],
+  "exclude": ["dist", "stories.tsx"],
+  "references": [
+    {
+      "path": "../../../../core/helpers"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,6 +2076,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.5.0.tgz#d8ea25cc396f31bd4baedb8f6d7d3727a9af1fa7"
   integrity sha512-IYXMdqW6vg9mVnAXbbWCm0R9AZfWlAjfJ668TnCx3ypX5/u4AYAXdOfrWWX+uWvFvs3Ulub+E8vEm+eUkxi6rQ==
 
+"@guardian/types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-6.0.0.tgz#65f4001e390fc8c22f196676742121b89ff28651"
+  integrity sha512-HAYOUfy+Xm1WodByJ7fUH4emSSzVh3YW8euJx1r4TopsG/tIsI94IntOI38s6kwtsClY90gFKG25UiasKJL/Jw==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
## What?
Adds a new `Button` component to the `editorial` design system.

This editorial `Button` component extends the core `Button` component adding a single additional prop along the way. This new prop is `format`, taken from https://github.com/guardian/types/

`format` is then used to override the css props `color`, `background-color`, `border` and, sometimes, `:hover` based on `priority`

--------

### `primary`
![Screenshot 2021-04-15 at 12 08 45](https://user-images.githubusercontent.com/1336821/114859984-5a1e3c00-9de3-11eb-8c80-39b4b9d2b7f0.jpg)

### `secondary`
![Screenshot 2021-04-15 at 12 08 45](https://user-images.githubusercontent.com/1336821/114860013-6609fe00-9de3-11eb-8edc-a987abd1263f.jpg)

### `tertiary`
![Screenshot 2021-04-15 at 12 09 08](https://user-images.githubusercontent.com/1336821/114860026-699d8500-9de3-11eb-9fff-5e1b6ec8077c.jpg)

### `subdued`
![Screenshot 2021-04-15 at 12 09 31](https://user-images.githubusercontent.com/1336821/114860064-73bf8380-9de3-11eb-8453-eea3f75f447f.jpg)


## Why?
This component [already exists in Discussion](https://github.com/guardian/discussion-rendering/blob/fc14c26db73bfec8a04ff7a503ed9f90f1a1a8ad/src/components/PillarButton/PillarButton.tsx#L86) and is generic enough to warrent a position higher up, where it can be imported into multiple codebases

## What about `secondary`?
Right now, this is returning the same values as for `primary`. When `PillarButton` was first built in discussion I don't think `secondary` existed as an option so it wasn't styled for and I can't think of an obvious way to go. @HarryFischer Akemi, any thoughts?

## `ButtonProps` are now being exported
This PR exports `ButtonProps` from the `core` `Button` component so that we can extend from it in the `editorial` version, allowing us to pass in those props in addition to `format`