### PR TITLE
Forward ref to the underlying HTMLInputElement of the TextInput

### DIFF
--- a/packages/@guardian/src-text-input/TextInput.tsx
+++ b/packages/@guardian/src-text-input/TextInput.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { SerializedStyles } from '@emotion/react';
 import { InlineError, InlineSuccess } from '@guardian/src-user-feedback';
 import { Label } from '@guardian/src-label';
@@ -83,61 +83,69 @@ export interface TextInputProps
  *
  * The following themes are supported: `light`
  */
-export const TextInput = ({
-	id,
-	label: labelText,
-	optional = false,
-	hideLabel = false,
-	supporting,
-	width,
-	error,
-	success,
-	cssOverrides,
-	...props
-}: TextInputProps) => {
-	const textInputId = id || generateSourceId();
-	return (
-		<Label
-			text={labelText}
-			optional={!!optional}
-			hideLabel={hideLabel}
-			supporting={supporting}
-		>
-			{error && (
-				<div css={inlineMessageMargin}>
-					<InlineError id={descriptionId(textInputId)}>
-						{error}
-					</InlineError>
-				</div>
-			)}
-			{!error && success && (
-				<div css={inlineMessageMargin}>
-					<InlineSuccess id={descriptionId(textInputId)}>
-						{success}
-					</InlineSuccess>
-				</div>
-			)}
-			<input
-				css={(theme) => [
-					width ? widths[width] : widthFluid,
-					textInput(theme.textInput && theme),
-					supporting ? supportingTextMargin : labelMargin,
-					error ? errorInput(theme.textInput && theme) : '',
-					!error && success
-						? successInput(theme.textInput && theme)
-						: '',
-					cssOverrides,
-				]}
-				type="text"
-				id={textInputId}
-				aria-required={!optional}
-				aria-invalid={!!error}
-				aria-describedby={
-					error || success ? descriptionId(textInputId) : ''
-				}
-				required={!optional}
-				{...props}
-			/>
-		</Label>
-	);
-};
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+	(
+		{
+			id,
+			label: labelText,
+			optional = false,
+			hideLabel = false,
+			supporting,
+			width,
+			error,
+			success,
+			cssOverrides,
+			...props
+		}: TextInputProps,
+		ref,
+	) => {
+		const textInputId = id || generateSourceId();
+		return (
+			<Label
+				text={labelText}
+				optional={!!optional}
+				hideLabel={hideLabel}
+				supporting={supporting}
+			>
+				{error && (
+					<div css={inlineMessageMargin}>
+						<InlineError id={descriptionId(textInputId)}>
+							{error}
+						</InlineError>
+					</div>
+				)}
+				{!error && success && (
+					<div css={inlineMessageMargin}>
+						<InlineSuccess id={descriptionId(textInputId)}>
+							{success}
+						</InlineSuccess>
+					</div>
+				)}
+				<input
+					ref={ref}
+					css={(theme) => [
+						width ? widths[width] : widthFluid,
+						textInput(theme.textInput && theme),
+						supporting ? supportingTextMargin : labelMargin,
+						error ? errorInput(theme.textInput && theme) : '',
+						!error && success
+							? successInput(theme.textInput && theme)
+							: '',
+						cssOverrides,
+					]}
+					type="text"
+					id={textInputId}
+					aria-required={!optional}
+					aria-invalid={!!error}
+					aria-describedby={
+						error || success ? descriptionId(textInputId) : ''
+					}
+					required={!optional}
+					{...props}
+				/>
+			</Label>
+		);
+	},
+);
+
+TextInput.displayName = 'TextInput';


### PR DESCRIPTION
## What is the purpose of this change?
Allow for a ref to be passed to the TextInput component so that a reference to the input element can be obtained.

## Reason for the change
A planned usage of the TextInput component needs to listen on the `blur` and `invalid` events for a specific field so we can run validation code based on the built in HTML input validation.

## Example of how it helps in our use case
Here we register two handlers, one to validate on the `blur` event, the other to act if an `invalid` event is fired on that specific field once validated.

![carbon (3)](https://user-images.githubusercontent.com/1771189/138745139-a0f5f8ba-9ddd-49b3-b97a-ab40eb4bf26e.png)

