### PR TITLE
Include source foundations in build:all and clean:all

### DIFF
--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -13,7 +13,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && rollup -c",
+    "build": "yarn clean && rollup -c",
+    "clean": "rm -rf dist",
     "tsc": "tsc -b"
   },
   "devDependencies": {

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -11,11 +11,20 @@ const build = (dir: string) => {
 	});
 };
 
-const { foundations, icons, brand, helpers, kitchen, coreComponents } = paths;
+const {
+	foundations,
+	sourceFoundations,
+	icons,
+	brand,
+	helpers,
+	kitchen,
+	coreComponents,
+} = paths;
 
 // Build these packages in the specified order
 const prioritisedPackages = [
 	foundations,
+	sourceFoundations,
 	helpers,
 	icons,
 	brand,

--- a/scripts/clean-all.ts
+++ b/scripts/clean-all.ts
@@ -1,16 +1,19 @@
 import execa from 'execa';
 import { paths, getComponentPaths } from './paths';
 
-const { foundations, icons, brand, helpers, kitchen } = paths;
+const { foundations, icons, brand, helpers, kitchen, sourceFoundations } =
+	paths;
 
 const clean = (dir: string) => {
 	return execa('yarn', ['--cwd', `${dir}`, 'run', 'clean'], {
 		stdio: 'inherit',
 	});
 };
-[foundations, icons, brand, helpers, kitchen].forEach((dir) => {
-	clean(dir);
-});
+[foundations, icons, brand, helpers, kitchen, sourceFoundations].forEach(
+	(dir) => {
+		clean(dir);
+	},
+);
 
 getComponentPaths().then((paths) => {
 	paths.forEach((path) => {

--- a/scripts/paths.ts
+++ b/scripts/paths.ts
@@ -7,6 +7,10 @@ const statP = promisify(stat);
 
 const root = join(__dirname, '..');
 const foundations = join(__dirname, '../src/core/foundations');
+const sourceFoundations = join(
+	__dirname,
+	'../packages/@guardian/source-foundations',
+);
 const icons = join(__dirname, '../src/core/icons');
 const brand = join(__dirname, '../src/core/brand');
 const helpers = join(__dirname, '../src/core/helpers');
@@ -60,6 +64,7 @@ export const getKitchenComponentPaths = () =>
 export const paths = {
 	root,
 	foundations,
+	sourceFoundations,
 	icons,
 	brand,
 	helpers,


### PR DESCRIPTION
## What is the purpose of this change?

At the moment the `build:all` and `clean:all` commands don't include the `@guardian/source-foundations` package. This is confusing.

## What does this change?

-   Add a `sourceFoundations` export to the `paths` script
-   Add `sourceFoundations` to the `clean-all` script
-   Add `sourceFoundations` to the `build-all` script
- Split the build command in the foundations package.json into separate clean and build steps