### PR TITLE
Make all scripts directories workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "license": "Apache-2.0",
   "workspaces": [
     "packages/@guardian/*",
-    "scripts/get-usage",
-    "scripts/validate-dist",
-    "scripts/eslint-integration-test"
+    "scripts/*"
   ],
   "scripts": {
     "build": "npm-run-all build:packages build:storybook",


### PR DESCRIPTION
## What is the purpose of this change?

This PR updates the workspace configuration to make all directories in the `scripts` directories workspaces as currently all three are listed separately and https://github.com/guardian/source/pull/1118/files adds yet another.