### PR TITLE
`src-ed-pulsing-dot`

### DIFF
--- a/src/editorial/web/components/pulsing-dot/README.md
+++ b/src/editorial/web/components/pulsing-dot/README.md
@@ -1,0 +1,39 @@
+# PulsingDot
+
+The Guardian pulsing dot is used in kickers and in front of some text on live blog (Updated n seconds ago...).
+
+## Install
+
+```sh
+$ yarn add @guardian/src-ed-pulsing-dot
+```
+
+or
+
+```sh
+$ npm i @guardian/src-ed-pulsing-dot
+```
+
+## Use
+
+```jsx
+import { PulsingDot } from '@guardian/src-ed-pulsing-dot';
+
+const Kicker = () => (
+    <>
+        <PulsingDot format={format} />
+        <span>
+            Live / European Super League: fan fury at plans for football
+            breakaway
+        </span>
+    </>
+);
+```
+
+## `PulsingDot` Props
+
+### `format`
+
+See **`@guardian/types`**: https://github.com/guardian/types/blob/main/src/format.ts
+
+What we use to decide the editorial colour

--- a/src/editorial/web/components/pulsing-dot/index.tsx
+++ b/src/editorial/web/components/pulsing-dot/index.tsx
@@ -1,0 +1,99 @@
+import { css, keyframes } from '@emotion/react';
+
+import { Format, Pillar, Special } from '@guardian/types';
+import {
+	culture,
+	labs,
+	lifestyle,
+	news,
+	opinion,
+	specialReport,
+	sport,
+} from '@guardian/src-foundations';
+import { storage } from '@guardian/libs';
+
+const dotStyles = css`
+	::before {
+		border-radius: 62.5rem;
+		display: inline-block;
+		position: relative;
+		background-color: currentColor;
+		width: 0.75em;
+		height: 0.75em;
+		content: '';
+		margin-right: 0.1875rem;
+		vertical-align: initial;
+	}
+`;
+
+const dotColor = (format: Format) => {
+	switch (format.theme) {
+		case Pillar.News: {
+			return css`
+				color: ${news[400]};
+			`;
+		}
+		case Pillar.Opinion: {
+			return css`
+				color: ${opinion[400]};
+			`;
+		}
+		case Pillar.Culture: {
+			return css`
+				color: ${culture[400]};
+			`;
+		}
+		case Pillar.Sport: {
+			return css`
+				color: ${sport[400]};
+			`;
+		}
+		case Pillar.Lifestyle: {
+			return css`
+				color: ${lifestyle[400]};
+			`;
+		}
+		case Special.SpecialReport: {
+			return css`
+				color: ${specialReport[400]};
+			`;
+		}
+		case Special.Labs: {
+			return css`
+				color: ${labs[400]};
+			`;
+		}
+	}
+};
+
+const livePulse = keyframes`{
+    0% {opacity: 1;}
+    10% {opacity: .25;}
+    40% {opacity: 1;}
+    100% {opacity: 1;}
+}`;
+
+const animate = css`
+	animation: ${livePulse} 1s infinite;
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+`;
+
+type Props = {
+	format: Format;
+};
+
+export const PulsingDot = ({ format }: Props) => {
+	// Respect the accessibility flag set here
+	// https://www.theguardian.com/help/accessibility-help
+	const flashingPreference = storage.local.get(
+		'gu.prefs.accessibility.flashing-elements',
+	);
+	// flashingPreference is null if no preference exists and explicitly
+	// false when the reader has said they don't want flashing
+	const flashingEnabled = flashingPreference !== false;
+	return (
+		<span css={[dotColor(format), dotStyles, flashingEnabled && animate]} />
+	);
+};

--- a/src/editorial/web/components/pulsing-dot/package.json
+++ b/src/editorial/web/components/pulsing-dot/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@guardian/src-ed-pulsing-dot",
+  "version": "3.5.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/guardian/source.git"
+  },
+  "license": "Apache-2.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/esm",
+    "dist/cjs",
+    "dist/types"
+  ],
+  "scripts": {
+    "build": "npm-run-all clean --parallel build:*",
+    "build:cjs": "tsc --composite false --declaration false --emitDeclarationOnly false --outDir dist/cjs --module commonjs",
+    "build:esm": "tsc --composite false --declaration false --emitDeclarationOnly false --outDir dist/esm --module ES6",
+    "build:types": "tsc -b",
+    "clean": "rm -rf dist",
+    "prepublish": "yarn build",
+    "publish:public": "yarn publish --access public",
+    "verbump:major": "yarn version --major --no-git-tag-version",
+    "verbump:minor": "yarn version --minor --no-git-tag-version",
+    "verbump:patch": "yarn version --patch --no-git-tag-version",
+    "verbump:premajor": "yarn version --premajor --preid rc --no-git-tag-version",
+    "verbump:preminor": "yarn version --preminor --preid rc --no-git-tag-version",
+    "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
+  },
+  "dependencies": {
+    "@guardian/src-helpers": "^3.5.0"
+  },
+  "devDependencies": {
+    "mini-svg-data-uri": "^1.2.3",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^4.1.3"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11.1.2",
+    "@guardian/src-foundations": "^3.5.0",
+    "react": "^17.0.1"
+  }
+}

--- a/src/editorial/web/components/pulsing-dot/stories.tsx
+++ b/src/editorial/web/components/pulsing-dot/stories.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { css } from '@emotion/react';
+
+import { Design, Display, Pillar, Special } from '@guardian/types';
+import { headline } from '@guardian/src-foundations/typography';
+
+import { PulsingDot } from './index';
+
+export default {
+	title: 'Editorial/PulsingDot',
+	component: PulsingDot,
+};
+
+const Kicker = ({ children }: { children: React.ReactNode }) => (
+	<div
+		css={css`
+			${headline.xxxsmall()};
+			display: inline;
+		`}
+	>
+		{children}
+	</div>
+);
+
+export const Dot = () => (
+	<>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.News,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Sport,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Culture,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Lifestyle,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Pillar.Opinion,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.SpecialReport,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+		<div>
+			<PulsingDot
+				format={{
+					display: Display.Standard,
+					design: Design.Article,
+					theme: Special.Labs,
+				}}
+			/>
+			<Kicker>Live</Kicker>
+		</div>
+	</>
+);
+Dot.story = { name: 'with different themes' };

--- a/src/editorial/web/components/pulsing-dot/tsconfig.json
+++ b/src/editorial/web/components/pulsing-dot/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["."],
+  "exclude": ["dist", "stories.tsx"],
+  "references": [
+    {
+      "path": "../../../../core/helpers"
+    }
+  ]
+}


### PR DESCRIPTION
## What?
Adds a `PulsingDot` component.

**This PR is draft while we examine build issues with optinal chaining and nullish coalesing**

## Why?
Although just a dot it's a common dot, one which could be used to prefix live kickers on multiple platformas. Plus this PR includes respect for the accessibility preferences of readers which is easily overlooked and subject to change in future so having this in one location makes us more future proof.