### PR TITLE
Add `sideEffects` value to `source-*` `package.json`s

### DIFF
--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/guardian/source.git"
   },
   "license": "Apache-2.0",
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/@guardian/source-react-components/package.json
+++ b/packages/@guardian/source-react-components/package.json
@@ -6,6 +6,7 @@
     "url": "https://github.com/guardian/source.git"
   },
   "license": "Apache-2.0",
+  "sideEffects": false,
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What is the purpose of this change?

Add `"sideEffects": false` to the `package.json`s of `source-react-components` and `source-foundations` to enable tree shaking in consumer applications.