### PR TITLE
Export missing kitchen components

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/index.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/index.tsx
@@ -1,3 +1,6 @@
+export { Divider } from './components/divider';
+export type { DividerProps } from './components/divider';
+
 export {
 	EditorialButton,
 	EditorialLinkButton,
@@ -18,3 +21,9 @@ export type { HeadlineSize, QuoteIconProps } from './components/quote-icon';
 
 export { StarRating } from './components/star-rating';
 export type { StarRatingProps } from './components/star-rating';
+
+export { ErrorSummary, SuccessSummary } from './components/summary';
+export type {
+	ErrorSummaryProps,
+	SuccessSummaryProps,
+} from './components/summary';

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## What does this change?

Exports the `Divider`, `ErrorSummary`, and `SuccessSummary` components from the kitchen so that they can be consumed.
