### PR TITLE
Update exclude value in component tsconfigs

### DIFF
--- a/src/core/components/accordion/tsconfig.json
+++ b/src/core/components/accordion/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "index.stories.tsx", "stories/**/*"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../foundations"

--- a/src/core/components/button/tsconfig.json
+++ b/src/core/components/button/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../foundations"

--- a/src/core/components/checkbox/tsconfig.json
+++ b/src/core/components/checkbox/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "*.stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../foundations"

--- a/src/core/components/choice-card/tsconfig.json
+++ b/src/core/components/choice-card/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../foundations"

--- a/src/core/components/footer/tsconfig.json
+++ b/src/core/components/footer/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "Footer.stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../foundations"

--- a/src/core/components/label/tsconfig.json
+++ b/src/core/components/label/tsconfig.json
@@ -7,7 +7,7 @@
     "composite": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "*.stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../helpers"

--- a/src/core/components/layout/tsconfig.json
+++ b/src/core/components/layout/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "*.stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../helpers"

--- a/src/core/components/radio/tsconfig.json
+++ b/src/core/components/radio/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "*.stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../helpers"

--- a/src/core/components/select/tsconfig.json
+++ b/src/core/components/select/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../icons"

--- a/src/core/components/text-area/tsconfig.json
+++ b/src/core/components/text-area/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../icons"

--- a/src/core/components/text-input/tsconfig.json
+++ b/src/core/components/text-input/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
-  "exclude": ["dist", "stories", "stories.tsx"],
+  "exclude": ["dist", "*.stories.tsx"],
   "references": [
     {
       "path": "../../helpers"


### PR DESCRIPTION
## What is the purpose of this change?

This change updates the `tsconfig.json` files for all components to be correct now that all stories have been updated to the latest recommendations. For all components the value related to stories is set to `*.stories.tsx`, following the agreed pattern for storybook file names.

I have taken the approach of using `*.stories.tsx` everywhere for consistency and also so that it will work for any future components added, rather than requiring a change for any new components.

## What does this change?

-   Updates all the component `tsconfig.json` files to have `exclude: ["dist", "*.stories.tsx"]`
