### PR TITLE
Add jsx support to `validate-dist`

### DIFF
--- a/scripts/validate-dist/tsconfig.json
+++ b/scripts/validate-dist/tsconfig.json
@@ -1,24 +1,24 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ES2015", // TODO change this to ES2020 in v4.0.0
-    "lib": ["es5", "es6", "es7", "es2017", "es2019", "es2020", "dom"],
-    "strict": true,
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "lib": ["es5", "es6", "es7", "es2017", "es2019", "es2020", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
     "noEmit": true,
-    "jsx": "react-jsx"
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2020"
   },
-  "include": ["."],
-  "exclude": ["dist"]
+  "exclude": ["dist"],
+  "include": ["."]
 }


### PR DESCRIPTION
## What is the purpose of this change?

i'm not sure why it hasn't come up before, but #1033 is breaking because `validate-dist` wasn't set up to handle jsx. this adds support, adopts ES2020 and sorts the config file

