### PR TITLE
Spacing in input fields

### DIFF
--- a/src/core/components/label/styles.ts
+++ b/src/core/components/label/styles.ts
@@ -21,5 +21,5 @@ export const optionalText = ({ label } = labelDefault) => css`
 export const supportingText = ({ label } = labelDefault) => css`
 	${textSans.small({ lineHeight: 'regular' })};
 	color: ${label.textSupporting};
-	margin: 0;
+	margin: 2px 0 0;
 `;

--- a/src/core/components/text-area/TextArea.tsx
+++ b/src/core/components/text-area/TextArea.tsx
@@ -1,7 +1,14 @@
 import { InputHTMLAttributes } from 'react';
 import { InlineError } from '@guardian/src-user-feedback';
 import { Label } from '@guardian/src-label';
-import { widthFluid, textArea, errorInput } from './styles';
+import {
+	widthFluid,
+	textArea,
+	errorInput,
+	labelMargin,
+	supportingTextMargin,
+	inlineMessageMargin,
+} from './styles';
 import {
 	visuallyHidden as _visuallyHidden,
 	descriptionId,
@@ -89,14 +96,17 @@ export const TextArea = ({
 			hideLabel={hideLabel}
 		>
 			{error && (
-				<InlineError id={descriptionId(textAreaId)}>
-					{error}
-				</InlineError>
+				<div css={inlineMessageMargin}>
+					<InlineError id={descriptionId(textAreaId)}>
+						{error}
+					</InlineError>
+				</div>
 			)}
 			<textarea
 				css={[
 					widthFluid,
 					textArea,
+					supporting ? supportingTextMargin : labelMargin,
 					error ? errorInput : '',
 					cssOverrides,
 				]}

--- a/src/core/components/text-area/styles.ts
+++ b/src/core/components/text-area/styles.ts
@@ -8,6 +8,7 @@ import { resets } from '@guardian/src-foundations/utils';
 export const errorInput = css`
 	border: 4px solid ${border.error};
 	color: ${text.error};
+	margin-top: 0;
 `;
 
 export const textArea = css`
@@ -39,6 +40,18 @@ export const textArea = css`
 			${errorInput}
 		}
 	}
+`;
+
+export const labelMargin = css`
+	margin-top: ${space[1]}px;
+`;
+
+export const supportingTextMargin = css`
+	margin-top: 6px;
+`;
+
+export const inlineMessageMargin = css`
+	margin-top: 2px;
 `;
 
 export const widthFluid = css`

--- a/src/core/components/text-input/TextInput.tsx
+++ b/src/core/components/text-input/TextInput.tsx
@@ -10,6 +10,8 @@ import {
 	textInput,
 	errorInput,
 	successInput,
+	supportingTextMargin,
+	labelMargin,
 } from './styles';
 import {
 	visuallyHidden as _visuallyHidden,
@@ -114,6 +116,7 @@ export const TextInput = ({
 				css={(theme) => [
 					width ? widths[width] : widthFluid,
 					textInput(theme.textInput && theme),
+					supporting ? supportingTextMargin : labelMargin,
 					error ? errorInput(theme.textInput && theme) : '',
 					!error && success
 						? successInput(theme.textInput && theme)

--- a/src/core/components/text-input/TextInput.tsx
+++ b/src/core/components/text-input/TextInput.tsx
@@ -12,6 +12,7 @@ import {
 	successInput,
 	supportingTextMargin,
 	labelMargin,
+	inlineMessageMargin,
 } from './styles';
 import {
 	visuallyHidden as _visuallyHidden,
@@ -103,14 +104,18 @@ export const TextInput = ({
 			supporting={supporting}
 		>
 			{error && (
-				<InlineError id={descriptionId(textInputId)}>
-					{error}
-				</InlineError>
+				<div css={inlineMessageMargin}>
+					<InlineError id={descriptionId(textInputId)}>
+						{error}
+					</InlineError>
+				</div>
 			)}
 			{!error && success && (
-				<InlineSuccess id={descriptionId(textInputId)}>
-					{success}
-				</InlineSuccess>
+				<div css={inlineMessageMargin}>
+					<InlineSuccess id={descriptionId(textInputId)}>
+						{success}
+					</InlineSuccess>
+				</div>
 			)}
 			<input
 				css={(theme) => [

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -9,11 +9,13 @@ import { resets } from '@guardian/src-foundations/utils';
 export const errorInput = ({ textInput } = textInputDefault) => css`
 	border: 4px solid ${textInput.borderError};
 	color: ${textInput.textError};
+	margin-top: 0;
 `;
 
 export const successInput = ({ textInput } = textInputDefault) => css`
 	border: 4px solid ${textInput.borderSuccess};
 	color: ${textInput.textSuccess};
+	margin-top: 0;
 `;
 
 export const textInput = (theme = textInputDefault) => {
@@ -48,6 +50,14 @@ export const textInput = (theme = textInputDefault) => {
 		}
 	`;
 };
+
+export const labelMargin = css`
+	margin-top: ${space[1]}px;
+`;
+
+export const supportingTextMargin = css`
+	margin-top: 6px;
+`;
 
 export const widthFluid = css`
 	width: 100%;

--- a/src/core/components/text-input/styles.ts
+++ b/src/core/components/text-input/styles.ts
@@ -59,6 +59,10 @@ export const supportingTextMargin = css`
 	margin-top: 6px;
 `;
 
+export const inlineMessageMargin = css`
+	margin-top: 2px;
+`;
+
 export const widthFluid = css`
 	width: 100%;
 `;


### PR DESCRIPTION
## What is the purpose of this change?
<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

<img width="1225" alt="Screenshot 2021-09-28 at 10 37 29 (1)" src="https://user-images.githubusercontent.com/13315440/135463302-a96d0db2-0b2b-43a0-9ee8-d42dc4089b7e.png">

To update the spacing in input field components (`TextInput`/`TextArea`) between the input element and the labels to match closer to design requirements.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Adding a 2px margin-top to the supporting text in the label component, to space it from the main label text
-   Updates the TextInput component to apply the spacings between the label component, inline messages, and input field.
-   Updates the TextArea component to apply the spacings between the label component, inline messages, and input field.
- A margin wasn't added when an inline error/success was visible, as there is already quite a bit of space when it's visible.

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

![chrome_aTPt7lXXLp](https://user-images.githubusercontent.com/13315440/135593150-c2b054a2-c55f-4385-bf3f-aded9807613c.png)

![chrome_FQTfyF876v](https://user-images.githubusercontent.com/13315440/135593261-519e273f-7283-4fa7-a05e-f64d01afc61f.png)

![chrome_JpXUhHxcCH](https://user-images.githubusercontent.com/13315440/135593636-710666b5-3f46-44e3-bcf5-ad83cf0f6fbb.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/78ac51)
-   [x] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/009027)
-   [x] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/58dbf2)
-   [x] [The component doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/61524d)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
