### PR TITLE
Exclude layout stories at all depths

### DIFF
--- a/src/core/components/layout/tsconfig.json
+++ b/src/core/components/layout/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "dist/types",
     "declaration": true,
     "emitDeclarationOnly": true,
-	"composite": true
+    "composite": true
   },
   "include": [".", "../../foundations/types/themes.d.ts"],
   "exclude": ["dist", "**/*.stories.tsx"],


### PR DESCRIPTION
## What is the purpose of this change?

Layout stories are located not at the root of the directory, but at one layer deeper, in component-specific folders. This leads to problems with the build, meaning layout modules don't get published.

## What does this change?

-   Exclude stories at all depths from the build

