### PR TITLE
Change ci:build to build:ci for consistency

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn validate
-          yarn ci:build
+          yarn build:ci
       - name: deploy
         env:
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ jobs:
           cache: 'yarn'
       - run: |
           yarn install --frozen-lockfile
-          yarn ci:build
+          yarn build:ci
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn validate
-          yarn ci:build
+          yarn build:ci

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build-storybook": "build-storybook -o dist",
     "build:all": "ts-node ./scripts/build-all",
-    "ci:build": "NODE_ENV=production build-storybook -o dist",
+    "build:ci": "NODE_ENV=production build-storybook -o dist",
     "clean": "rm -rf dist",
     "clean:all": "ts-node ./scripts/clean-all",
     "fix": "yarn lint:js --fix",


### PR DESCRIPTION
## What is the purpose of this change?

Change the ci build script name to provide consistency with other scripts designed to be run in ci.

## What does this change?

-   Change `ci:build` to `build:ci` in package.json scripts
-   Change `ci:build` to `build:ci` in all workflows