### PR TITLE
Show packages in storybook nav

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -14,6 +14,7 @@ export const parameters = {
 	},
 	options: {
 		storySort: {
+			order: ['Source', 'Editorial'],
 			method: 'alphabetical',
 		},
 	},

--- a/src/core/components/accordion/Accordion.tsx
+++ b/src/core/components/accordion/Accordion.tsx
@@ -19,18 +19,6 @@ export interface AccordionProps extends Props {
  * [Design System](https://theguardian.design/2a1e5182b/p/38c5aa-accordion/b/92b71e) •
  * [GitHub](https://github.com/guardian/source/tree/main/src/core/components/accordion) •
  * [NPM](https://www.npmjs.com/package/@guardian/src-accordion)
- *
- * ### Example
- * ```js
- * import { Accordion, AccordionRow } from '@guardian/src-accordion';
- *
- * const MyAccordion = () => (
- *     <Accordion hideToggleLabel={true}>
- *         <AccordionRow label=""></AccordionRow>
- *         <AccordionRow label=""></AccordionRow>
- *     </Accordion>
- * )
- * ```
  */
 export const Accordion = ({
 	hideToggleLabel = false,

--- a/src/core/components/accordion/AccordionRow.tsx
+++ b/src/core/components/accordion/AccordionRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ReactNode } from 'react';
+import React, { useState, useEffect, HTMLAttributes } from 'react';
 import { Props } from '@guardian/src-helpers';
 import { SvgChevronDownSingle } from '@guardian/src-icons';
 import {
@@ -21,7 +21,9 @@ const visuallyHidden = css`
 	${_visuallyHidden}
 `;
 
-export interface AccordionRowProps extends Props {
+export interface AccordionRowProps
+	extends Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>,
+		Props {
 	/**
 	 * A line of text to summarise the information that lies within the expanded state.
 	 * Appears in the collapsed state, as well as prominently at the top of the expanded state.
@@ -36,7 +38,6 @@ export interface AccordionRowProps extends Props {
 	 * @ignore passed down by the parent <Accordion />
 	 */
 	hideToggleLabel?: boolean;
-	children: ReactNode;
 }
 
 export const AccordionRow = ({

--- a/src/core/components/accordion/index.stories.tsx
+++ b/src/core/components/accordion/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Accordion, AccordionProps, AccordionRow } from './index';
 
 export default {
-	title: 'Accordion',
+	title: 'Source/src-accordion/Accordion',
 	component: Accordion,
 	subcomponents: { AccordionRow },
 };
@@ -27,4 +27,4 @@ Default.args = {
 	hideToggleLabel: false,
 };
 
-Default.story = { name: 'default' };
+Default.story = { name: 'Accordion' };

--- a/src/core/components/accordion/index.stories.tsx
+++ b/src/core/components/accordion/index.stories.tsx
@@ -26,14 +26,14 @@ Demo.args = {
 
 export const WithCTALabels = (args: AccordionProps) => (
 	<Accordion {...args} hideToggleLabel={false}>
-		<AccordionRow label="" />
-		<AccordionRow label="" />
+		<AccordionRow label="Lorem ipsum dolor sit amet" />
+		<AccordionRow label="Consectetur adipiscing elit" />
 	</Accordion>
 );
 
 export const WithoutCTALabels = (args: AccordionProps) => (
 	<Accordion {...args} hideToggleLabel={true}>
-		<AccordionRow label="" />
-		<AccordionRow label="" />
+		<AccordionRow label="Lorem ipsum dolor sit amet" />
+		<AccordionRow label="Consectetur adipiscing elit" />
 	</Accordion>
 );

--- a/src/core/components/accordion/index.stories.tsx
+++ b/src/core/components/accordion/index.stories.tsx
@@ -6,25 +6,34 @@ export default {
 	subcomponents: { AccordionRow },
 };
 
-export const Default = (args: AccordionProps) => (
+export const Demo = (args: AccordionProps) => (
 	<Accordion {...args}>
 		<AccordionRow label="Collecting from multiple newsagents">
 			Present your card to a newsagent each time you collect the paper.
 			The newsagent will scan your card and will be reimbursed for each
 			transaction automatically.
 		</AccordionRow>
-		<AccordionRow
-			label="Delivery from your retailer"
-			hideToggleLabel={false}
-		>
+		<AccordionRow label="Delivery from your retailer">
 			Simply give your preferred store / retailer the barcode printed on
 			your subscription letter.
 		</AccordionRow>
 	</Accordion>
 );
 
-Default.args = {
+Demo.args = {
 	hideToggleLabel: false,
 };
 
-Default.story = { name: 'Accordion' };
+export const WithCTALabels = (args: AccordionProps) => (
+	<Accordion {...args} hideToggleLabel={false}>
+		<AccordionRow label="" />
+		<AccordionRow label="" />
+	</Accordion>
+);
+
+export const WithoutCTALabels = (args: AccordionProps) => (
+	<Accordion {...args} hideToggleLabel={true}>
+		<AccordionRow label="" />
+		<AccordionRow label="" />
+	</Accordion>
+);


### PR DESCRIPTION
## What is the purpose of this change?

- breaks out stories by package in the nav
- provides a `Demo` story for accordion docs
- fills out stories for all possible accordion prop states for chromatic to watch

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

![image](https://user-images.githubusercontent.com/867233/127169832-4f3c55aa-5823-4560-b885-5daaf7708f0b.png)

**After**

![image](https://user-images.githubusercontent.com/867233/127315991-d330d1a2-3d28-4174-adcd-e6034e118490.png)


