### PR TITLE
Add vendor prefixes to properties in `@supports` declaration

### DIFF
--- a/packages/@guardian/source-foundations/src/index.ts
+++ b/packages/@guardian/source-foundations/src/index.ts
@@ -96,6 +96,7 @@ export type {
 } from './typography/types';
 
 // utils
+export { appearance } from './utils/supports-queries';
 export { FocusStyleManager } from './utils/focus-style-manager';
 export { pxToRem, rootPixelFontSize } from './utils/px-to-rem';
 export { resets } from './utils/resets';

--- a/packages/@guardian/source-foundations/src/utils/supports-queries.ts
+++ b/packages/@guardian/source-foundations/src/utils/supports-queries.ts
@@ -1,0 +1,6 @@
+// FYI
+// src/core/foundations/src/utils/supports-queries.ts SYMLINKS TO
+// packages/@guardian/source-foundations/src/utils/supports-queries.ts
+
+export const appearance =
+	'(appearance: none) or (-webkit-appearance: none) or (-moz-appearance: none)';

--- a/src/core/components/checkbox/styles.ts
+++ b/src/core/components/checkbox/styles.ts
@@ -4,7 +4,7 @@ import { height, width } from '@guardian/src-foundations/size';
 import { textSans } from '@guardian/src-foundations/typography';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { checkboxDefault } from '@guardian/src-foundations/themes';
-import { resets } from '@guardian/src-foundations/utils';
+import { resets, appearance } from '@guardian/src-foundations/utils';
 
 export const fieldset = css`
 	${resets.fieldset};
@@ -52,7 +52,7 @@ export const checkbox = ({ checkbox } = checkboxDefault) => css`
 		${focusHalo};
 	}
 
-	@supports (appearance: none) {
+	@supports (${appearance}) {
 		appearance: none;
 		&:checked {
 			border: 2px solid ${checkbox.borderChecked};
@@ -95,7 +95,10 @@ export const supportingText = ({ checkbox } = checkboxDefault) => css`
 `;
 
 export const tick = ({ checkbox } = checkboxDefault) => css`
-	@supports (appearance: none) {
+	@supports (
+		(appearance: none) or (-webkit-appearance: none) or
+			(-moz-appearance: none)
+	) {
 		/* overall positional properties */
 		position: absolute;
 		width: 6px;
@@ -144,14 +147,14 @@ export const tick = ({ checkbox } = checkboxDefault) => css`
 `;
 
 export const tickWithLabelText = css`
-	@supports (appearance: none) {
+	@supports (${appearance}) {
 		top: 15px;
 		left: 9px;
 	}
 `;
 
 export const tickWithSupportingText = css`
-	@supports (appearance: none) {
+	@supports (${appearance}) {
 		top: 5px;
 	}
 `;

--- a/src/core/components/radio/styles.ts
+++ b/src/core/components/radio/styles.ts
@@ -4,7 +4,7 @@ import { height, width } from '@guardian/src-foundations/size';
 import { textSans } from '@guardian/src-foundations/typography';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { radioDefault } from '@guardian/src-foundations/themes';
-import { resets } from '@guardian/src-foundations/utils';
+import { appearance, resets } from '@guardian/src-foundations/utils';
 
 export const fieldset = ({ radio } = radioDefault) => css`
 	${resets.fieldset};
@@ -65,7 +65,7 @@ export const radio = ({ radio } = radioDefault) => css`
 	I have chosen to keep these styles in the @supports block as
 	moving them out makes radio buttons look horrible on older browsers
 	*/
-	@supports (appearance: none) {
+	@supports (${appearance}) {
 		appearance: none;
 		background-color: transparent;
 

--- a/src/core/components/select/styles.ts
+++ b/src/core/components/select/styles.ts
@@ -4,6 +4,7 @@ import { height, width } from '@guardian/src-foundations/size';
 import { textSans } from '@guardian/src-foundations/typography';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { selectDefault } from '@guardian/src-foundations/themes';
+import { appearance } from '@guardian/src-foundations/utils';
 
 export const errorInput = ({ select } = selectDefault) => css`
 	border: 4px solid ${select.borderError};
@@ -55,7 +56,7 @@ export const select = (theme = selectDefault) => {
 		border: 2px solid ${select.border};
 		padding-left: ${space[2]}px;
 
-		@supports (appearance: none) {
+		@supports (${appearance}) {
 			appearance: none;
 			padding-right: ${space[2]}px;
 

--- a/src/core/foundations/src/utils/css.ts
+++ b/src/core/foundations/src/utils/css.ts
@@ -1,0 +1,2 @@
+export const appearance =
+	'(appearance: none) or (-webkit-appearance: none) or (-moz-appearance: none)';

--- a/src/core/foundations/src/utils/css.ts
+++ b/src/core/foundations/src/utils/css.ts
@@ -1,2 +1,0 @@
-export const appearance =
-	'(appearance: none) or (-webkit-appearance: none) or (-moz-appearance: none)';

--- a/src/core/foundations/src/utils/index.ts
+++ b/src/core/foundations/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { FocusStyleManager } from './focus-style-manager';
 export { pxToRem, rootPixelFontSize } from './px-to-rem';
 export { resets } from './resets';
+export { appearance } from './css';

--- a/src/core/foundations/src/utils/index.ts
+++ b/src/core/foundations/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { FocusStyleManager } from './focus-style-manager';
 export { pxToRem, rootPixelFontSize } from './px-to-rem';
 export { resets } from './resets';
-export { appearance } from './css';
+export { appearance } from './supports-queries';

--- a/src/core/foundations/src/utils/supports-queries.ts
+++ b/src/core/foundations/src/utils/supports-queries.ts
@@ -1,0 +1,1 @@
+../../../../../packages/@guardian/source-foundations/src/utils/supports-queries.ts


### PR DESCRIPTION
## What is the purpose of this change?

Stylis, the CSS preprocessor used by Emotion under the hood, [doesn't add vendor prefixes to CSS properties in `@supports` declarations](https://github.com/thysultan/stylis.js/issues/34). This is a design decision that they are unlikely to change.

As a result, browsers that don't fully support properties used in these declarations (usually [`appearance`](https://caniuse.com/?search=appearance)) will not render styles declared inside the `@supports` block.

The workaround I've chosen here is to manually add vendor prefixes to the appearance property, when it appears inside a `@supports` declaration.

## What does this change?

Adds `-webkit-` and `-moz-` prefixes to `appearance` in the following components:

-   Radio
-   Checkbox
-   Select


## Screenshots

**Before (Safari 14.1.2)**

![Screenshot 2021-09-10 at 14 08 00](https://user-images.githubusercontent.com/5931528/132858024-049e634e-8aab-4185-9d23-885cb3844117.png)
![Screenshot 2021-09-10 at 14 08 06](https://user-images.githubusercontent.com/5931528/132858028-3cd50ec6-5347-4f3e-8e13-ed25adbcf54e.png)
![Screenshot 2021-09-10 at 14 08 12](https://user-images.githubusercontent.com/5931528/132858029-c6f7cb84-df83-401d-8a71-085d2d2f908a.png)


**After(Safari 14.1.2)**

![Screenshot 2021-09-10 at 14 07 13](https://user-images.githubusercontent.com/5931528/132858073-a5cefe5b-243a-476c-9e1b-22d07ceb058f.png)
![Screenshot 2021-09-10 at 14 07 20](https://user-images.githubusercontent.com/5931528/132858076-e610af9f-9e84-4a01-9363-dd2b0db74c36.png)
![Screenshot 2021-09-10 at 14 07 27](https://user-images.githubusercontent.com/5931528/132858077-7645d0a9-339e-40ef-b3e0-37a466804637.png)

