### PR TITLE
Revert "Get Chromatic to run on different viewports"

### DIFF
--- a/lib/story-intents.ts
+++ b/lib/story-intents.ts
@@ -1,5 +1,3 @@
-import type { Breakpoint } from '../packages/@guardian/source-foundations/src';
-import { breakpoints } from '../packages/@guardian/source-foundations/src';
 import { Story } from './@types/storybook-emotion-10-fixes';
 
 /**
@@ -52,14 +50,6 @@ export const asPlayground = <Args>(story: Story<Args>) => {
  * Make sure you have one of these for every possible state of your component.
  */
 export const asChromaticStory = <Args>(story: Story<Args>) => {
-	const defaultViewport = story.parameters?.viewport?.defaultViewport;
-
-	const chromatic: Record<string, unknown> = { disable: false };
-
-	if (defaultViewport && defaultViewport in breakpoints) {
-		chromatic.viewports = [breakpoints[defaultViewport as Breakpoint]];
-	}
-
 	story.parameters = {
 		...story.parameters,
 		viewMode: 'canvas',
@@ -70,6 +60,6 @@ export const asChromaticStory = <Args>(story: Story<Args>) => {
 		},
 		docs: { disable: true },
 		controls: { disabled: true },
-		chromatic,
+		chromatic: { disable: false },
 	};
 };


### PR DESCRIPTION
Reverts guardian/source#1105

Chromatic started failing after merging #1105. I wonder if this was a coincidence?