### PR TITLE
Export `IconSize` and `IconProps`

### DIFF
--- a/src/core/icons/index.ts
+++ b/src/core/icons/index.ts
@@ -49,3 +49,5 @@ export * from './tick-round';
 export * from './twitter';
 export * from './video';
 export * from './whats-app';
+
+export type { IconProps, IconSize } from './types';


### PR DESCRIPTION
## What is the purpose of this change?

Export `IconSize` and `IconProps` so that other applications can use them if required
