### PR TITLE
Move animations source code to `source-foundations`

### DIFF
--- a/packages/@guardian/source-foundations/src/animation.ts
+++ b/packages/@guardian/source-foundations/src/animation.ts
@@ -1,0 +1,11 @@
+// FYI
+// src/core/foundations/src/animation.ts SYMLINKS TO
+// packages/@guardian/source-foundations/src/animation.ts
+
+const transitions = {
+	short: '.2s cubic-bezier(.64, .57, .67, 1.53)',
+	medium: '.3s ease-in-out',
+	long: '.65s ease-in-out',
+};
+
+export { transitions };

--- a/packages/@guardian/source-foundations/src/index.ts
+++ b/packages/@guardian/source-foundations/src/index.ts
@@ -1,1 +1,2 @@
-export { transitions } from '../../../../src/core/foundations/src/animation';
+// animation
+export { transitions } from './animation';

--- a/src/core/foundations/src/animation.ts
+++ b/src/core/foundations/src/animation.ts
@@ -1,9 +1,1 @@
-import { transitions as _transitions } from './theme';
-
-const transitions = {
-	short: _transitions[0],
-	medium: _transitions[1],
-	long: _transitions[2],
-};
-
-export { transitions };
+../../../../packages/@guardian/source-foundations/src/animation.ts

--- a/src/core/foundations/src/theme.ts
+++ b/src/core/foundations/src/theme.ts
@@ -145,12 +145,6 @@ const breakpoints = [740, 980, 1140, 1300];
 // fluid grid on mobile devices
 const tweakpoints = [320, 375, 480, 660];
 
-const transitions = [
-	'.2s cubic-bezier(.64, .57, .67, 1.53)',
-	'.3s ease-in-out',
-	'.65s ease-in-out',
-];
-
 export {
 	fontSizes,
 	fonts,
@@ -161,5 +155,4 @@ export {
 	size,
 	breakpoints,
 	tweakpoints,
-	transitions,
 };


### PR DESCRIPTION
## What is the purpose of this change?

Move `animation` to `source-foundation` and share the code `src-foundation` with a symbolic link.

### Why?

- we want to move the source code into `source-` packages 
- we want `source-` packages to be as close to final as possible (not dependent on `src-` implementation details)
- we need to maintain `src-` until `source-` is released
- typescript won't easily compile useful `dist`s for `src-` packages when the source code lives so far away
  - typescript is grumpy playmate if you have a complex platform game of folder locations
  - multiple tsconfigs and builds compounds this

Therefore, this tries to bridge the new world and the old by moving the source to its new home but symlinking to it from the old one.

Symlinking _to_ the new location also means when we delete the `src-` stuff, the symlinks will go, leaving only the finished new world in place 🌄.

## What does this change?

- moves animation stuff to `source-foundations`
- creates symlink back to original file

