### PR TITLE
Run CI workflow on `pull_request` event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  push:
+  pull_request:
     branches-ignore:
       - 'main'
       - 'gh-pages'


### PR DESCRIPTION
## What is the purpose of this change?

This change updates the trigger for the CI event in order to get `coveralls` to comment on the PR with the coverage change.

## What does this change

-   Change the trigger in the `ci` workflow to `pull_request`