### PR TITLE
Fix "how to use" readme text

### DIFF
--- a/src/core/components/accordion/README.md
+++ b/src/core/components/accordion/README.md
@@ -14,4 +14,4 @@ See [storybook](https://guardian.github.io/source/?path=/docs/source-src-accordi
 
 ### How to use
 
-For context and visual guides relating text input usage see the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/38c5aa-accordion).
+For context and visual guides relating to usage see the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/38c5aa-accordion).


### PR DESCRIPTION
## What is the purpose of this change?

This PR fixes some text in the Accordion README in the `How to Use` section.