### PR TITLE
Add a new rule to disallow `*` imports and exports

### DIFF
--- a/packages/@guardian/eslint-plugin-source/src/index.ts
+++ b/packages/@guardian/eslint-plugin-source/src/index.ts
@@ -1,7 +1,9 @@
+import { noStarImportsOrExports } from './rules/no-star-imports-or-exports';
 import { validImportPaths } from './rules/valid-import-path';
 
 export const rules = {
 	'valid-import-path': validImportPaths,
+	'no-star-imports-or-exports': noStarImportsOrExports,
 };
 
 export const configs = {
@@ -10,6 +12,7 @@ export const configs = {
 
 		rules: {
 			'@guardian/source/valid-import-path': 'error',
+			'@guardian/source/no-star-imports-or-exports': 'error',
 			'import/no-duplicates': 'error',
 		},
 	},

--- a/packages/@guardian/eslint-plugin-source/src/rules/no-star-imports-or-exports.test.ts
+++ b/packages/@guardian/eslint-plugin-source/src/rules/no-star-imports-or-exports.test.ts
@@ -1,0 +1,145 @@
+import { RuleTester } from 'eslint';
+import { noStarImportsOrExports } from './no-star-imports-or-exports';
+
+const ruleTester = new RuleTester({
+	parser: `${__dirname}/../../node_modules/@typescript-eslint/parser`,
+	parserOptions: {
+		ecmaVersion: 2020,
+		sourceType: 'module',
+	},
+});
+
+ruleTester.run('no-star-imports-or-exports', noStarImportsOrExports, {
+	valid: [
+		`import { Label } from '@guardian/source-react-components'`,
+		`import type { LabelProps } from '@guardian/source-react-components'`,
+		`import { breakpoints } from '@guardian/source-foundations'`,
+		`import type { Breakpoint } from '@guardian/source-foundations'`,
+		`import { Label } from '@guardian/src-label'`,
+		`import type { LabelProps } from '@guardian/src-label'`,
+		`import { breakpoints } from '@guardian/src-foundations'`,
+		`import type { Breakpoint } from '@guardian/src-foundations'`,
+	],
+	invalid: [
+		{
+			// Import everything
+			code: `import * as themes from '@guardian/src-foundations/themes';`,
+			errors: [
+				{
+					message:
+						'Importing * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named imports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from a component
+			code: `export * from '@guardian/src-button';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from the root of foundations
+			code: `export * from '@guardian/src-foundations';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Export everything with an alias from the root of foundations
+			code: `export * as foundations from '@guardian/src-foundations';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from a submodule of foundations
+			code: `export * from '@guardian/src-foundations/size';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from helpers
+			code: `export * from '@guardian/src-helpers';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Import everything from source-foundations
+			code: `import * as foundations from '@guardian/source-foundations';`,
+			errors: [
+				{
+					message:
+						'Importing * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named imports instead.',
+				},
+			],
+		},
+		{
+			// Import everything from source-react-components
+			code: `import * as components from '@guardian/source-react-components';`,
+			errors: [
+				{
+					message:
+						'Importing * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named imports instead.',
+				},
+			],
+		},
+		{
+			// Import everything from source-react-components-development-kitchen
+			code: `import * as kitchen from '@guardian/source-react-components-development-kitchen';`,
+			errors: [
+				{
+					message:
+						'Importing * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named imports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from source-foundations
+			code: `export * from '@guardian/source-foundations';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from source-react-components
+			code: `export * from '@guardian/source-react-components';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+		{
+			// Export everything from source-react-components-development-kitchen
+			code: `export * from '@guardian/source-react-components-development-kitchen';`,
+			errors: [
+				{
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				},
+			],
+		},
+	],
+});

--- a/packages/@guardian/eslint-plugin-source/src/rules/no-star-imports-or-exports.ts
+++ b/packages/@guardian/eslint-plugin-source/src/rules/no-star-imports-or-exports.ts
@@ -1,0 +1,55 @@
+import type { Rule } from 'eslint';
+import type { ExportAllDeclaration, ImportDeclaration } from 'estree';
+
+type Node = (ImportDeclaration | ExportAllDeclaration) &
+	Rule.NodeParentExtension;
+
+const isSourcePackage = (node: Node): boolean => {
+	const source = node.source.raw;
+	if (!source) return false;
+
+	return (
+		source.startsWith("'@guardian/src-") ||
+		source.startsWith("'@guardian/source-")
+	);
+};
+
+export const noStarImportsOrExports: Rule.RuleModule = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow * imports and exports',
+			category: 'Possible Problems',
+			url: 'https://github.com/guardian/source',
+		},
+	},
+
+	create(context: Rule.RuleContext): Rule.RuleListener {
+		return {
+			ImportDeclaration(node) {
+				if (!isSourcePackage(node)) return;
+
+				const anyNamespaceSpecifiers = !node.specifiers.every(
+					(s) => s.type !== 'ImportNamespaceSpecifier',
+				);
+
+				if (!anyNamespaceSpecifiers) return;
+
+				return context.report({
+					node,
+					message:
+						'Importing * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named imports instead.',
+				});
+			},
+			ExportAllDeclaration(node) {
+				// e.g. export * from '@guardian/src-foundations'`
+				if (!isSourcePackage(node)) return;
+				return context.report({
+					node,
+					message:
+						'Exporting * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named exports instead.',
+				});
+			},
+		};
+	},
+};

--- a/scripts/eslint-integration-test/index.ts
+++ b/scripts/eslint-integration-test/index.ts
@@ -1,2 +1,3 @@
 import { Label } from '@guardian/src-label';
 import { Button } from '@guardian/src-button';
+import * as kitchen from '@guardian/source-react-components-development-kitchen';


### PR DESCRIPTION
## What is the purpose of this change?

Following https://github.com/guardian/source/pull/1044, this PR introduces a new rule which marks import and exporting everything from a source package as an error.

For example:

- `import * as themes from '@guardian/src-foundations/themes'`
- `export * from '@guardian/src-foundations/themes'`

## Why?

This has come to light as part of the migration to fewer, larger packages as we cannot autofix import/export statements that reference everything in a package. In general we don't recommend this approach as:

* It's harder to manage as the package changes
* It's harder to see what a file actually uses from an import
* It's harder for bundlers to deal with
* In the new world, importing everything will be a lot of things