### PR TITLE
story defaults spruce

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,8 +1,8 @@
 module.exports = {
 	stories: ['../src/**/*.stories.mdx', '../src/**/*stories.@(js|jsx|ts|tsx)'],
 	addons: [
-		'@storybook/addon-links',
-		'@storybook/addon-essentials',
 		'@storybook/addon-a11y',
+		'@storybook/addon-essentials',
+		'@storybook/addon-links',
 	],
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,11 +18,6 @@ export const parameters = {
 			method: 'alphabetical',
 		},
 	},
-	docs: {
-		source: {
-			state: 'open',
-		},
-	},
 };
 
 export const decorators = [FocusManagerDecorator];

--- a/src/lib/story-intents.ts
+++ b/src/lib/story-intents.ts
@@ -5,7 +5,7 @@ import { Story } from '../@types/storybook-emotion-10-fixes';
  * - renders the story in a storybook docs view
  * - does not create a storybook canvas view
  * - enables controls and removes the canvas tab for this story
- * - renames the story in the nav to `Playground 🧶`
+ * - renames the story in the nav to `🧶 Playground`
  *
  * Make sure all props are configurable in storybook's controls table.
  *
@@ -20,7 +20,7 @@ export const asPlayground = (story: Story) => {
 			},
 		},
 	};
-	story.storyName = 'Playground 🧶';
+	story.storyName = '🧶 Playground';
 };
 
 /**


### PR DESCRIPTION
- move accessibility tab to the start (also now open by default)
- close the code preview in docs by default
- move the 🧶 to the start of the playground menu item

![image](https://user-images.githubusercontent.com/867233/129177546-adfe866e-8748-47f8-ab14-97bf2b5a8688.png)
