### PR TITLE
Add `ThemeProviderDecorator`

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import { viewport } from './preview/viewport';
 import { backgrounds } from './preview/backgrounds';
 import { FocusManagerDecorator } from './preview/FocusManagerDecorator';
+import { ThemeProviderDecorator } from './preview/ThemeProviderDecorator';
 
 export const parameters = {
 	viewport,
@@ -20,4 +21,4 @@ export const parameters = {
 	},
 };
 
-export const decorators = [FocusManagerDecorator];
+export const decorators = [FocusManagerDecorator, ThemeProviderDecorator];

--- a/.storybook/preview/ThemeProviderDecorator.tsx
+++ b/.storybook/preview/ThemeProviderDecorator.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ThemeProvider } from '@emotion/react';
+
+export const ThemeProviderDecorator = (storyFn, context) => {
+	const theme = context.parameters.theme;
+	return theme ? (
+		<ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>
+	) : (
+		<>{storyFn()}</>
+	);
+};

--- a/docs/10-stories.md
+++ b/docs/10-stories.md
@@ -345,3 +345,16 @@ Story.argTypes = {
     }
 }
 ```
+
+### Theming
+
+A decorator is available to simplify creating stories with different themes. To make use of it, simply pass the required theme in as a parameter.
+
+```tsx
+...
+
+const MyComponentBrandTheme = Template.bind({})
+MyComponentBrandTheme.parameters = {
+    theme: myComponentBrand
+}
+```

--- a/src/core/components/link/ButtonLink.stories.tsx
+++ b/src/core/components/link/ButtonLink.stories.tsx
@@ -1,5 +1,4 @@
 import { SvgExternal } from '@guardian/src-icons';
-import { ThemeProvider } from '@emotion/react';
 import { ButtonLink } from './ButtonLink';
 import { linkDefault } from './index';
 import { ButtonLinkProps } from './ButtonLink';
@@ -38,98 +37,90 @@ asPlayground(Playground);
 
 // *****************************************************************************
 
-export const PrimaryButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimaryButtonLinkLightTheme = Template.bind({});
 PrimaryButtonLinkLightTheme.args = {
 	icon: undefined,
+};
+PrimaryButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(PrimaryButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const SecondaryButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SecondaryButtonLinkLightTheme = Template.bind({});
 SecondaryButtonLinkLightTheme.args = {
 	priority: 'secondary',
 	icon: undefined,
+};
+SecondaryButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(SecondaryButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const PrimarySubduedButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimarySubduedButtonLinkLightTheme = Template.bind({});
 PrimarySubduedButtonLinkLightTheme.args = {
 	subdued: true,
 	icon: undefined,
+};
+PrimarySubduedButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(PrimarySubduedButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const SecondarySubduedButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SecondarySubduedButtonLinkLightTheme = Template.bind({});
 SecondarySubduedButtonLinkLightTheme.args = {
 	priority: 'secondary',
 	subdued: true,
 	icon: undefined,
 };
+SecondarySubduedButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
+};
 asChromaticStory(SecondarySubduedButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const PrimaryIconButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimaryIconButtonLinkLightTheme = Template.bind({});
+PrimaryIconButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
+};
 asChromaticStory(PrimaryIconButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const SecondaryIconButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SecondaryIconButtonLinkLightTheme = Template.bind({});
 SecondaryIconButtonLinkLightTheme.args = {
 	priority: 'secondary',
+};
+SecondaryIconButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(SecondaryIconButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const SubduedIconButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SubduedIconButtonLinkLightTheme = Template.bind({});
 SubduedIconButtonLinkLightTheme.args = {
 	subdued: true,
+};
+SubduedIconButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(SubduedIconButtonLinkLightTheme);
 
 // *****************************************************************************
 
-export const RightIconButtonLinkLightTheme = (args: ButtonLinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const RightIconButtonLinkLightTheme = Template.bind({});
 RightIconButtonLinkLightTheme.args = {
 	iconSide: 'right',
+};
+RightIconButtonLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(RightIconButtonLinkLightTheme);
 

--- a/src/core/components/link/Link.stories.tsx
+++ b/src/core/components/link/Link.stories.tsx
@@ -1,4 +1,3 @@
-import { ThemeProvider } from '@emotion/react';
 import { linkDefault, linkBrandAlt, linkBrand } from './index';
 import { Link, LinkProps } from './Link';
 import { SvgExternal } from '@guardian/src-icons';
@@ -36,23 +35,18 @@ asPlayground(Playground);
 
 // *****************************************************************************
 
-export const PrimaryLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimaryLinkLightTheme = Template.bind({});
 PrimaryLinkLightTheme.args = {
 	icon: undefined,
+};
+PrimaryLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(PrimaryLinkLightTheme);
 
 // *****************************************************************************
 
-export const PrimaryLinkBrandTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimaryLinkBrandTheme = Template.bind({});
 PrimaryLinkBrandTheme.args = {
 	icon: undefined,
 };
@@ -61,16 +55,13 @@ PrimaryLinkBrandTheme.parameters = {
 		default: 'brand',
 		values: [storybookBackgrounds.brand],
 	},
+	theme: linkBrand,
 };
 asChromaticStory(PrimaryLinkBrandTheme);
 
 // *****************************************************************************
 
-export const PrimaryLinkBrandAltTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkBrandAlt}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimaryLinkBrandAltTheme = Template.bind({});
 PrimaryLinkBrandAltTheme.args = {
 	icon: undefined,
 };
@@ -79,90 +70,84 @@ PrimaryLinkBrandAltTheme.parameters = {
 		default: 'brandAlt',
 		values: [storybookBackgrounds.brandAlt],
 	},
+	theme: linkBrandAlt,
 };
 asChromaticStory(PrimaryLinkBrandAltTheme);
 
 // *****************************************************************************
 
-export const SecondaryLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SecondaryLinkLightTheme = Template.bind({});
 SecondaryLinkLightTheme.args = {
 	priority: 'secondary',
 	icon: undefined,
+};
+SecondaryLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(SecondaryLinkLightTheme);
 
 // *****************************************************************************
 
-export const PrimarySubduedLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimarySubduedLinkLightTheme = Template.bind({});
 PrimarySubduedLinkLightTheme.args = {
 	subdued: true,
 	icon: undefined,
+};
+PrimarySubduedLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(PrimarySubduedLinkLightTheme);
 
 // *****************************************************************************
 
-export const SecondarySubduedLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SecondarySubduedLinkLightTheme = Template.bind({});
 SecondarySubduedLinkLightTheme.args = {
 	priority: 'secondary',
 	subdued: true,
 	icon: undefined,
 };
+SecondarySubduedLinkLightTheme.parameters = {
+	theme: linkDefault,
+};
 asChromaticStory(SecondarySubduedLinkLightTheme);
 
 // *****************************************************************************
 
-export const PrimaryIconLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const PrimaryIconLinkLightTheme = Template.bind({});
+PrimaryIconLinkLightTheme.parameters = {
+	theme: linkDefault,
+};
 asChromaticStory(PrimaryIconLinkLightTheme);
 
 // *****************************************************************************
 
-export const SecondaryIconLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SecondaryIconLinkLightTheme = Template.bind({});
 SecondaryIconLinkLightTheme.args = {
 	priority: 'secondary',
+};
+SecondaryIconLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(SecondaryIconLinkLightTheme);
 
 // *****************************************************************************
 
-export const SubduedIconLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SubduedIconLinkLightTheme = Template.bind({});
 SubduedIconLinkLightTheme.args = {
 	subdued: true,
+};
+SubduedIconLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(SubduedIconLinkLightTheme);
 
 // *****************************************************************************
 
-export const RightIconLinkLightTheme = (args: LinkProps) => (
-	<ThemeProvider theme={linkDefault}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const RightIconLinkLightTheme = Template.bind({});
 RightIconLinkLightTheme.args = {
 	iconSide: 'right',
+};
+RightIconLinkLightTheme.parameters = {
+	theme: linkDefault,
 };
 asChromaticStory(RightIconLinkLightTheme);

--- a/src/core/components/radio/Radio.stories.tsx
+++ b/src/core/components/radio/Radio.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Radio } from './Radio';
 import type { RadioProps } from './Radio';
 import { radioBrand } from './index';
-import { ThemeProvider } from '@emotion/react';
 import type { Story } from '../../../@types/storybook-emotion-10-fixes';
 import { asPlayground, asChromaticStory } from '../../../lib/story-intents';
 
@@ -49,15 +48,12 @@ asChromaticStory(DefaultLightTheme);
 
 // *****************************************************************************
 
-export const DefaultBrandTheme = (args: RadioProps) => (
-	<ThemeProvider theme={radioBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const DefaultBrandTheme = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
+	theme: radioBrand,
 };
 asChromaticStory(DefaultBrandTheme);
 
@@ -71,15 +67,12 @@ asChromaticStory(SupportingTextLightTheme);
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme: Story = (args: RadioProps) => (
-	<ThemeProvider theme={radioBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SupportingTextBrandTheme = Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
+	theme: radioBrand,
 };
 SupportingTextBrandTheme.args = {
 	supporting: '#ff0000',
@@ -97,17 +90,12 @@ asChromaticStory(SupportingTextOnlyLightTheme);
 
 // *****************************************************************************
 
-export const SupportingTextOnlyBrandTheme = (args: RadioProps) => (
-	<ThemeProvider theme={radioBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
-SupportingTextOnlyBrandTheme.story = {
-	parameters: {
-		backgrounds: {
-			default: 'brandBackground.primary',
-		},
+export const SupportingTextOnlyBrandTheme = Template.bind({});
+SupportingTextOnlyBrandTheme.parameters = {
+	backgrounds: {
+		default: 'brandBackground.primary',
 	},
+	theme: radioBrand,
 };
 SupportingTextOnlyBrandTheme.args = {
 	supporting: '#ff0000',

--- a/src/core/components/radio/RadioGroup.stories.tsx
+++ b/src/core/components/radio/RadioGroup.stories.tsx
@@ -1,7 +1,6 @@
 import { RadioGroup, RadioGroupProps } from './RadioGroup';
 import { Radio } from './Radio';
 import { radioBrand } from './index';
-import { ThemeProvider } from '@emotion/react';
 import RadioStories from './Radio.stories';
 import type { Story } from '../../../@types/storybook-emotion-10-fixes';
 import { asPlayground, asChromaticStory } from '../../../lib/story-intents';
@@ -60,15 +59,12 @@ asChromaticStory(DefaultLightTheme);
 
 // *****************************************************************************
 
-export const DefaultBrandTheme: Story = (args: RadioGroupProps) => (
-	<ThemeProvider theme={radioBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const DefaultBrandTheme = Template.bind({});
 DefaultBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
+	theme: radioBrand,
 };
 asChromaticStory(DefaultBrandTheme);
 
@@ -98,15 +94,12 @@ asChromaticStory(SupportingTextLightTheme);
 
 // *****************************************************************************
 
-export const SupportingTextBrandTheme: Story = (args: RadioGroupProps) => (
-	<ThemeProvider theme={radioBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const SupportingTextBrandTheme = Template.bind({});
 SupportingTextBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
+	theme: radioBrand,
 };
 SupportingTextBrandTheme.args = {
 	supporting: 'You can always change it later',
@@ -131,11 +124,7 @@ asChromaticStory(ErrorLightTheme);
 
 // *****************************************************************************
 
-export const ErrorBrandTheme: Story = (args: RadioGroupProps) => (
-	<ThemeProvider theme={radioBrand}>
-		<Template {...args} />
-	</ThemeProvider>
-);
+export const ErrorBrandTheme = Template.bind({});
 ErrorBrandTheme.args = {
 	error: 'Please select a colour',
 };
@@ -143,6 +132,7 @@ ErrorBrandTheme.parameters = {
 	backgrounds: {
 		default: 'brandBackground.primary',
 	},
+	theme: radioBrand,
 };
 asChromaticStory(ErrorBrandTheme);
 


### PR DESCRIPTION
## What is the purpose of this change?

This change adds a global decorator which wraps the story in a `ThemeProvider` when a `theme` parameter is present. This means that themed stories can use `Template.bind({})` like any other story and pass the theme in as a parameter, saving on LOC.

## What does this change?

-   Add a new `ThemeProviderDecorator` and include in `.storybook/preview.tsx`
-   Refactor themed stories in `Radio.stories.tsx` to pass the theme in as a parameter

## TODO

- [x] Add some documentation
- [x] Apply to all stories