### PR TITLE
Add `fit` and `none` as size and spaceAbove options respectively.

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/components/divider/Divider.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/divider/Divider.stories.tsx
@@ -51,6 +51,14 @@ asChromaticStory(TightDivider);
 
 // *****************************************************************************
 
+export const NoneDivider = Template.bind({});
+NoneDivider.args = {
+	spaceAbove: 'none',
+};
+asChromaticStory(NoneDivider);
+
+// *****************************************************************************
+
 export const FullDivider = Template.bind({});
 FullDivider.args = {
 	size: 'full',
@@ -64,3 +72,11 @@ TextDivider.args = {
 	displayText: 'I am centred',
 };
 asChromaticStory(TextDivider);
+
+// *****************************************************************************
+
+export const FitDivider = Template.bind({});
+FitDivider.args = {
+	size: 'fit',
+};
+asChromaticStory(FitDivider);

--- a/packages/@guardian/source-react-components-development-kitchen/components/divider/Divider.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/components/divider/Divider.tsx
@@ -1,18 +1,19 @@
 import { css, SerializedStyles } from '@emotion/react';
-
 import { border, text } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { textSans } from '@guardian/src-foundations/typography';
-
 import { partialStyles, fullStyles } from './styles';
+
+type Sizes = 'full' | 'partial' | 'fit';
+type Spaces = 'tight' | 'loose' | 'none';
 export type DividerProps = {
-	size?: 'full' | 'partial';
-	spaceAbove?: 'tight' | 'loose';
+	size?: Sizes;
+	spaceAbove?: Spaces;
 	displayText?: string;
 };
 
 const decideSpace = (
-	spaceAbove: 'tight' | 'loose',
+	spaceAbove: Spaces,
 	displayText?: string,
 ): SerializedStyles => {
 	switch (spaceAbove) {
@@ -32,6 +33,51 @@ const decideSpace = (
 				: css`
 						margin-top: ${space[12]}px;
 				  `;
+		case 'none':
+			return css`
+				margin-top: 0;
+			`;
+	}
+};
+
+const decideSize = (size: Sizes, displayText?: string) => {
+	switch (size) {
+		case 'fit':
+			return displayText
+				? css`
+						:before {
+							margin-left: 0;
+						}
+
+						:after {
+							margin-right: 0;
+						}
+				  `
+				: null;
+		case 'full':
+			return displayText
+				? css`
+						:before {
+							margin-left: -10px;
+						}
+
+						:after {
+							margin-right: -10px;
+						}
+				  `
+				: fullStyles;
+		case 'partial':
+			return displayText
+				? css`
+						:before {
+							margin-left: 30%;
+						}
+
+						:after {
+							margin-right: 30%;
+						}
+				  `
+				: partialStyles;
 	}
 };
 
@@ -60,18 +106,13 @@ export const Divider = ({
 							margin: auto;
 						}
 						:before {
-							margin-left: ${size === 'partial'
-								? '30%'
-								: '-10px'};
 							margin-right: 10px;
 						}
 						:after {
-							margin-right: ${size === 'partial'
-								? '30%'
-								: '-10px'};
 							margin-left: 10px;
 						}
 					`,
+					decideSize(size, displayText),
 					decideSpace(spaceAbove, displayText),
 				]}
 			>
@@ -89,7 +130,7 @@ export const Divider = ({
 					margin-bottom: ${space[1]}px;
 					background-color: ${border.secondary};
 				`,
-				size === 'partial' ? partialStyles : fullStyles,
+				decideSize(size),
 				decideSpace(spaceAbove),
 			]}
 		/>

--- a/packages/@guardian/source-react-components-development-kitchen/components/divider/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/components/divider/README.md
@@ -38,14 +38,15 @@ const Content = () => (
 
 ### `size`
 
-**`'partial' | 'full'` **
+**`'partial' | 'full' | 'fit'` **
 
 `full` means the divider will span the full width of the content
 `partial` left aligns the divider and limits its length
+`fit` means the divider will fit to the container and not overlap the sides
 
 ### `spaceAbove`
 
-**`'tight' | 'loose'`**
+**`'tight' | 'loose' | 'none'`**
 
 How much space is given above the divider
 


### PR DESCRIPTION
## What is the purpose of this change?

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

In Gateway, we needed a way to have more granular control over the spacing and width of the Divider component.

## What does this change?
This PR proposes two new options added to the `size` and `spaceAbove` props.

`size='fit'` allows the divider to fit the container exactly,
without overlap on the sides.

`spaceAbove='none'` allows the divider to have no margin above so that
the end user can have complete control over its spacing.

## Screenshots

**Before**
Divider projecting past the container.

![Screenshot 2021-10-04 at 12 12 58](https://user-images.githubusercontent.com/1771189/135841783-1df5aaf6-9b31-47f9-95c8-f306a7096672.png)

**After**
Divider fitting within the container.

![Screenshot 2021-10-04 at 12 12 24](https://user-images.githubusercontent.com/1771189/135841771-c8949832-372d-4e62-8c29-bf3a1efb629b.png)

## Checklist

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
