### PR TITLE
provide default options for `cssOverrides`

### DIFF
--- a/src/core/helpers/types.ts
+++ b/src/core/helpers/types.ts
@@ -5,7 +5,7 @@ export type ThemeName = 'default' | 'brand' | 'brandAlt';
 export interface Props {
 	className?: string;
 	/**
-	 * `SerializedStyles` (or an array of them) are the result of using [emotion's `css` function/prop](https://emotion.sh/docs/introduction).
+	 * Override component styles by passing in the result of [emotion's `css` function/prop](https://emotion.sh/docs/introduction).
 	 */
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 }

--- a/src/lib/story-intents.ts
+++ b/src/lib/story-intents.ts
@@ -19,6 +19,8 @@ export const asPlayground = (story: Story) => {
 				hidden: true,
 			},
 		},
+		// className is part of react API anyway, we don't need to document it
+		controls: { exclude: ['className'] },
 	};
 	story.args = {
 		...story.args,

--- a/src/lib/story-intents.ts
+++ b/src/lib/story-intents.ts
@@ -30,10 +30,10 @@ export const asPlayground = (story: Story) => {
 	story.argTypes = {
 		...story.argTypes,
 		cssOverrides: {
-			options: ['undefined', '{ backgroundColor: "red" }'],
+			options: ['undefined', 'css`background-color: red;`'],
 			mapping: {
 				undefined: undefined,
-				'{ backgroundColor: "red" }': { backgroundColor: 'red' },
+				'css`background-color: red;`': { backgroundColor: 'red' },
 			},
 			control: { type: 'radio' },
 		},

--- a/src/lib/story-intents.ts
+++ b/src/lib/story-intents.ts
@@ -21,6 +21,7 @@ export const asPlayground = (story: Story) => {
 		},
 		// className is part of react API anyway, we don't need to document it
 		controls: { exclude: ['className'] },
+		chromatic: { disable: true },
 	};
 	story.args = {
 		...story.args,
@@ -59,5 +60,6 @@ export const asChromaticStory = (story: Story) => {
 		},
 		docs: { disable: true },
 		controls: { disabled: true },
+		chromatic: { disable: false },
 	};
 };

--- a/src/lib/story-intents.ts
+++ b/src/lib/story-intents.ts
@@ -20,6 +20,21 @@ export const asPlayground = (story: Story) => {
 			},
 		},
 	};
+	story.args = {
+		...story.args,
+		cssOverrides: 'undefined',
+	};
+	story.argTypes = {
+		...story.argTypes,
+		cssOverrides: {
+			options: ['undefined', '{ backgroundColor: "red" }'],
+			mapping: {
+				undefined: undefined,
+				'{ backgroundColor: "red" }': { backgroundColor: 'red' },
+			},
+			control: { type: 'radio' },
+		},
+	};
 	story.storyName = '🧶 Playground';
 };
 


### PR DESCRIPTION
## What is the purpose of this change?

give all `cssOverrides` props in docs view a default set of options (`undefined` or a css object)

I was hoping to fix the default story always being canvas view but it looks like it's being worked on in https://github.com/storybookjs/storybook/issues/13128.

sorting the args table would also be good but [it's coming in 6.4](https://github.com/storybookjs/storybook/commit/3be68b5ed7ddb70154701e783604258efcdb080e#diff-53d1d90b71220b0003266dab7e033c99619f5b22fffdea24d5686f0eb688ce1fR313).