### PR TITLE
Split workflow into separate steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,19 @@ on:
       - 'gh-pages'
       - '[0-9]+.[0-9]+'
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn validate:ci
+      - name: Report coverage
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   build:
     runs-on: ubuntu-latest
     steps:
@@ -13,12 +26,5 @@ jobs:
       - uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
-      - name: build
-        run: |
-          yarn install --frozen-lockfile
-          yarn validate:ci
-          yarn build:ci
-      - name: Report coverage
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn build:ci


### PR DESCRIPTION
## What is the purpose of this change?

This PR splits some of the calls in the ci workflow into separate steps so that they can run in parallel. This is done ahead of https://github.com/guardian/source/pull/985 which adds another long running step.

## What does this change?

-   Split the `build` step into separate `build` and `validate` steps