### PR TITLE
Add `build:all` step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,12 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn build:ci
+  build-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build:all


### PR DESCRIPTION
## What is the purpose of this change?

This PR adds the `build:all` step to CI. This is done to support the work done in https://github.com/guardian/source/pull/985 as the packages must be built before being validated.
