### PR TITLE
Export HeadlineSize type for QuoteIcon

### DIFF
--- a/src/editorial/web/components/quote-icon/index.tsx
+++ b/src/editorial/web/components/quote-icon/index.tsx
@@ -66,7 +66,7 @@ const quoteColor = (format: Format) => {
 	}
 };
 
-type HeadlineSize = 'xsmall' | 'small' | 'medium' | 'large';
+export type HeadlineSize = 'xsmall' | 'small' | 'medium' | 'large';
 
 const sizeStyles = (size: HeadlineSize) => {
 	switch (size) {


### PR DESCRIPTION
## What is the purpose of this change?

export `HeadlineSize` type from QuoteIcon component

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

## What does this change?

export type variable in package
<!--
Give an overview of the changes you have made.
-->

-   Change 1
-   Change 2

## Checklist

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->
