### PR TITLE
Bump actions-setup-node version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
       - name: build

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: guardian/actions-setup-node@v2.4.0
+      - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
       - name: build


### PR DESCRIPTION
## What is the purpose of this change?

Bump the version of [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) to the latest version