### PR TITLE
Handle the name change for theme exports

### DIFF
--- a/packages/@guardian/eslint-plugin-source/src/rules/valid-import-path.test.ts
+++ b/packages/@guardian/eslint-plugin-source/src/rules/valid-import-path.test.ts
@@ -193,7 +193,7 @@ import {  size as s } from '@guardian/source-foundations';`,
 						"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.",
 				},
 			],
-			output: `import { labelDefault } from '@guardian/source-react-components';`,
+			output: `import { labelThemeDefault } from '@guardian/source-react-components';`,
 		},
 		{
 			// Import default
@@ -337,7 +337,49 @@ import {  size as s } from '@guardian/source-foundations';`,
 					message: `@guardian/src-* packages are deprecated. Export from '@guardian/source-foundations' instead.`,
 				},
 			],
-			output: `export { headline } from '@guardian/source-foundations';`,
+			output: `export { headlineObjectStyles } from '@guardian/source-foundations';`,
+		},
+		{
+			// Rename theme imports in imports
+			code: `import { choiceCardDefault } from '@guardian/src-foundations/themes';`,
+			errors: [
+				{
+					message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.`,
+				},
+			],
+			output: `import { choiceCardThemeDefault } from '@guardian/source-react-components';`,
+		},
+		{
+			// Rename theme imports in exports
+			code: `export { choiceCardDefault } from '@guardian/src-foundations/themes';`,
+			errors: [
+				{
+					message: `@guardian/src-* packages are deprecated. Export from '@guardian/source-react-components' instead.`,
+				},
+			],
+			output: `export { choiceCardThemeDefault } from '@guardian/source-react-components';`,
+		},
+		{
+			// Rename and remove theme imports
+			code: `import { choiceCardDefault, brand } from '@guardian/src-foundations/themes';`,
+			errors: [
+				{
+					message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been removed: brand.`,
+				},
+			],
+			output: `import { brand } from '@guardian/src-foundations/themes';
+import { choiceCardThemeDefault, } from '@guardian/source-react-components';`,
+		},
+		{
+			// Rename and remove theme imports regardless of order
+			code: `import { brand, choiceCardDefault } from '@guardian/src-foundations/themes';`,
+			errors: [
+				{
+					message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been removed: brand.`,
+				},
+			],
+			output: `import { brand } from '@guardian/src-foundations/themes';
+import {  choiceCardThemeDefault } from '@guardian/source-react-components';`,
 		},
 	],
 });

--- a/packages/@guardian/eslint-plugin-source/src/rules/valid-import-path.ts
+++ b/packages/@guardian/eslint-plugin-source/src/rules/valid-import-path.ts
@@ -27,6 +27,31 @@ const removedImports: Record<string, string[]> = {
 	],
 };
 
+const newThemeNames: Record<string, string> = {
+	accordionDefault: 'accordionThemeDefault',
+	buttonReaderRevenue: 'buttonThemeReaderRevenue',
+	buttonReaderRevenueBrand: 'buttonThemeReaderRevenueBrand',
+	buttonReaderRevenueBrandAlt: 'buttonThemeReaderRevenueBrandAlt',
+	buttonBrand: 'buttonThemeBrand',
+	buttonBrandAlt: 'buttonThemeBrandAlt',
+	buttonDefault: 'buttonThemeDefault',
+	checkboxBrand: 'checkboxThemeBrand',
+	checkboxDefault: 'checkboxThemeDefault',
+	choiceCardDefault: 'choiceCardThemeDefault',
+	footerBrand: 'footerThemeBrand',
+	labelDefault: 'labelThemeDefault',
+	labelBrand: 'labelThemeBrand',
+	linkBrand: 'linkThemeBrand',
+	linkBrandAlt: 'linkThemeBrandAlt',
+	linkDefault: 'linkThemeDefault',
+	radioBrand: 'radioThemeBrand',
+	radioDefault: 'radioThemeDefault',
+	selectDefault: 'selectThemeDefault',
+	textInputDefault: 'textInputThemeDefault',
+	userFeedbackBrand: 'userFeedbackThemeBrand',
+	userFeedbackDefault: 'userFeedbackThemeDefault',
+};
+
 const capitalise = (str: string): string =>
 	str.charAt(0).toUpperCase() + str.slice(1);
 
@@ -114,6 +139,28 @@ const getRenameImportFixers = (
 					fixer.replaceTextRange(
 						range ?? [0, 0],
 						`${name}ObjectStyles`,
+					),
+				);
+			}
+		}
+	}
+
+	// Some of the theme exports have changed name
+	if (node.source.raw === "'@guardian/src-foundations/themes'") {
+		for (const i of node.specifiers) {
+			if (
+				i.type === 'ImportNamespaceSpecifier' ||
+				i.type === 'ImportDefaultSpecifier'
+			)
+				continue;
+
+			const name = getSpecifierName(i);
+			const range = getSpecifierRange(i);
+			if (name in newThemeNames) {
+				fixers.push(
+					fixer.replaceTextRange(
+						range ?? [0, 0],
+						`${newThemeNames[name]}`,
 					),
 				);
 			}


### PR DESCRIPTION
## What is the purpose of this change?

In v4, themes have moved from `@guardian/src-foundations/theme` to `@guardian/source-react-components`. They have also all changed name slightly. This PR accounts for that name change in the eslint autofix logic.

## What does this change?

-   Handle imports and export for name changes
-   Handle theme name changes