### PR TITLE
Bump kitchen to 0.0.5

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
## What is the purpose of this change?

Release v0.0.5 of the kitchen

## What does this change?

-   Bump kitchen to 0.0.5

## Screenshots

![6297ac4a-754a-496a-9966-9226a83a82a2](https://user-images.githubusercontent.com/5931528/136100741-d0ac4338-63b0-4a5f-957a-bd82eabb4c19.gif)
