### PR TITLE
Mark the development kitchen as not having side effects

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -2,6 +2,7 @@
   "name": "@guardian/source-react-components-development-kitchen",
   "version": "0.0.1",
   "license": "Apache-2.0",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
## What is the purpose of this change?

This change adds the `sideEffects` option to the development kitchen to (hopefully) ensure that the package is tree shaken when used in applications. This is particularly important now that we have combined multiple components into a single package.

## What does this change?

-   Add `"sideEffects": false` to development kitchen `package.json`