### PR TITLE
Cache dependencies in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,9 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
       - name: build
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn validate
           yarn ci:build
       - name: deploy

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@v2.4.0
         with:
           cache: 'yarn'
       - name: build

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
-      - uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@v2.4.0
         with:
           cache: 'yarn'
       - run: |

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,8 +12,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
       - run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn ci:build
       - uses: chromaui/action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@main
+      - uses: guardian/actions-setup-node@v2.4.0
         with:
           cache: 'yarn'
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: guardian/actions-setup-node@main
+        with:
+          cache: 'yarn'
       - name: build
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn validate
           yarn ci:build


### PR DESCRIPTION
## What is the purpose of this change?

This change adds caching to the dependency installation steps in CI workflows.

## What does this change?

-   Add configuration parameter to [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) enable caching
-   Change install step to add `--frozen-lockfile` to ensure repeatable runs
