### PR TITLE
Remove editorial workspaces from package.json as they no longer exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "workspaces": [
     "src/core/*",
     "src/core/components/*",
-    "src/editorial/web",
-    "src/editorial/web/components/*",
     "packages/@guardian/*"
   ],
   "scripts": {


### PR DESCRIPTION
## What is the purpose of this change?

This change drops the editorial workspaces from the `package.json` file as, following #963, they no longer exist.

## What does this change?

- Remove `src/editorial/web` and `src/editorial/web/components/*` workspaces from `package.json`