### PR TITLE
Bump kitchen `package.json` version to 0.0.2

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## What is the purpose of this change?

Bump the `package.json` version number to keep it inline with the most recent published version