### PR TITLE
Add release notes directory

### DIFF
--- a/docs/release-notes/v3.stories.mdx
+++ b/docs/release-notes/v3.stories.mdx
@@ -1,0 +1,73 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta
+	title="Docs/Release notes/Source v3"
+	parameters={{ previewTabs: { canvas: { hidden: true } } }}
+/>
+
+# What's new in v3.0.0
+
+## Breaking changes
+
+There are a small number of breaking changes. A detailed breakdown can be found in our [v3.0.0 migration guide](https://docs.google.com/document/d/1qmHSCCCRs98LI9vN2B8I0yjqBAsRfJclEqcPma0wqbI/edit) (internal document).
+
+## New peer dependencies
+
+We are upgrading the following peer dependencies:
+
+-   `@emotion/core@^10.0.14` to `@emotion/react@^11.1.2`
+-   `react@^16.8.6` to `react@^17.0.1`
+
+## Package deletions
+
+The following legacy packages have been replaced:
+
+-   `@guardian/src-inline-error` with `@guardian/src-user-feedback`
+-   `@guardian/src-svgs` with `@guardian/src-icons`
+
+## Icon rename
+
+The icon `SvgAlert` has been renamed to `SvgAlertTriangle`.
+
+## Colour deletion
+
+The colour `dynamo[400]` has been deleted.
+
+## Typography option rename
+
+The typography option `textSans.xsmall` has been renamed to `textSans.xxsmall`.
+
+## CSS reset
+
+From v3.0.0, Source will provide an optional CSS reset that sets some sensible default CSS rules. The intention is to provide a base for a consistent environment across projects and browsers. See the [discussion in Client Side Infra](https://github.com/orgs/guardian/teams/client-side-infra/discussions/17).
+
+The reset is minimal and is optional for consumers of Source v3.0.0. In a future major version upgrade, consuming the reset will become mandatory for consumers of Source. To get ahead of the game, we recommend trying to consume it when you upgrade to Source v3.
+
+```tsx
+import { resets } from '@guardian/src-foundations/utils';
+
+const document = () => (
+	<html>
+		<head>
+			<style>{resets.defaults}</style>
+		</head>
+		<body>{/* … */}</body>
+	</html>
+);
+```
+
+## Internal stuff
+
+### Labels and legends
+
+All input field components are now consuming the [Label](https://guardian.github.io/source/?path=/docs/source-src-label-label--playground) and [Legend](https://guardian.github.io/source/?path=/docs/source-src-label-legend--playground) components found in `@guardian/src-label`. This should bring further consistency. In the longer term it will reduce the amount of JavaScript that gets shipped.
+
+### IDs for input fields
+
+Under the hood, all elements for input field components receive an ID attribute. This is for accessibility, ensuring error messages get associated with the correct input field element.
+
+It is not necessary to explicitly pass an ID to all components. If you don't pass an ID, an ID gets generated automatically.
+
+### Get in touch
+
+If you have any questions, suggestions or concerns, we would love to hear from you. There are a number of ways to [contact the Design System Team](https://theguardian.design/2a1e5182b/v/14821/p/231f6b-contact-us), so please feel free to drop us a line ☎️

--- a/docs/release-notes/v4.stories.mdx
+++ b/docs/release-notes/v4.stories.mdx
@@ -1,11 +1,11 @@
 import { Meta } from '@storybook/addon-docs';
 
 <Meta
-	title="Docs/11 Migrating from v3 to v4"
+	title="Docs/Release notes/Source v4"
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 
-# Migrating from v3 to v4
+# Introducing Source v4
 
 The latest version, v4, of Source brings a big change to how the packages are structured. Previously, the `@guardian/src-foundations` package contained the atoms from which all our visual design is built (colours, spacing, typography). A number of packages following the `@guardian/src-*` naming pattern provided React components designed for this system.
 


### PR DESCRIPTION
## What is the purpose of this change?

Release notes are ephemeral and shouldn't exist at the same level as more fundamental foundations docs. We should move them into a dedicated `Release notes` folder.

We should also add the v3 release notes as some teams have not yet upgraded to v3

## What does this change?

-   Move v3 - v4 migration notes to release notes directory
-   Add v3 release notes
