### PR TITLE
Update colours

### DIFF
--- a/src/core/foundations/src/palette/global.ts
+++ b/src/core/foundations/src/palette/global.ts
@@ -87,11 +87,12 @@ export const culture = {
 	100: colors.browns[1],
 	200: colors.browns[2],
 	300: colors.browns[3],
-	400: colors.browns[4],
-	500: colors.browns[5],
-	600: colors.browns[6],
-	700: colors.browns[7],
-	800: colors.browns[8],
+	350: colors.browns[4],
+	400: colors.browns[5],
+	500: colors.browns[6],
+	600: colors.browns[7],
+	700: colors.browns[8],
+	800: colors.browns[9],
 };
 export const lifestyle = {
 	100: colors.pinks[0],

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -82,6 +82,7 @@ const colors = {
 		'#3E3323', //culture-100
 		'#574835', //culture-200
 		'#6B5840', //culture-300
+		'#866D50', //culture-350
 		'#A1845C', //culture-400
 		'#EACCA0', //culture-500
 		'#E7D4B9', //culture-600

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -55,7 +55,7 @@ const colors = {
 	oranges: [
 		'#672005', //opinion-100
 		'#8D2700', //opinion-200
-		'#CB4700', //opinion-300
+		'#C74600', //opinion-300
 		'#E05E00', //opinion-400
 		'#FF7F0F', //opinion-500
 		'#FF9941', //opinion-550

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -66,7 +66,7 @@ const colors = {
 		'#003C60', //sport-100
 		'#004E7C', //sport-200
 		'#005689', //sport-300
-		'#0084C6', //sport-400
+		'#0077B6', //sport-400
 		'#00B2FF', //sport-500
 		'#90DCFF', //sport-600
 		'#F1F8FC', //sport-800


### PR DESCRIPTION
## What is the purpose of this change?

This changes makes updates to two existing colours and adds one additional colour, based on design changes.

## What does this change?

* Change opinion.300 to #C74600 (Update value in `colors.oranges` array)
* Change sport.400 to #0077B6 (Update value in `colors.blues` array)
* Add culture.350 as #866D50 (Add new value in `colors.browns` array and update culture object)

## Potential Issues

As the values are changed in the fundamental `theme.ts` file they have the potential to cause breaking changes, particularly the addition of a new values in the `colors.browns` array. The following searches look for use of the arrays (e.g. `colors.browns`) across guardian projects. These show that the arrays are only used in `src/core/foundations/src/palette/global.ts`.

* [`colors.oranges`](https://github.com/search?q=org%3Aguardian+colors.oranges&type=code)
* [`colors.browns`](https://github.com/search?q=org%3Aguardian+colors.browns&type=code)
* [`colors.blues`](https://github.com/search?q=org%3Aguardian+colors.blues&type=code)

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [ ] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->
