### PR TITLE
Update all component README to make consistent

### DIFF
--- a/src/core/components/button/README.md
+++ b/src/core/components/button/README.md
@@ -10,114 +10,13 @@ $ yarn add @guardian/src-button
 
 ## Use
 
-```js
-import { LinkButton, Button } from '@guardian/src-button';
-import { SvgCheckmark, SvgArrowRightStraight } from '@guardian/src-icons';
+### API
 
-const Form = () => (
-    <form>
-        <LinkButton
-            priority="primary"
-            size="default"
-            icon={<SvgArrowRightStraight />}
-            iconSide="left"
-            nudgeIcon={true}
-            href="/read-more"
-        >
-            Read more
-        </LinkButton>
-        <Button
-            priority="primary"
-            size="default"
-            icon={<SvgCheckmark />}
-            iconSide="left"
-            onClick={() => {
-                alert('Thanks for clicking');
-            }}
-        >
-            Click me
-        </Button>
-    </form>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-button-button--playground).
 
-## `LinkButton` Props
+### How to use
 
-### `priority`
-
-**`"primary" | "secondary" | "tertiary" | "subdued"`** _= "primary"_
-
-Informs users of how important an action is
-
-### `size`
-
-**`"default" | "small" | "xsmall"`** _= "default"_
-
-Reflects the prominance of the action
-
-### `icon`
-
-**`JSX.Element`**
-
-An icon that appears inside the button, alongside text
-
-### `iconSide`
-
-**`"left" | "right"`** _= "left"_
-
-The side of the button on which the icon appears
-
-### `nudgeIcon`
-
-**`boolean`** _= "false"_
-
-When set, the icon (if visible) will move slightly to the right on hover.
-
-### `hideLabel`
-
-**`boolean`** _= "false"_
-
-Whether to hide the text label visually. It is only appropriate to set this flag
-if an `icon` is passed. The text label will still be read out by screen readers.
-
-## `Button` Props
-
-### `priority`
-
-**`"primary" | "secondary" | "tertiary" | "subdued"`** _= "primary"_
-
-Informs users of how important an action is
-
-### `size`
-
-**`"default" | "small" | "xsmall"`** _= "default"_
-
-Reflects the prominance of the action
-
-### `icon`
-
-**`JSX.Element`**
-
-An icon that appears inside the button, alongside text
-
-### `iconSide`
-
-**`"left" | "right"`** _= "left"_
-
-The side of the button on which the icon appears
-
-### `nudgeIcon`
-
-**`boolean`** _= "false"_
-
-When set, the icon (if visible) will move slightly to the right on hover.
-
-### `hideLabel`
-
-**`boolean`** _= "false"_
-
-Whether to hide the text label visually. It is only appropriate to set this flag
-if an `icon` is passed. The text label will still be read out by screen readers.
+For context and visual guides relating to button usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/435225-button).
 
 ## Supported themes
 

--- a/src/core/components/footer/Footer.tsx
+++ b/src/core/components/footer/Footer.tsx
@@ -19,7 +19,7 @@ export interface FooterProps extends HTMLAttributes<HTMLElement>, Props {
 }
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/source-src-footer-footer--demo) •
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-src-footer-footer--playground) •
  * [Design System](https://theguardian.design/2a1e5182b/p/12ce79--footer/b/09ee0e) •
  * [GitHub](https://github.com/guardian/source/tree/main/src/core/components/footer) •
  * [NPM](https://www.npmjs.com/package/@guardian/src-footer)

--- a/src/core/components/footer/README.md
+++ b/src/core/components/footer/README.md
@@ -10,19 +10,13 @@ $ yarn add @guardian/src-footer
 
 ## Use
 
-```js
-import { Footer } from '@guardian/src-footer';
+### API
 
-const Wrapper = () => <Footer showBackToTop={true} />;
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-footer-footer--playground).
 
-## `Footer` Props
+### How to use
 
-### `showBackToTop`
-
-**`boolean`** _= false_
-
-Whether the "Back to top" link is visible in the footer
+For context and visual guides relating to button usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/12ce79--footer/b/09ee0e).
 
 ## Supported themes
 

--- a/src/core/components/footer/README.md
+++ b/src/core/components/footer/README.md
@@ -16,7 +16,7 @@ See [storybook](https://guardian.github.io/source/?path=/docs/source-src-footer-
 
 ### How to use
 
-For context and visual guides relating to button usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/12ce79--footer/b/09ee0e).
+For context and visual guides relating to footer usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/12ce79--footer/b/09ee0e).
 
 ## Supported themes
 

--- a/src/core/components/label/README.md
+++ b/src/core/components/label/README.md
@@ -16,7 +16,7 @@ See [storybook](https://guardian.github.io/source/?path=/docs/source-src-label-l
 
 ### How to use
 
-For context and visual guides relating to button usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/40151e-label/b/86af7d).
+For context and visual guides relating to label usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/40151e-label/b/86af7d).
 
 ## Supported themes
 

--- a/src/core/components/label/README.md
+++ b/src/core/components/label/README.md
@@ -10,57 +10,13 @@ $ yarn add @guardian/src-label
 
 ## Use
 
-```tsx
-import { Label, Legend } from '@guardian/src-label';
+### API
 
-const Form = () => (
-    <form>
-        <Label text="Email" supporting="alex@example.com">
-            <input type="email" />
-        </Label>
-    </form>
-);
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-label-label-).
 
-const Fieldset = () => (
-    <fieldset>
-        <Legend
-            text="Subscribe to our newsletters"
-            supporting="Select as many as you like"
-            optional={true}
-        />
-        <label>
-            <input type="checkbox" />
-            Guardian Today: UK
-        </label>
-    </fieldset>
-);
-```
+### How to use
 
-## Label and Legend Props
-
-### `text`
-
-**`string`**
-
-The label text
-
-### `supporting`
-
-**`string | JSX.Element`**
-
-Additional text or component that appears below the label.
-
-### `optional`
-
-**`boolean`** _= "false"_
-
-Adds the word "Optional" after the label.
-
-### `hideLabel`
-
-**`boolean`** _= "false"_
-
-Visually hides the label.
+For context and visual guides relating to button usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/40151e-label/b/86af7d).
 
 ## Supported themes
 

--- a/src/core/components/layout/README.md
+++ b/src/core/components/layout/README.md
@@ -12,47 +12,25 @@ $ yarn add @guardian/src-layout
 
 Centres the page content and applies a width that corresponds to the grid at the current breakpoint.
 
-```tsx
-import { Container } from '@guardian/src-layout';
+### API
 
-const Wrapper = () => (
-    <Container>
-        <div css={contents}>Contents</div>
-    </Container>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-layout-container).
 
-### Props
+### How to use
 
-#### `border`
-
-**`boolean`** _= false_
-
-Whether to show a border to the left and right of the Container
+For context and visual guides relating to Container usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/440a83-container).
 
 ## Stack
 
 Children will be stacked one on top of the other.
 
-```tsx
-import { Stack } from '@guardian/src-layout';
+### API
 
-const Wrapper = () => (
-    <Stack>
-        <div css={contents}>Item 1</div>
-        <div css={contents}>Item 2</div>
-        <div css={contents}>Item 3</div>
-    </Stack>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-layout-stack).
 
-### Props
+### How to use
 
-#### `space`
-
-**`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
-
-Units of space between stack items (one unit is 4px)
+For context and visual guides relating to Stack usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/827581-stack).
 
 ## Columns
 
@@ -60,138 +38,42 @@ Columns will be arranged side by side on a single row, with the specified width.
 
 Use Columns in conjunction with Container to help the columns align neatly with [the Guardian's grids](https://www.theguardian.design/2a1e5182b/p/41be19-grids).
 
-```tsx
-import { Container, Columns, Column } from '@guardian/src-layout';
+### API
 
-const Wrapper = () => (
-    <Container>
-        <Columns collapseBelow={tablet}>
-            <Column width={1 / 4}>1/4</Column>
-            <Column width={1 / 4}>1/4</Column>
-            <Column>*</Column>
-        </Columns>
-    </Container>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-layout-columns).
 
-### Columns Props
+### How to use
 
-#### `collapseBelow`
-
-**`Breakpoint`**
-
-Columns will be stacked one on top of the other at viewport widths lower than the specified breakpoint
-
-#### `spaceY`
-
-**`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
-
-Units of space between columns vertically when collapsed (one unit is 4px)
-
-### Column Props
-
-#### `width`
-
-**`number | number[]`**
-
-Fraction of the parent container's width that the column will occupy.
-
-Pass 0 to hide the column completely.
-
-Pass an array of fractions to set the width that the column occupies at different breakpoints. The first value in the array will
-reflect the width at mobile, the second value at tablet, then desktop, leftCol and wide.
-
-If neither `width` nor `span` is passed, the column width will be fluid (i.e. take up remaining space, divided between all fluid columns).
-
-If both `width` and `span` are passed, `width` takes priority.
-
-#### `span`
-
-**`number | number[]`**
-
-Number of [grid columns](https://theguardian.design/2a1e5182b/p/41be19-grids) that the column will occupy.
-
-Pass 0 to hide the column completely.
-
-Pass an array of numbers to set the number of grid columns the column component occupies at different breakpoints. The first value in the array will reflect the width at mobile, the second value at tablet, then desktop, leftCol and wide.
-
-If neither `width` nor `span` is passed, the column width will be fluid (i.e. take up remaining space, divided between all fluid columns).
-
-If both `width` and `span` are passed, `width` takes priority.
+For context and visual guides relating to Columns usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/41cd49-columns).
 
 ## Hide
 
 Hide a component above or below a certain breakpoint
 
-```tsx
-import { Hide } from '@guardian/src-layout';
+### API
 
-const Wrapper = () => (
-    <>
-        <Hide above="tablet">
-            <MobileNavigation />
-        </Hide>
-        <Hide below="desktop">
-            <DesktopNavigation />
-        </Hide>
-    </>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-layout-hide).
 
-### Props
+### How to use
 
-#### `above`
-
-**`Breakpoint`**
-
-Contents will be hidden at viewport widths greater than the specified breakpoint
-
-#### `below`
-
-**`Breakpoint`**
-
-Contents will be hidden at viewport widths less than the specified breakpoint
+For context and visual guides relating to Hide usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/78cb73-hide).
 
 ## Inline
 
-```tsx
-import { Inline } from '@guardian/src-layout';
+### API
 
-const Wrapper = () => (
-    <Inline>
-        <div css={contents}>Item 1</div>
-        <div css={contents}>Item 2</div>
-        <div css={contents}>Item 3</div>
-    </Inline>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-layout-inline).
 
-### Props
+### How to use
 
-#### `space`
-
-**`1 | 2 | 3 | 4 | 5 | 6 | 9 | 12 | 24`**
-
-Units of space between inline items (one unit is 4px)
+For context and visual guides relating to Inline usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/99f3c1-inline).
 
 ## Tiles
 
-```tsx
-import { Tiles } from '@guardian/src-layout';
+### API
 
-const Wrapper = () => (
-    <Tiles columns={3}>
-        <div css={contents}>Item 1</div>
-        <div css={contents}>Item 2</div>
-        <div css={contents}>Item 3</div>
-    </Tiles>
-);
-```
+See [storybook](https://guardian.github.io/source/?path=/docs/source-src-layout-tiles).
 
-### Props
+### How to use
 
-#### `collapseBelow`
-
-**`Breakpoint`**
-
-Tiles will be stacked one on top of the other at viewport widths lower than the specified breakpoint.
+For context and visual guides relating to Tiles usage see the [Source Design System website](https://theguardian.design/2a1e5182b/p/00e9f5-tiles).


### PR DESCRIPTION
## What is the purpose of this change?

This PR updates a number of README.md files that were missed during the migration of docs from ZeroHeight to Storybook. It removes some documentation from the files and replaces it with links to storybook and [theguardian.design](https://theguardian.design).