### PR TITLE
Bump @guardian/source-react-components-development-kitchen to v0.0.3

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## What is the purpose of this change?

Since #1000 was merged, we should publish a new version to allow teams to consume it

## What does this change?

- Bumps @guardian/source-react-components-development-kitchen to v0.0.3
