### PR TITLE
Allow users to set a 'Report this error' link

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
@@ -12,7 +12,8 @@ export default {
 	args: {
 		error: 'There has been a problem',
 		context: '',
-	},
+		errorReportUrl: '',
+	} as ErrorSummaryProps,
 };
 
 const Template: Story<ErrorSummaryProps> = (args: ErrorSummaryProps) => (
@@ -40,3 +41,13 @@ WithContext.args = {
 	context: 'This is some more information about this error message',
 };
 asChromaticStory(WithContext);
+
+// *****************************************************************************
+
+export const WithReportLink = Template.bind({});
+WithReportLink.args = {
+	error: 'Here is an error',
+	context: 'This is some more information about this error message',
+	errorReportUrl: 'https://www.theguardian.com/info/tech-feedback',
+};
+asChromaticStory(WithReportLink);

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.tsx
@@ -16,6 +16,10 @@ export interface ErrorSummaryProps extends Props {
 	 */
 	error: string;
 	/**
+	 * The error report link URL
+	 */
+	errorReportUrl?: string;
+	/**
 	 * Optional context information about the error
 	 */
 	context?: string;
@@ -23,6 +27,7 @@ export interface ErrorSummaryProps extends Props {
 
 export const ErrorSummary = ({
 	error,
+	errorReportUrl,
 	context,
 	cssOverrides,
 	...props
@@ -33,6 +38,14 @@ export const ErrorSummary = ({
 		</div>
 		<div css={messageWrapperStyles}>
 			<div css={messageStyles(errorColors[400])}>{error}</div>
+			{errorReportUrl && (
+				<a
+					css={messageStyles(errorColors[400], false)}
+					href={errorReportUrl}
+				>
+					Report this error
+				</a>
+			)}
 			{context && <div css={contextStyles}>{context}</div>}
 		</div>
 	</div>

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/styles.ts
@@ -22,8 +22,11 @@ export const iconStyles = (color: string): SerializedStyles => css`
 	}
 `;
 
-export const messageStyles = (color: string): SerializedStyles => css`
-	${textSans.medium({ fontWeight: 'bold' })}
+export const messageStyles = (
+	color: string,
+	isBold = true,
+): SerializedStyles => css`
+	${textSans.medium({ fontWeight: isBold ? 'bold' : 'regular' })}
 	color: ${color};
 `;
 


### PR DESCRIPTION
## What is the purpose of this change?
As part of some error message improvements we're making on Gateway we need the ability to set a link for users to be able to report the error.

This pull request extends the ErrorSummary component to add the ability to pass a URL in to show this link ("Report this error")

## What does this look like?
Adds the "Report this error" link below the heading

<img width="488" alt="Screenshot 2021-10-26 at 21 53 31" src="https://user-images.githubusercontent.com/1771189/138959298-a9d3f13b-4813-4ff8-8d9e-686bb08adc59.png">


## Reference Figma component
<img width="364" alt="Screenshot 2021-10-26 at 21 46 09" src="https://user-images.githubusercontent.com/1771189/138958360-a80656a9-18cf-4345-8422-e62e96391026.png">



