### PR TITLE
Update husky version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.23.1",
     "execa": "^5.0.0",
-    "husky": "^7.0.0",
+    "husky": "^7.0.1",
     "jest": "^26.6.0",
     "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",


### PR DESCRIPTION
## What is the purpose of this change?

Somehow the Husky version has become confused in the yarn.lock. Running `yarn` changes the version from 7.0.1 to 7.0.0

## What does this change?

~Commits the change that is produced by running `yarn`~

Edit: Update to latest version of Husky in the `package.json`

