### PR TITLE
Remove push trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,6 @@ on:
       - 'gh-pages'
       - '[0-9]+.[0-9]+'
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'gh-pages'
-      - '[0-9]+.[0-9]+'
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What is the purpose of this change?

Remove the push trigger from the CI workflow as the pull_request trigger seems to work now that the branch ignore doesn't include main. This means that the checks don't all run twice.