### PR TITLE
Update kitchen components path

### DIFF
--- a/scripts/paths.ts
+++ b/scripts/paths.ts
@@ -13,7 +13,7 @@ const helpers = join(__dirname, '../packages/@guardian/src-helpers');
 const coreComponents = join(__dirname, '../packages/@guardian');
 const kitchenComponents = join(
 	__dirname,
-	'../packages/@guardian/source-react-components-development-kitchen/components',
+	'../packages/@guardian/source-react-components-development-kitchen/src/components',
 );
 
 const isDirectory = (path: string) =>


### PR DESCRIPTION
## What is the purpose of this change?

Update the path to kitchen components in the `paths.ts` script as they now live inside `src` directory and this was breaking the `get-usage` script.