### PR TITLE
Add foundations as a peer dependency of ESLint plugin

### DIFF
--- a/packages/@guardian/eslint-plugin-source/package.json
+++ b/packages/@guardian/eslint-plugin-source/package.json
@@ -30,6 +30,9 @@
     "@types/estree": "^0.0.50",
     "typescript": "^4.4.3"
   },
+  "peerDependencies": {
+    "@guardian/source-foundations": "4.0.0-alpha.4"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## What is the purpose of this change?

This change add `@guardian/source-foundations` as a peer dependency of `@guardian/eslint-plugin-source`. This means that consumers will get a warning if they are using a version of the plugin that is incompatible with their version of the foundations.

It does not add a peer dependency on `@guardian/source-react-components` as it is possible to use this plugin without that package.

An alternative approach to this problem is detailed in: #1089 

## What does this change?

-   Add `@guardian/source-foundations` as a peer dependency of `@guardian/eslint-plugin-source`

## Downsides

As `@guardian/source-react-components` is not a peer dependency, no warning will be shown if the versions are incompatible.