### PR TITLE
Improve documentation for the source space scale mappings.

### DIFF
--- a/packages/@guardian/source-foundations/src/space.ts
+++ b/packages/@guardian/source-foundations/src/space.ts
@@ -4,6 +4,23 @@
 
 import { pxToRem } from './utils/px-to-rem';
 
+/**
+ * Space
+ *
+ * The following units can be applied to margin or padding properties, vertically or horizontally.
+ * @see https://theguardian.design/2a1e5182b/p/449bd5-space
+ *
+ * Space scale
+ * 1 -> 4px
+ * 2 -> 8px
+ * 3 -> 12px
+ * 4 -> 16px
+ * 5 -> 20px
+ * 6 -> 24px
+ * 9 -> 36px
+ * 12 -> 48px
+ * 24 -> 96px
+ */
 export const space = {
 	1: 4,
 	2: 8,
@@ -14,7 +31,7 @@ export const space = {
 	9: 36,
 	12: 48,
 	24: 96,
-};
+} as const;
 
 /* TODO: this should be exposed as a number instead of a string,
    so consumers can perform calculations on it */


### PR DESCRIPTION
## Motivation
I was frequently having to open https://theguardian.design/2a1e5182b/p/449bd5-space/t/13a96a whilst developing. So I narrowed the types to preserve the px values of the space mapping and added a doc comment with the link.

## What is the purpose of this change?
Use a typescript const assertion to tell tsc to narrow the type down to the specific values, so we get a useful autocomplete for px values when entering spaces during dev

## Compiled output
![carbon (1)](https://user-images.githubusercontent.com/1771189/138698750-3b6b88d9-16f9-4893-b6fd-1fea2102ecf8.png)

