### PR TITLE
Export all component prop types

### DIFF
--- a/src/core/components/checkbox/index.tsx
+++ b/src/core/components/checkbox/index.tsx
@@ -4,4 +4,6 @@ export {
 } from '@guardian/src-foundations/themes';
 
 export { CheckboxGroup } from './CheckboxGroup';
+export type { CheckboxGroupProps } from './CheckboxGroup';
 export { Checkbox } from './Checkbox';
+export type { CheckboxProps } from './Checkbox';

--- a/src/core/components/footer/index.tsx
+++ b/src/core/components/footer/index.tsx
@@ -1,1 +1,2 @@
 export { Footer } from './Footer';
+export type { FooterProps } from './Footer';

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -2,6 +2,6 @@ export { Columns, ColumnsProps } from './Columns/Columns';
 export { Column, ColumnProps } from './Columns/Column';
 export { Container, ContainerProps } from './Container/Container';
 export { Hide, HideProps } from './Hide/Hide';
-export { Stack } from './Stack/Stack';
+export { Stack, StackProps } from './Stack/Stack';
 export { Tiles, TilesProps } from './Tiles/Tiles';
 export { Inline, InlineProps } from './Inline/Inline';

--- a/src/core/components/link/index.tsx
+++ b/src/core/components/link/index.tsx
@@ -7,4 +7,6 @@ export {
 export type { LinkPriority } from './types';
 
 export { Link } from './Link';
+export type { LinkProps } from './Link';
 export { ButtonLink } from './ButtonLink';
+export type { ButtonLinkProps } from './ButtonLink';

--- a/src/core/components/radio/index.tsx
+++ b/src/core/components/radio/index.tsx
@@ -1,4 +1,6 @@
 export { radioBrand, radioDefault } from '@guardian/src-foundations/themes';
 
 export { RadioGroup } from './RadioGroup';
+export type { RadioGroupProps } from './RadioGroup';
 export { Radio } from './Radio';
+export type { RadioProps } from './Radio';

--- a/src/core/components/select/index.tsx
+++ b/src/core/components/select/index.tsx
@@ -1,3 +1,5 @@
 export { selectDefault } from '@guardian/src-foundations/themes';
 export { Option } from './Option';
+export type { OptionProps } from './Option';
 export { Select } from './Select';
+export type { SelectProps } from './Select';

--- a/src/core/components/user-feedback/index.tsx
+++ b/src/core/components/user-feedback/index.tsx
@@ -5,5 +5,7 @@ export {
 	userFeedbackBrand,
 } from '@guardian/src-foundations/themes';
 
+export { UserFeedbackProps } from './types';
+
 export { InlineError } from './InlineError';
 export { InlineSuccess } from './InlineSuccess';


### PR DESCRIPTION
## What is the purpose of this change?

This change updates all the index files to export the `ComponentProps` types for each component, rather than just the subset that we were previously exporting.

## What does this change?

-   Export `ComponentProps` types (as types) for all components
  -  The only exception is `StackProps` which, as it was the only one in that file that wasn't exported already, I've exported not as a type