### PR TITLE
Revert "Create a workflow triggered by Dependabot PRs"

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,14 +1,9 @@
 name: Chromatic
 on:
-  workflow_run:
-    workflows: ['Dependabot PR Check']
-    types:
-      - completed
   push:
     branches-ignore:
       - 'gh-pages'
       - '[0-9]+.[0-9]+'
-      - 'dependabot/**'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,8 +1,0 @@
-name: Dependabot PR Check
-on: push
-jobs:
-  check-dependabot:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - run: echo "PR created by Dependabot"


### PR DESCRIPTION
This PR reverts the changes made in guardian/source#834 which configured a special workflow that was run if the PR author was Dependabot. This in turn triggered chromatic via the `workflow_run` trigger. This technique proved unsuccessful as Chromatic does not currently support the `workflow_run` event. 

Support for this event is planned for [Chromatic's Q3 improvements](https://github.com/chromaui/chromatic-cli/milestone/2) at which point we will re-implement this solution. In the meantime, the chromatic check will fail for dependabot PRs and have to be re-run manually. 