### PR TITLE
Export types as types

### DIFF
--- a/src/core/brand/index.ts
+++ b/src/core/brand/index.ts
@@ -1,7 +1,17 @@
-export * from './SvgGuardianLogo';
-export * from './SvgGuardianLiveLogo';
+export { SvgGuardianLogo } from './SvgGuardianLogo';
+export type { SvgGuardianLogoProps } from './SvgGuardianLogo';
 
-export * from './SvgRoundelBrand';
-export * from './SvgRoundelBrandInverse';
-export * from './SvgRoundelDefault';
-export * from './SvgRoundelInverse';
+export { SvgGuardianLiveLogo } from './SvgGuardianLiveLogo';
+export type { SvgGuardianLiveLogoProps } from './SvgGuardianLiveLogo';
+
+export { SvgRoundelBrand } from './SvgRoundelBrand';
+export type { SvgRoundelBrandProps } from './SvgRoundelBrand';
+
+export { SvgRoundelBrandInverse } from './SvgRoundelBrandInverse';
+export type { SvgRoundelBrandInverseProps } from './SvgRoundelBrandInverse';
+
+export { SvgRoundelDefault } from './SvgRoundelDefault';
+export type { SvgRoundelDefaultProps } from './SvgRoundelDefault';
+
+export { SvgRoundelInverse } from './SvgRoundelInverse';
+export type { SvgRoundelInverseProps } from './SvgRoundelInverse';

--- a/src/core/components/accordion/index.tsx
+++ b/src/core/components/accordion/index.tsx
@@ -1,3 +1,5 @@
-export { Accordion, AccordionProps } from './Accordion';
-export { AccordionRow, AccordionRowProps } from './AccordionRow';
+export { Accordion } from './Accordion';
+export type { AccordionProps } from './Accordion';
+export { AccordionRow } from './AccordionRow';
+export type { AccordionRowProps } from './AccordionRow';
 export { accordionDefault } from '@guardian/src-foundations/themes';

--- a/src/core/components/button/index.tsx
+++ b/src/core/components/button/index.tsx
@@ -10,5 +10,7 @@ export {
 } from './themes';
 
 export type { ButtonPriority, IconSide, Size } from './types';
-export { Button, ButtonProps } from './Button';
-export { LinkButton, LinkButtonProps } from './LinkButton';
+export { Button } from './Button';
+export type { ButtonProps } from './Button';
+export { LinkButton } from './LinkButton';
+export type { LinkButtonProps } from './LinkButton';

--- a/src/core/components/choice-card/index.tsx
+++ b/src/core/components/choice-card/index.tsx
@@ -1,7 +1,10 @@
 export { choiceCardDefault } from '@guardian/src-foundations/themes';
-export { ChoiceCard, ChoiceCardProps } from './ChoiceCard';
-export {
-	ChoiceCardGroup,
+
+export { ChoiceCard } from './ChoiceCard';
+export type { ChoiceCardProps } from './ChoiceCard';
+
+export { ChoiceCardGroup } from './ChoiceCardGroup';
+export type {
 	ChoiceCardGroupProps,
 	ChoiceCardColumns,
 } from './ChoiceCardGroup';

--- a/src/core/components/label/index.tsx
+++ b/src/core/components/label/index.tsx
@@ -1,3 +1,5 @@
 export { labelBrand, labelDefault } from '@guardian/src-foundations/themes';
-export { Label, LabelProps } from './Label';
-export { Legend, LegendProps } from './Legend';
+export { Label } from './Label';
+export type { LabelProps } from './Label';
+export { Legend } from './Legend';
+export type { LegendProps } from './Legend';

--- a/src/core/components/layout/index.tsx
+++ b/src/core/components/layout/index.tsx
@@ -1,7 +1,20 @@
-export { Columns, ColumnsProps } from './Columns/Columns';
-export { Column, ColumnProps } from './Columns/Column';
-export { Container, ContainerProps } from './Container/Container';
-export { Hide, HideProps } from './Hide/Hide';
-export { Stack, StackProps } from './Stack/Stack';
-export { Tiles, TilesProps } from './Tiles/Tiles';
-export { Inline, InlineProps } from './Inline/Inline';
+export { Columns } from './Columns/Columns';
+export type { ColumnsProps } from './Columns/Columns';
+
+export { Column } from './Columns/Column';
+export type { ColumnProps } from './Columns/Column';
+
+export { Container } from './Container/Container';
+export type { ContainerProps } from './Container/Container';
+
+export { Hide } from './Hide/Hide';
+export type { HideProps } from './Hide/Hide';
+
+export { Stack } from './Stack/Stack';
+export type { StackProps } from './Stack/Stack';
+
+export { Tiles } from './Tiles/Tiles';
+export type { TilesProps } from './Tiles/Tiles';
+
+export { Inline } from './Inline/Inline';
+export type { InlineProps } from './Inline/Inline';

--- a/src/core/components/text-area/index.tsx
+++ b/src/core/components/text-area/index.tsx
@@ -1,1 +1,2 @@
-export { TextArea, TextAreaProps } from './TextArea';
+export { TextArea } from './TextArea';
+export type { TextAreaProps } from './TextArea';

--- a/src/core/components/text-input/index.tsx
+++ b/src/core/components/text-input/index.tsx
@@ -1,2 +1,3 @@
 export { textInputDefault } from '@guardian/src-foundations/themes';
-export { TextInput, TextInputProps } from './TextInput';
+export { TextInput } from './TextInput';
+export type { TextInputProps } from './TextInput';

--- a/src/core/components/user-feedback/index.tsx
+++ b/src/core/components/user-feedback/index.tsx
@@ -5,7 +5,7 @@ export {
 	userFeedbackBrand,
 } from '@guardian/src-foundations/themes';
 
-export { UserFeedbackProps } from './types';
+export type { UserFeedbackProps } from './types';
 
 export { InlineError } from './InlineError';
 export { InlineSuccess } from './InlineSuccess';

--- a/src/core/helpers/index.ts
+++ b/src/core/helpers/index.ts
@@ -1,3 +1,3 @@
 export { storybookBackgrounds } from './storybook-bg';
-export * from './types';
+export type { ThemeName, Props } from './types';
 export { svgBackgroundImage } from './svgBackgroundImage';


### PR DESCRIPTION
## What is the purpose of this change?

This change updates all type exports to make sure they follow the pattern  `export type {Type} from './file'`.

This change has been prompted by the analysis script which finds component usage as it means that we can easily distinguish between components and types.

## What does this change?

-   Ensure all types are actually exported as types