### PR TITLE
migrate from @guardian/types to @guardian/libs

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,8 +1,17 @@
 const path = require('path');
+
+const nodeModulesExclude = [
+	{
+		test: /node_modules/,
+		exclude: [/@guardian\//],
+	},
+];
+
 module.exports = ({ config, mode }) => {
 	//Get TypeScript working via babel preset
 	config.module.rules.push({
 		test: /\.(ts|tsx)$/,
+		exclude: nodeModulesExclude,
 		loader: require.resolve('babel-loader'),
 		options: {
 			presets: [
@@ -13,6 +22,12 @@ module.exports = ({ config, mode }) => {
 			plugins: ['@babel/plugin-proposal-class-properties'],
 		},
 	});
+
+	// update storybook webpack config to transpile *all* JS
+	config.module.rules.find(
+		(rule) => String(rule.test) === String(/\.(mjs|tsx?|jsx?)$/),
+	).exclude = nodeModulesExclude;
+
 	config.resolve.extensions.push('.ts', '.tsx');
 	config.resolve.alias = {
 		'@guardian/src-foundations': path.resolve(

--- a/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/EditorialButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/EditorialButton.stories.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { Design, Display, Pillar, Special } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { EditorialButton, EditorialButtonProps } from './index';
 import { SvgCross } from '@guardian/src-icons';
 import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
@@ -9,8 +14,8 @@ import {
 } from '../../../../../lib/story-intents';
 
 const defaultFormat = {
-	display: Display.Standard,
-	design: Design.Article,
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
 };
 
 export default {
@@ -28,16 +33,16 @@ export default {
 				'labs',
 			],
 			mapping: {
-				news: { ...defaultFormat, theme: Pillar.News },
-				sport: { ...defaultFormat, theme: Pillar.Sport },
-				culture: { ...defaultFormat, theme: Pillar.Culture },
-				lifestyle: { ...defaultFormat, theme: Pillar.Lifestyle },
-				opinion: { ...defaultFormat, theme: Pillar.Opinion },
+				news: { ...defaultFormat, theme: ArticlePillar.News },
+				sport: { ...defaultFormat, theme: ArticlePillar.Sport },
+				culture: { ...defaultFormat, theme: ArticlePillar.Culture },
+				lifestyle: { ...defaultFormat, theme: ArticlePillar.Lifestyle },
+				opinion: { ...defaultFormat, theme: ArticlePillar.Opinion },
 				special_report: {
 					...defaultFormat,
-					theme: Special.SpecialReport,
+					theme: ArticleSpecial.SpecialReport,
 				},
-				labs: { ...defaultFormat, theme: Special.Labs },
+				labs: { ...defaultFormat, theme: ArticleSpecial.Labs },
 			},
 			control: { type: 'radio' },
 		},
@@ -80,13 +85,13 @@ Playground.args = {
 asPlayground(Playground);
 
 const pillars = [
-	Pillar.News,
-	Pillar.Sport,
-	Pillar.Culture,
-	Pillar.Lifestyle,
-	Pillar.Opinion,
-	Special.SpecialReport,
-	Special.Labs,
+	ArticlePillar.News,
+	ArticlePillar.Sport,
+	ArticlePillar.Culture,
+	ArticlePillar.Lifestyle,
+	ArticlePillar.Opinion,
+	ArticleSpecial.SpecialReport,
+	ArticleSpecial.Labs,
 ];
 
 const RowTemplate: Story<EditorialButtonProps> = (

--- a/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/EditorialLinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/EditorialLinkButton.stories.tsx
@@ -1,5 +1,10 @@
 import { css } from '@emotion/react';
-import { Design, Display, Pillar, Special } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { EditorialLinkButton, EditorialLinkButtonProps } from './index';
 import { SvgCross } from '@guardian/src-icons';
 import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
@@ -9,8 +14,8 @@ import {
 } from '../../../../../lib/story-intents';
 
 const defaultFormat = {
-	display: Display.Standard,
-	design: Design.Article,
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
 };
 
 export default {
@@ -28,16 +33,16 @@ export default {
 				'labs',
 			],
 			mapping: {
-				news: { ...defaultFormat, theme: Pillar.News },
-				sport: { ...defaultFormat, theme: Pillar.Sport },
-				culture: { ...defaultFormat, theme: Pillar.Culture },
-				lifestyle: { ...defaultFormat, theme: Pillar.Lifestyle },
-				opinion: { ...defaultFormat, theme: Pillar.Opinion },
+				news: { ...defaultFormat, theme: ArticlePillar.News },
+				sport: { ...defaultFormat, theme: ArticlePillar.Sport },
+				culture: { ...defaultFormat, theme: ArticlePillar.Culture },
+				lifestyle: { ...defaultFormat, theme: ArticlePillar.Lifestyle },
+				opinion: { ...defaultFormat, theme: ArticlePillar.Opinion },
 				special_report: {
 					...defaultFormat,
-					theme: Special.SpecialReport,
+					theme: ArticleSpecial.SpecialReport,
 				},
-				labs: { ...defaultFormat, theme: Special.Labs },
+				labs: { ...defaultFormat, theme: ArticleSpecial.Labs },
 			},
 			control: { type: 'radio' },
 		},
@@ -82,13 +87,13 @@ asPlayground(Playground);
 // *****************************************************************************
 
 const pillars = [
-	Pillar.News,
-	Pillar.Sport,
-	Pillar.Culture,
-	Pillar.Lifestyle,
-	Pillar.Opinion,
-	Special.SpecialReport,
-	Special.Labs,
+	ArticlePillar.News,
+	ArticlePillar.Sport,
+	ArticlePillar.Culture,
+	ArticlePillar.Lifestyle,
+	ArticlePillar.Opinion,
+	ArticleSpecial.SpecialReport,
+	ArticleSpecial.Labs,
 ];
 
 const RowTemplate: Story<EditorialLinkButtonProps> = (

--- a/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/styles.ts
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react';
 
-import { Design, Display, Format, Pillar, Special } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticleFormat,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { ButtonPriority } from '@guardian/src-button';
 import {
 	culture,
@@ -14,19 +20,22 @@ import {
 } from '@guardian/src-foundations';
 
 export const defaultFormat = {
-	display: Display.Standard,
-	design: Design.Article,
-	theme: Pillar.News,
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
+	theme: ArticlePillar.News,
 };
 
 const WHITE = neutral[100];
 
-export const decideBackground = (format: Format, priority: ButtonPriority) => {
+export const decideBackground = (
+	format: ArticleFormat,
+	priority: ButtonPriority,
+) => {
 	switch (priority) {
 		case 'primary':
 		case 'secondary':
 			switch (format.theme) {
-				case Pillar.News:
+				case ArticlePillar.News:
 					return css`
 						background-color: ${news[300]};
 						:hover {
@@ -34,7 +43,7 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 							border: 1px solid ${news[400]};
 						}
 					`;
-				case Pillar.Culture:
+				case ArticlePillar.Culture:
 					return css`
 						background-color: ${culture[300]};
 						:hover {
@@ -42,7 +51,7 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 							border: 1px solid ${culture[400]};
 						}
 					`;
-				case Pillar.Lifestyle:
+				case ArticlePillar.Lifestyle:
 					return css`
 						background-color: ${lifestyle[300]};
 						:hover {
@@ -50,7 +59,7 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 							border: 1px solid ${lifestyle[400]};
 						}
 					`;
-				case Pillar.Sport:
+				case ArticlePillar.Sport:
 					return css`
 						background-color: ${sport[300]};
 						:hover {
@@ -58,7 +67,7 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 							border: 1px solid ${sport[400]};
 						}
 					`;
-				case Pillar.Opinion:
+				case ArticlePillar.Opinion:
 					return css`
 						background-color: ${opinion[300]};
 						:hover {
@@ -66,7 +75,7 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 							border: 1px solid ${opinion[400]};
 						}
 					`;
-				case Special.Labs:
+				case ArticleSpecial.Labs:
 					return css`
 						background-color: ${labs[300]};
 						:hover {
@@ -74,7 +83,7 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 							border: 1px solid ${labs[400]};
 						}
 					`;
-				case Special.SpecialReport:
+				case ArticleSpecial.SpecialReport:
 					return css`
 						background-color: ${specialReport[300]};
 						:hover {
@@ -91,7 +100,10 @@ export const decideBackground = (format: Format, priority: ButtonPriority) => {
 	}
 };
 
-export const decideBorder = (format: Format, priority: ButtonPriority) => {
+export const decideBorder = (
+	format: ArticleFormat,
+	priority: ButtonPriority,
+) => {
 	switch (priority) {
 		case 'primary':
 		case 'secondary':
@@ -106,7 +118,7 @@ export const decideBorder = (format: Format, priority: ButtonPriority) => {
 	}
 };
 
-export const decideFont = (format: Format, priority: ButtonPriority) => {
+export const decideFont = (format: ArticleFormat, priority: ButtonPriority) => {
 	switch (priority) {
 		case 'primary':
 		case 'secondary':
@@ -116,31 +128,31 @@ export const decideFont = (format: Format, priority: ButtonPriority) => {
 		case 'subdued':
 		case 'tertiary':
 			switch (format.theme) {
-				case Pillar.News:
+				case ArticlePillar.News:
 					return css`
 						color: ${news[400]};
 					`;
-				case Pillar.Culture:
+				case ArticlePillar.Culture:
 					return css`
 						color: ${culture[400]};
 					`;
-				case Pillar.Lifestyle:
+				case ArticlePillar.Lifestyle:
 					return css`
 						color: ${lifestyle[400]};
 					`;
-				case Pillar.Sport:
+				case ArticlePillar.Sport:
 					return css`
 						color: ${sport[400]};
 					`;
-				case Pillar.Opinion:
+				case ArticlePillar.Opinion:
 					return css`
 						color: ${opinion[400]};
 					`;
-				case Special.Labs:
+				case ArticleSpecial.Labs:
 					return css`
 						color: ${labs[400]};
 					`;
-				case Special.SpecialReport:
+				case ArticleSpecial.SpecialReport:
 					return css`
 						color: ${specialReport[400]};
 					`;

--- a/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/types.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/components/editorial-button/types.ts
@@ -1,4 +1,4 @@
-import { Format } from '@guardian/types';
+import { ArticleFormat } from '@guardian/libs';
 
 export interface SharedEditorialButtonProps {
 	/**
@@ -15,5 +15,5 @@ export interface SharedEditorialButtonProps {
 	 * }
 	 * ```
 	 */
-	format?: Format;
+	format?: ArticleFormat;
 }

--- a/packages/@guardian/source-react-components-development-kitchen/components/quote-icon/QuoteIcon.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/quote-icon/QuoteIcon.stories.tsx
@@ -1,4 +1,9 @@
-import { Design, Display, Pillar, Special } from '@guardian/types';
+import {
+	ArticleDesign,
+	ArticleDisplay,
+	ArticlePillar,
+	ArticleSpecial,
+} from '@guardian/libs';
 import { QuoteIcon, QuoteIconProps } from './QuoteIcon';
 import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
 import {
@@ -7,8 +12,8 @@ import {
 } from '../../../../../lib/story-intents';
 
 const defaultFormat = {
-	display: Display.Standard,
-	design: Design.Article,
+	display: ArticleDisplay.Standard,
+	design: ArticleDesign.Standard,
 };
 
 export default {
@@ -26,16 +31,16 @@ export default {
 				'labs',
 			],
 			mapping: {
-				news: { ...defaultFormat, theme: Pillar.News },
-				sport: { ...defaultFormat, theme: Pillar.Sport },
-				culture: { ...defaultFormat, theme: Pillar.Culture },
-				lifestyle: { ...defaultFormat, theme: Pillar.Lifestyle },
-				opinion: { ...defaultFormat, theme: Pillar.Opinion },
+				news: { ...defaultFormat, theme: ArticlePillar.News },
+				sport: { ...defaultFormat, theme: ArticlePillar.Sport },
+				culture: { ...defaultFormat, theme: ArticlePillar.Culture },
+				lifestyle: { ...defaultFormat, theme: ArticlePillar.Lifestyle },
+				opinion: { ...defaultFormat, theme: ArticlePillar.Opinion },
 				special_report: {
 					...defaultFormat,
-					theme: Special.SpecialReport,
+					theme: ArticleSpecial.SpecialReport,
 				},
-				labs: { ...defaultFormat, theme: Special.Labs },
+				labs: { ...defaultFormat, theme: ArticleSpecial.Labs },
 			},
 			control: { type: 'radio' },
 		},
@@ -54,7 +59,11 @@ const Template: Story<QuoteIconProps> = (args: QuoteIconProps) => (
 export const Playground = Template.bind({});
 Playground.args = {
 	size: 'xsmall',
-	format: 'news',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
 };
 asPlayground(Playground);
 
@@ -63,7 +72,11 @@ asPlayground(Playground);
 export const News = Template.bind({});
 News.args = {
 	size: 'medium',
-	format: 'news',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
 };
 asChromaticStory(News);
 
@@ -72,7 +85,11 @@ asChromaticStory(News);
 export const Sport = Template.bind({});
 Sport.args = {
 	size: 'medium',
-	format: 'sport',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Sport,
+	},
 };
 asChromaticStory(Sport);
 
@@ -81,7 +98,11 @@ asChromaticStory(Sport);
 export const Culture = Template.bind({});
 Culture.args = {
 	size: 'medium',
-	format: 'culture',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Culture,
+	},
 };
 asChromaticStory(Culture);
 
@@ -90,7 +111,11 @@ asChromaticStory(Culture);
 export const Lifestyle = Template.bind({});
 Lifestyle.args = {
 	size: 'medium',
-	format: 'lifestyle',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Lifestyle,
+	},
 };
 asChromaticStory(Lifestyle);
 
@@ -99,7 +124,11 @@ asChromaticStory(Lifestyle);
 export const Opinion = Template.bind({});
 Opinion.args = {
 	size: 'medium',
-	format: 'opinion',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.Opinion,
+	},
 };
 asChromaticStory(Opinion);
 
@@ -108,7 +137,11 @@ asChromaticStory(Opinion);
 export const SpecialReport = Template.bind({});
 SpecialReport.args = {
 	size: 'medium',
-	format: 'special_report',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.SpecialReport,
+	},
 };
 asChromaticStory(SpecialReport);
 
@@ -117,7 +150,11 @@ asChromaticStory(SpecialReport);
 export const Labs = Template.bind({});
 Labs.args = {
 	size: 'medium',
-	format: 'labs',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticleSpecial.Labs,
+	},
 };
 asChromaticStory(Labs);
 
@@ -126,7 +163,11 @@ asChromaticStory(Labs);
 export const XSmall = Template.bind({});
 XSmall.args = {
 	size: 'xsmall',
-	format: 'news',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
 };
 asChromaticStory(XSmall);
 
@@ -135,7 +176,11 @@ asChromaticStory(XSmall);
 export const Small = Template.bind({});
 Small.args = {
 	size: 'small',
-	format: 'news',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
 };
 asChromaticStory(Small);
 
@@ -144,7 +189,11 @@ asChromaticStory(Small);
 export const Medium = Template.bind({});
 Medium.args = {
 	size: 'medium',
-	format: 'news',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
 };
 asChromaticStory(Medium);
 
@@ -153,6 +202,10 @@ asChromaticStory(Medium);
 export const Large = Template.bind({});
 Large.args = {
 	size: 'large',
-	format: 'news',
+	format: {
+		display: ArticleDisplay.Standard,
+		design: ArticleDesign.Standard,
+		theme: ArticlePillar.News,
+	},
 };
 asChromaticStory(Large);

--- a/packages/@guardian/source-react-components-development-kitchen/components/quote-icon/QuoteIcon.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/quote-icon/QuoteIcon.stories.tsx
@@ -59,11 +59,7 @@ const Template: Story<QuoteIconProps> = (args: QuoteIconProps) => (
 export const Playground = Template.bind({});
 Playground.args = {
 	size: 'xsmall',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: 'news',
 };
 asPlayground(Playground);
 
@@ -72,11 +68,7 @@ asPlayground(Playground);
 export const News = Template.bind({});
 News.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: 'news',
 };
 asChromaticStory(News);
 
@@ -85,11 +77,7 @@ asChromaticStory(News);
 export const Sport = Template.bind({});
 Sport.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Sport,
-	},
+	format: 'sport',
 };
 asChromaticStory(Sport);
 
@@ -98,11 +86,7 @@ asChromaticStory(Sport);
 export const Culture = Template.bind({});
 Culture.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Culture,
-	},
+	format: 'culture',
 };
 asChromaticStory(Culture);
 
@@ -111,11 +95,7 @@ asChromaticStory(Culture);
 export const Lifestyle = Template.bind({});
 Lifestyle.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Lifestyle,
-	},
+	format: 'lifestyle',
 };
 asChromaticStory(Lifestyle);
 
@@ -124,11 +104,7 @@ asChromaticStory(Lifestyle);
 export const Opinion = Template.bind({});
 Opinion.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.Opinion,
-	},
+	format: 'opinion',
 };
 asChromaticStory(Opinion);
 
@@ -137,11 +113,7 @@ asChromaticStory(Opinion);
 export const SpecialReport = Template.bind({});
 SpecialReport.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.SpecialReport,
-	},
+	format: 'special_report',
 };
 asChromaticStory(SpecialReport);
 
@@ -150,11 +122,7 @@ asChromaticStory(SpecialReport);
 export const Labs = Template.bind({});
 Labs.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticleSpecial.Labs,
-	},
+	format: 'labs',
 };
 asChromaticStory(Labs);
 
@@ -163,11 +131,7 @@ asChromaticStory(Labs);
 export const XSmall = Template.bind({});
 XSmall.args = {
 	size: 'xsmall',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: 'news',
 };
 asChromaticStory(XSmall);
 
@@ -176,11 +140,7 @@ asChromaticStory(XSmall);
 export const Small = Template.bind({});
 Small.args = {
 	size: 'small',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: 'news',
 };
 asChromaticStory(Small);
 
@@ -189,11 +149,7 @@ asChromaticStory(Small);
 export const Medium = Template.bind({});
 Medium.args = {
 	size: 'medium',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: 'news',
 };
 asChromaticStory(Medium);
 
@@ -202,10 +158,6 @@ asChromaticStory(Medium);
 export const Large = Template.bind({});
 Large.args = {
 	size: 'large',
-	format: {
-		display: ArticleDisplay.Standard,
-		design: ArticleDesign.Standard,
-		theme: ArticlePillar.News,
-	},
+	format: 'news',
 };
 asChromaticStory(Large);

--- a/packages/@guardian/source-react-components-development-kitchen/components/quote-icon/QuoteIcon.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/quote-icon/QuoteIcon.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { Format, Pillar, Special } from '@guardian/types';
+import { ArticleFormat, ArticlePillar, ArticleSpecial } from '@guardian/libs';
 import { SvgQuote } from '@guardian/src-icons';
 import {
 	culture,
@@ -11,51 +11,51 @@ import {
 	sport,
 } from '@guardian/src-foundations';
 
-const quoteColor = (format: Format) => {
+const quoteColor = (format: ArticleFormat) => {
 	switch (format.theme) {
-		case Pillar.News: {
+		case ArticlePillar.News: {
 			return css`
 				svg {
 					fill: ${news[400]};
 				}
 			`;
 		}
-		case Pillar.Opinion: {
+		case ArticlePillar.Opinion: {
 			return css`
 				svg {
 					fill: ${opinion[400]};
 				}
 			`;
 		}
-		case Pillar.Culture: {
+		case ArticlePillar.Culture: {
 			return css`
 				svg {
 					fill: ${culture[400]};
 				}
 			`;
 		}
-		case Pillar.Sport: {
+		case ArticlePillar.Sport: {
 			return css`
 				svg {
 					fill: ${sport[400]};
 				}
 			`;
 		}
-		case Pillar.Lifestyle: {
+		case ArticlePillar.Lifestyle: {
 			return css`
 				svg {
 					fill: ${lifestyle[400]};
 				}
 			`;
 		}
-		case Special.SpecialReport: {
+		case ArticleSpecial.SpecialReport: {
 			return css`
 				svg {
 					fill: ${specialReport[400]};
 				}
 			`;
 		}
-		case Special.Labs: {
+		case ArticleSpecial.Labs: {
 			return css`
 				svg {
 					fill: ${labs[400]};
@@ -112,7 +112,7 @@ export type QuoteIconProps = {
 	/**
 	 * What we use to decide the editorial colour for the quotes
 	 */
-	format: Format;
+	format: ArticleFormat;
 	/**
 	 * The size of the quote.
 	 */

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -30,16 +30,16 @@
     "@guardian/src-helpers": "^3.9.0"
   },
   "devDependencies": {
-    "@guardian/types": "^6.0.0",
+    "@guardian/libs": "^3.2.1",
     "mini-svg-data-uri": "^1.3.3",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
+    "@guardian/libs": "^3.2.1",
     "@guardian/src-foundations": "^3.9.0",
     "@guardian/src-icons": "^3.9.0",
-    "@guardian/types": "^6.0.0",
     "react": "^17.0.1"
   }
 }

--- a/src/core/components/accordion/package.json
+++ b/src/core/components/accordion/package.json
@@ -30,6 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
+    "@guardian/libs": "^3.2.1",
     "@guardian/src-helpers": "^3.9.0"
   },
   "devDependencies": {

--- a/src/core/components/footer/package.json
+++ b/src/core/components/footer/package.json
@@ -30,6 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
+    "@guardian/libs": "^3.2.1",
     "@guardian/src-helpers": "^3.9.0"
   },
   "devDependencies": {

--- a/src/core/components/link/package.json
+++ b/src/core/components/link/package.json
@@ -30,6 +30,7 @@
     "verbump:prerelease": "yarn version --prerelease --preid rc --no-git-tag-version"
   },
   "dependencies": {
+    "@guardian/libs": "^3.2.1",
     "@guardian/src-helpers": "^3.9.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,11 +1457,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.6.0.tgz#b3dcbef0e2a9232d2afe04dff075426b2939f44e"
   integrity sha512-RN8GBRth5BXHoWymCZIYDbmZM8DkUbgecf+wyv+9hdXA/ad4Ob4qP9u/ARU689qMo+JSC1z3FRKelvkkjtYzJw==
 
-"@guardian/types@^6.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/types/-/types-6.1.0.tgz#5189c34c5cc4da1e549f70706c78276fa69ef7d3"
-  integrity sha512-CP1bmqOutfG/hLQrAzBaqj9EitCNPJQ1qTyHfiCAElFsWKofYuEzMgHYM2ut5nSrkSC+n0AhXUt3qItl+2A3eQ==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,6 +1447,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@guardian/libs@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.2.1.tgz#96368fcd76f63b842708ea1489275bd3200f5e4b"
+  integrity sha512-/o84jYYlodIfKs+aRj1QoluHnQ/OdgJN/v1FONwGCf7eGn6RYn9BCh5QvHRujpoSqzgq435tzx5Ug3EF1wWvfQ==
+
 "@guardian/prettier@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@guardian/prettier/-/prettier-0.6.0.tgz#b3dcbef0e2a9232d2afe04dff075426b2939f44e"


### PR DESCRIPTION
_description edited by @sndrs to reflect changes going to `main`_

## What is the purpose of this change?

This change updates ~~the kitchen~~ `main` to use [`@guardian/libs`](https://github.com/guardian/libs) over [`@guardian/types`](https://github.com/guardian/types) following the [deprecation](https://github.com/guardian/types/pull/140) of the types package.

## What does this change?

- Update ~~`src/kitchen/package.json`~~ ~~editorial~~ `packages/@guardian/source-react-components-development-kitchen` packages to install `@guardian/libs` instead of `@guardian/types`
- Update imports in `Button`, `LinkButton` and `QuoteIcon`
- Update usage of Format elements to add `Article` prefix
