### PR TITLE
`src-ed-quote-icon`

### DIFF
--- a/src/editorial/web/components/quote-icon/README.md
+++ b/src/editorial/web/components/quote-icon/README.md
@@ -1,0 +1,49 @@
+# QuoteIcon
+
+The Guardian quote icon is used in kickers, headlines, drop caps and pull quotes to denote quoted text.
+
+## Install
+
+```sh
+$ yarn add @guardian/src-ed-quote-icon
+```
+
+or
+
+```sh
+$ npm i @guardian/src-ed-quote-icon
+```
+
+## Use
+
+```jsx
+import { QuoteIcon } from '@guardian/src-ed-quote-icon';
+
+const Section = () => (
+    <>
+        <QuoteIcon
+            size="medium"
+            format={{
+                display: Display.Standard,
+                design: Design.Article,
+                theme: Pillar.News,
+            }}
+        />
+        <blockquote>I said this</blockquote>
+    </>
+);
+```
+
+## `QuoteIcon` Props
+
+### `size`
+
+**`"tiny" | "small" | "medium" | "large"`**
+
+The size of the quote.
+
+### `format`
+
+See **`@guardian/types`**: https://github.com/guardian/types/blob/main/src/format.ts
+
+What we use to decide the editorial colour for the quotes

--- a/src/editorial/web/components/quote-icon/README.md
+++ b/src/editorial/web/components/quote-icon/README.md
@@ -38,7 +38,7 @@ const Section = () => (
 
 ### `size`
 
-**`"tiny" | "small" | "medium" | "large"`**
+**`"xsmall" | "small" | "medium" | "large"`**
 
 The size of the quote.
 

--- a/src/editorial/web/components/quote-icon/index.tsx
+++ b/src/editorial/web/components/quote-icon/index.tsx
@@ -1,0 +1,136 @@
+import { css } from '@emotion/react';
+
+import { Format, Pillar, Special } from '@guardian/types';
+import { until } from '@guardian/src-foundations/mq';
+import {
+	culture,
+	labs,
+	lifestyle,
+	news,
+	opinion,
+	specialReport,
+	sport,
+} from '@guardian/src-foundations';
+
+const quoteStyles = css`
+	height: 17px;
+	width: 9px;
+	margin-right: 12px;
+	transform: translateY(-1px);
+	overflow: visible;
+`;
+
+const quoteColor = (format: Format) => {
+	switch (format.theme) {
+		case Pillar.News: {
+			return css`
+				fill: ${news[400]};
+			`;
+		}
+		case Pillar.Opinion: {
+			return css`
+				fill: ${opinion[400]};
+			`;
+		}
+		case Pillar.Culture: {
+			return css`
+				fill: ${culture[400]};
+			`;
+		}
+		case Pillar.Sport: {
+			return css`
+				fill: ${sport[400]};
+			`;
+		}
+		case Pillar.Lifestyle: {
+			return css`
+				fill: ${lifestyle[400]};
+			`;
+		}
+		case Special.SpecialReport: {
+			return css`
+				fill: ${specialReport[400]};
+			`;
+		}
+		case Special.Labs: {
+			return css`
+				fill: ${labs[400]};
+			`;
+		}
+	}
+};
+
+type HeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
+
+const sizeStyles = (size: HeadlineSize) => {
+	const tinySvg = css`
+		svg {
+			height: 13px;
+			width: 7px;
+		}
+	`;
+	const smallSvg = css`
+		svg {
+			height: 16px;
+			width: 8px;
+		}
+	`;
+	const mediumSvg = css`
+		margin-right: 4px;
+		svg {
+			height: 20px;
+			width: 11px;
+		}
+	`;
+	const largeSvg = css`
+		margin-right: 8px;
+		svg {
+			height: 24px;
+			width: 13px;
+		}
+	`;
+
+	switch (size) {
+		case 'tiny':
+			return css`
+				${tinySvg}
+			`;
+		case 'small':
+			return css`
+				${smallSvg}
+			`;
+		case 'medium':
+			return css`
+				${mediumSvg}
+				${until.desktop} {
+					${smallSvg}
+				}
+			`;
+		case 'large':
+			return css`
+				${largeSvg}
+				${until.desktop} {
+					${mediumSvg}
+				}
+			`;
+	}
+};
+
+type Props = {
+	format: Format;
+	size: HeadlineSize;
+};
+
+export const QuoteIcon = ({ format, size }: Props) => (
+	<span css={sizeStyles(size)}>
+		<svg
+			width="70"
+			height="49"
+			viewBox="0 0 35 25"
+			css={[quoteStyles, quoteColor(format)]}
+			data-testid="quote-icon"
+		>
+			<path d="M69.587.9c-1.842 15.556-3.89 31.316-4.708 48.1H37.043c3.07-16.784 8.391-32.544 17.602-48.1h14.942zM32.949.9c-2.047 15.556-4.094 31.316-4.912 48.1H.2C3.066 32.216 8.592 16.456 17.598.9h15.35z" />
+		</svg>
+	</span>
+);

--- a/src/editorial/web/components/quote-icon/index.tsx
+++ b/src/editorial/web/components/quote-icon/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 
 import { Format, Pillar, Special } from '@guardian/types';
-import { until } from '@guardian/src-foundations/mq';
+import { SvgQuote } from '@guardian/src-icons';
 import {
 	culture,
 	labs,
@@ -12,49 +12,55 @@ import {
 	sport,
 } from '@guardian/src-foundations';
 
-const quoteStyles = css`
-	height: 17px;
-	width: 9px;
-	margin-right: 12px;
-	transform: translateY(-1px);
-	overflow: visible;
-`;
-
 const quoteColor = (format: Format) => {
 	switch (format.theme) {
 		case Pillar.News: {
 			return css`
-				fill: ${news[400]};
+				svg {
+					fill: ${news[400]};
+				}
 			`;
 		}
 		case Pillar.Opinion: {
 			return css`
-				fill: ${opinion[400]};
+				svg {
+					fill: ${opinion[400]};
+				}
 			`;
 		}
 		case Pillar.Culture: {
 			return css`
-				fill: ${culture[400]};
+				svg {
+					fill: ${culture[400]};
+				}
 			`;
 		}
 		case Pillar.Sport: {
 			return css`
-				fill: ${sport[400]};
+				svg {
+					fill: ${sport[400]};
+				}
 			`;
 		}
 		case Pillar.Lifestyle: {
 			return css`
-				fill: ${lifestyle[400]};
+				svg {
+					fill: ${lifestyle[400]};
+				}
 			`;
 		}
 		case Special.SpecialReport: {
 			return css`
-				fill: ${specialReport[400]};
+				svg {
+					fill: ${specialReport[400]};
+				}
 			`;
 		}
 		case Special.Labs: {
 			return css`
-				fill: ${labs[400]};
+				svg {
+					fill: ${labs[400]};
+				}
 			`;
 		}
 	}
@@ -63,54 +69,41 @@ const quoteColor = (format: Format) => {
 type HeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
 
 const sizeStyles = (size: HeadlineSize) => {
-	const tinySvg = css`
-		svg {
-			height: 13px;
-			width: 7px;
-		}
-	`;
-	const smallSvg = css`
-		svg {
-			height: 16px;
-			width: 8px;
-		}
-	`;
-	const mediumSvg = css`
-		margin-right: 4px;
-		svg {
-			height: 20px;
-			width: 11px;
-		}
-	`;
-	const largeSvg = css`
-		margin-right: 8px;
-		svg {
-			height: 24px;
-			width: 13px;
-		}
-	`;
-
 	switch (size) {
 		case 'tiny':
 			return css`
-				${tinySvg}
+				svg {
+					height: 22px;
+					margin-left: -4px;
+					margin-bottom: -6px;
+					margin-top: -2px;
+				}
 			`;
 		case 'small':
 			return css`
-				${smallSvg}
+				svg {
+					height: 26px;
+					margin-left: -4px;
+					margin-bottom: -7px;
+					margin-top: -3px;
+				}
 			`;
 		case 'medium':
 			return css`
-				${mediumSvg}
-				${until.desktop} {
-					${smallSvg}
+				svg {
+					height: 28px;
+					margin-left: -4px;
+					margin-bottom: -8px;
+					margin-top: -4px;
 				}
 			`;
 		case 'large':
 			return css`
-				${largeSvg}
-				${until.desktop} {
-					${mediumSvg}
+				svg {
+					height: 38px;
+					margin-left: -4px;
+					margin-bottom: -10px;
+					margin-top: -6px;
 				}
 			`;
 	}
@@ -122,15 +115,7 @@ type Props = {
 };
 
 export const QuoteIcon = ({ format, size }: Props) => (
-	<span css={sizeStyles(size)}>
-		<svg
-			width="70"
-			height="49"
-			viewBox="0 0 35 25"
-			css={[quoteStyles, quoteColor(format)]}
-			data-testid="quote-icon"
-		>
-			<path d="M69.587.9c-1.842 15.556-3.89 31.316-4.708 48.1H37.043c3.07-16.784 8.391-32.544 17.602-48.1h14.942zM32.949.9c-2.047 15.556-4.094 31.316-4.912 48.1H.2C3.066 32.216 8.592 16.456 17.598.9h15.35z" />
-		</svg>
+	<span css={[sizeStyles(size), quoteColor(format)]}>
+		<SvgQuote />
 	</span>
 );

--- a/src/editorial/web/components/quote-icon/index.tsx
+++ b/src/editorial/web/components/quote-icon/index.tsx
@@ -66,11 +66,11 @@ const quoteColor = (format: Format) => {
 	}
 };
 
-type HeadlineSize = 'tiny' | 'small' | 'medium' | 'large';
+type HeadlineSize = 'xsmall' | 'small' | 'medium' | 'large';
 
 const sizeStyles = (size: HeadlineSize) => {
 	switch (size) {
-		case 'tiny':
+		case 'xsmall':
 			return css`
 				svg {
 					height: 22px;

--- a/src/editorial/web/components/quote-icon/package.json
+++ b/src/editorial/web/components/quote-icon/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "@guardian/editorial",
+  "name": "@guardian/src-ed-quote-icon",
   "version": "3.5.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/guardian/source.git"
+  },
   "license": "Apache-2.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -26,9 +30,10 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
-    "@guardian/types": "^6.0.0"
+    "@guardian/src-helpers": "^3.5.0"
   },
   "devDependencies": {
+    "mini-svg-data-uri": "^1.2.3",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.1.3"
   },

--- a/src/editorial/web/components/quote-icon/stories.tsx
+++ b/src/editorial/web/components/quote-icon/stories.tsx
@@ -57,7 +57,7 @@ export const Primary = () => (
 				}}
 			/>
 			<span>
-				I look life a buffoon. I feel incredible. And then I vomit
+				I look like a buffoon. I feel incredible. And then I vomit
 			</span>
 		</div>
 		<div>

--- a/src/editorial/web/components/quote-icon/stories.tsx
+++ b/src/editorial/web/components/quote-icon/stories.tsx
@@ -46,10 +46,10 @@ const LargeHeadline = ({ children }: { children: React.ReactNode }) => (
 
 export const Primary = () => (
 	<>
-		<h1>Tiny</h1>
+		<h1>XSmall</h1>
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,
@@ -62,7 +62,7 @@ export const Primary = () => (
 		</div>
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,
@@ -75,7 +75,7 @@ export const Primary = () => (
 		</div>
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,
@@ -88,7 +88,7 @@ export const Primary = () => (
 		</div>
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,
@@ -101,7 +101,7 @@ export const Primary = () => (
 		</div>
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,
@@ -114,7 +114,7 @@ export const Primary = () => (
 		</div>
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,
@@ -128,7 +128,7 @@ export const Primary = () => (
 
 		<div>
 			<QuoteIcon
-				size="tiny"
+				size="xsmall"
 				format={{
 					display: Display.Standard,
 					design: Design.Article,

--- a/src/editorial/web/components/quote-icon/stories.tsx
+++ b/src/editorial/web/components/quote-icon/stories.tsx
@@ -1,0 +1,422 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { Design, Display, Pillar, Special } from '@guardian/types';
+import { headline } from '@guardian/src-foundations/typography';
+
+import { QuoteIcon } from './index';
+
+export default {
+	title: 'Editorial/QuoteIcon',
+	component: QuoteIcon,
+};
+
+const SmallHeadline = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			${headline.xxxsmall()};
+			display: inline;
+		`}
+	>
+		{children}
+	</div>
+);
+
+const Headline = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			${headline.xxxsmall()};
+			display: inline;
+		`}
+	>
+		{children}
+	</div>
+);
+
+const LargeHeadline = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			${headline.xsmall()};
+			display: inline;
+		`}
+	>
+		{children}
+	</div>
+);
+
+export const Primary = () => (
+	<>
+		<h1>Tiny</h1>
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.News,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Sport,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Culture,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Lifestyle,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Opinion,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.SpecialReport,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+
+		<div>
+			<QuoteIcon
+				size="tiny"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.Labs,
+				}}
+			/>
+			<span>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</span>
+		</div>
+		<h1>Small</h1>
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.News,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Sport,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Culture,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Lifestyle,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Opinion,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.SpecialReport,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+
+		<div>
+			<QuoteIcon
+				size="small"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.Labs,
+				}}
+			/>
+			<SmallHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</SmallHeadline>
+		</div>
+		<h1>Medium</h1>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.News,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Sport,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Culture,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Lifestyle,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Opinion,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.SpecialReport,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="medium"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.Labs,
+				}}
+			/>
+			<Headline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</Headline>
+		</div>
+
+		<h1>Large</h1>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.News,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Sport,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Culture,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Lifestyle,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Opinion,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.SpecialReport,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+		<div>
+			<QuoteIcon
+				size="large"
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.Labs,
+				}}
+			/>
+			<LargeHeadline>
+				I look life a buffoon. I feel incredible. And then I vomit
+			</LargeHeadline>
+		</div>
+	</>
+);
+Primary.story = { name: 'when primary' };

--- a/src/editorial/web/components/quote-icon/tsconfig.json
+++ b/src/editorial/web/components/quote-icon/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["."],
+  "exclude": ["dist", "stories.tsx"],
+  "references": [
+    {
+      "path": "../../../../core/helpers"
+    }
+  ]
+}

--- a/src/editorial/web/package.json
+++ b/src/editorial/web/package.json
@@ -25,10 +25,9 @@
     "verbump:preminor": "yarn version --preminor --preid rc --no-git-tag-version",
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
-  "dependencies": {
-    "@guardian/types": "^6.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@guardian/types": "^6.0.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,6 +2076,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.5.0.tgz#d8ea25cc396f31bd4baedb8f6d7d3727a9af1fa7"
   integrity sha512-IYXMdqW6vg9mVnAXbbWCm0R9AZfWlAjfJ668TnCx3ypX5/u4AYAXdOfrWWX+uWvFvs3Ulub+E8vEm+eUkxi6rQ==
 
+"@guardian/types@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-6.0.0.tgz#65f4001e390fc8c22f196676742121b89ff28651"
+  integrity sha512-HAYOUfy+Xm1WodByJ7fUH4emSSzVh3YW8euJx1r4TopsG/tIsI94IntOI38s6kwtsClY90gFKG25UiasKJL/Jw==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
## What?
Adds the `QuoteIcon` component as part of the `src-ed-quote-icon` package.

![Screenshot 2021-04-16 at 15 22 43](https://user-images.githubusercontent.com/1336821/115038619-9c20ae00-9ec7-11eb-9d01-20f74c5d4fe2.jpg)


## Why?
The Guardian quote icon is used in many places and is a strong part of our brand identity. We should have one cannonical definition for it.

## You vomit?
It's [about aerial yoga](https://www.theguardian.com/lifeandstyle/2019/nov/12/aerial-yoga-i-look-like-a-buffoon-i-feel-incredible-and-then-i-vomit) 🤷 