### PR TITLE
Add initial README for `@guardian/source-react-components` package

### DIFF
--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -1,0 +1,7 @@
+# `@guardian/source-react-components`
+
+[![npm](https://img.shields.io/npm/v/@guardian/source-react-components)](https://www.npmjs.com/package/@guardian/source-react-components)
+
+⚠️🚧 _UNDER CONSTRUCTION You probably want one of the [`@guardian/src-*`](https://www.npmjs.com/search?q=%40guardian%2Fsrc-) packages for the moment._ 🚧⚠️
+
+x


### PR DESCRIPTION
## What is the purpose of this change?

Add a README to the `packages/@guardian/source-react-components` directory so that npm doesn't show

> This package does not have a README. Add a README to your package so that users know how to get started.