### PR TITLE
Add ErrorSummary and SuccessSummary components to the kitchen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 /packages/@guardian/source-react-components-development-kitchen/components/logo @guardian/dotcom-platform
 /packages/@guardian/source-react-components-development-kitchen/components/quote-icon @guardian/dotcom-platform
 /packages/@guardian/source-react-components-development-kitchen/components/star-rating @guardian/dotcom-platform
+/packages/@guardian/source-react-components-development-kitchen/components/summary @guardian/identity

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/ErrorSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/ErrorSummary.stories.tsx
@@ -1,0 +1,40 @@
+import { ErrorSummary, ErrorSummaryProps } from './ErrorSummary';
+import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
+import {
+	asPlayground,
+	asChromaticStory,
+} from '../../../../../lib/story-intents';
+
+export default {
+	title: 'Kitchen/source-react-components-development-kitchen/Error Summary',
+	component: ErrorSummary,
+	args: {
+		error: 'There has been a problem',
+	},
+};
+
+const Template: Story<ErrorSummaryProps> = (args: ErrorSummaryProps) => (
+	<ErrorSummary {...args} />
+);
+
+// *****************************************************************************
+
+export const Playground = Template.bind({});
+asPlayground(Playground);
+
+// *****************************************************************************
+
+export const ErrorOnly = Template.bind({});
+ErrorOnly.args = {
+	error: 'This is an example with an error message only',
+};
+asChromaticStory(ErrorOnly);
+
+// *****************************************************************************
+
+export const WithContext = Template.bind({});
+WithContext.args = {
+	error: 'Here is an error',
+	context: 'This is some more information about this error message',
+};
+asChromaticStory(WithContext);

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/ErrorSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/ErrorSummary.stories.tsx
@@ -10,6 +10,7 @@ export default {
 	component: ErrorSummary,
 	args: {
 		error: 'There has been a problem',
+		context: '',
 	},
 };
 

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/ErrorSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/ErrorSummary.tsx
@@ -1,0 +1,38 @@
+import { SvgAlertTriangle } from '@guardian/src-icons';
+import type { Props } from '@guardian/src-helpers';
+import {
+	wrapperStyles,
+	iconStyles,
+	messageWrapperStyles,
+	messageStyles,
+	contextStyles,
+} from './styles';
+import { error as errorColors } from '@guardian/src-foundations';
+
+export interface ErrorSummaryProps extends Props {
+	/**
+	 * The main error message
+	 */
+	error: string;
+	/**
+	 * Optional context information about the error
+	 */
+	context?: string;
+}
+
+export const ErrorSummary = ({
+	error,
+	context,
+	cssOverrides,
+	...props
+}: ErrorSummaryProps) => (
+	<div css={[wrapperStyles(errorColors[400]), cssOverrides]} {...props}>
+		<div css={iconStyles(errorColors[400])}>
+			<SvgAlertTriangle />
+		</div>
+		<div css={messageWrapperStyles}>
+			<div css={messageStyles(errorColors[400])}>{error}</div>
+			{context && <div css={contextStyles}>{context}</div>}
+		</div>
+	</div>
+);

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/README.md
@@ -1,0 +1,33 @@
+# Summary
+
+Summary messages appear at the top of a group of content to summarise any actions that the user has taken or errors that have occurred.
+
+There are two components available, `ErrorSummary` and `SuccessSummary`.
+
+## Install
+
+```sh
+$ yarn add @guardian/source-react-components-development-kitchen
+```
+
+or
+
+```sh
+$ npm i @guardian/source-react-components-development-kitchen
+```
+
+## Use
+
+### API
+
+#### `ErrorSummary`
+
+See [storybook](https://guardian.github.io/source/?path=/docs/kitchen-source-react-components-development-kitchen-error-summary--playground)
+
+#### `Success Summary`
+
+See [storybook](https://guardian.github.io/source/?path=/docs/kitchen-source-react-components-development-kitchen-success-summary--playground)
+
+### How to use
+
+For context and visual guides relating to usage see the [Source Design System website](https://www.theguardian.design/2a1e5182b/p/108ed3-user-feedback/b/3803b4/t/08c895).

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/SuccessSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/SuccessSummary.stories.tsx
@@ -10,6 +10,7 @@ export default {
 	component: SuccessSummary,
 	args: {
 		success: 'Your request was successful',
+		context: '',
 	},
 };
 

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/SuccessSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/SuccessSummary.stories.tsx
@@ -1,0 +1,40 @@
+import { SuccessSummary, SuccessSummaryProps } from './SuccessSummary';
+import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
+import {
+	asPlayground,
+	asChromaticStory,
+} from '../../../../../lib/story-intents';
+
+export default {
+	title: 'Kitchen/source-react-components-development-kitchen/Success Summary',
+	component: SuccessSummary,
+	args: {
+		success: 'Your request was successful',
+	},
+};
+
+const Template: Story<SuccessSummaryProps> = (args: SuccessSummaryProps) => (
+	<SuccessSummary {...args} />
+);
+
+// *****************************************************************************
+
+export const Playground = Template.bind({});
+asPlayground(Playground);
+
+// *****************************************************************************
+
+export const SuccessOnly = Template.bind({});
+SuccessOnly.args = {
+	success: 'This is an example with a success message only',
+};
+asChromaticStory(SuccessOnly);
+
+// *****************************************************************************
+
+export const WithContext = Template.bind({});
+WithContext.args = {
+	success: 'It was successful',
+	context: 'This is some more information about this success message',
+};
+asChromaticStory(WithContext);

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/SuccessSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/SuccessSummary.tsx
@@ -1,0 +1,38 @@
+import { SvgTickRound } from '@guardian/src-icons';
+import type { Props } from '@guardian/src-helpers';
+import {
+	wrapperStyles,
+	iconStyles,
+	messageWrapperStyles,
+	messageStyles,
+	contextStyles,
+} from './styles';
+import { success as successColors } from '@guardian/src-foundations';
+
+export interface SuccessSummaryProps extends Props {
+	/**
+	 * The main success message
+	 */
+	success: string;
+	/**
+	 * Optional context information about the success
+	 */
+	context?: string;
+}
+
+export const SuccessSummary = ({
+	success,
+	context,
+	cssOverrides,
+	...props
+}: SuccessSummaryProps) => (
+	<div css={[wrapperStyles(successColors[400]), cssOverrides]} {...props}>
+		<div css={iconStyles(successColors[400])}>
+			<SvgTickRound />
+		</div>
+		<div css={messageWrapperStyles}>
+			<div css={messageStyles(successColors[400])}>{success}</div>
+			{context && <div css={contextStyles}>{context}</div>}
+		</div>
+	</div>
+);

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/index.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/index.tsx
@@ -1,0 +1,4 @@
+export type { ErrorSummaryProps } from './ErrorSummary';
+export { ErrorSummary } from './ErrorSummary';
+export type { SuccessSummaryProps } from './SuccessSummary';
+export { SuccessSummary } from './SuccessSummary';

--- a/packages/@guardian/source-react-components-development-kitchen/components/summary/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/components/summary/styles.ts
@@ -1,0 +1,35 @@
+import { css } from '@emotion/react';
+import { space } from '@guardian/src-foundations';
+import { textSans } from '@guardian/src-foundations/typography';
+import { size } from '@guardian/src-foundations/size';
+
+export const wrapperStyles = (color: string) => css`
+	border: 4px solid ${color};
+	padding: ${space[1]}px;
+
+	display: flex;
+`;
+
+export const iconStyles = (color: string) => css`
+	display: flex;
+	flex: 0 1 auto;
+	margin-top: 1px;
+	svg {
+		fill: ${color};
+		height: ${size.xsmall}px;
+		width: ${size.xsmall}px;
+	}
+`;
+
+export const messageStyles = (color: string) => css`
+	${textSans.medium({ fontWeight: 'bold' })}
+	color: ${color};
+`;
+
+export const messageWrapperStyles = css`
+	margin-left: ${space[1]}px;
+`;
+
+export const contextStyles = css`
+	${textSans.medium()}
+`;


### PR DESCRIPTION
## What does this change?

Adds the Summary components (`ErrorSummary` and `SuccessSummary`) to the kitchen. Some information about the Summary component and how it should be used is already on the [source design system website](http://theguardian.design/2a1e5182b/p/108ed3-user-feedback/b/3803b4/t/08c895).

These components can display a message with optional context information.

## Screenshots

**ErrorSummary**
![chrome_U6tqTxuDdj](https://user-images.githubusercontent.com/13315440/135610875-03c50707-6fd0-407d-abb2-fdf821e9cc16.png)


**SuccessSummary**
![chrome_jYgwPRKwWZ](https://user-images.githubusercontent.com/13315440/135610892-771281aa-93b3-47a2-a125-e52a16af15c5.png)
