### PR TITLE
Use require resolve to find modules in tests

### DIFF
--- a/packages/@guardian/eslint-plugin-source/src/rules/no-star-imports-or-exports.test.ts
+++ b/packages/@guardian/eslint-plugin-source/src/rules/no-star-imports-or-exports.test.ts
@@ -2,7 +2,7 @@ import { RuleTester } from 'eslint';
 import { noStarImportsOrExports } from './no-star-imports-or-exports';
 
 const ruleTester = new RuleTester({
-	parser: `${__dirname}/../../node_modules/@typescript-eslint/parser`,
+	parser: require.resolve('@typescript-eslint/parser'),
 	parserOptions: {
 		ecmaVersion: 2020,
 		sourceType: 'module',


### PR DESCRIPTION
## What is the purpose of this change?

Update the `noStarImportsOrExports` test to use `require.resolve` to resolve the `@typescript-eslint/parser` module