### PR TITLE
Create stories for Source v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,12 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn validate-dist
+  check-stories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.5
+      - uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn workspace story-sync compare

--- a/packages/@guardian/source-react-components/src/stories/Accordion.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Accordion.stories.tsx
@@ -1,0 +1,13 @@
+import { Accordion } from '../../../src-accordion/Accordion';
+import { AccordionRow } from '../../../src-accordion/AccordionRow';
+
+export default {
+	title: 'Source v4/source-react-components/Accordion',
+	component: Accordion,
+	subcomponents: { AccordionRow },
+	args: {
+		hideToggleLabel: false,
+	},
+};
+
+export * from '../../../src-accordion/Accordion.stories';

--- a/packages/@guardian/source-react-components/src/stories/Accordion.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Accordion.stories.tsx
@@ -1,13 +1,8 @@
-import { Accordion } from '../../../src-accordion/Accordion';
-import { AccordionRow } from '../../../src-accordion/AccordionRow';
+import defaultStoryConfig from '../../../src-accordion/Accordion.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Accordion',
-	component: Accordion,
-	subcomponents: { AccordionRow },
-	args: {
-		hideToggleLabel: false,
-	},
 };
 
 export * from '../../../src-accordion/Accordion.stories';

--- a/packages/@guardian/source-react-components/src/stories/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Button.stories.tsx
@@ -1,28 +1,8 @@
-import { SvgCross } from '@guardian/src-icons';
-import { Button } from '../../../src-button/Button';
+import defaultStoryConfig from '../../../src-button/Button.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Button',
-	component: Button,
-	argTypes: {
-		icon: {
-			options: ['undefined', 'cross'],
-			mapping: {
-				undefined: undefined,
-				cross: <SvgCross />,
-			},
-			control: { type: 'radio' },
-		},
-	},
-	args: {
-		children: 'Button',
-		size: 'default',
-		hideLabel: false,
-		icon: undefined,
-		priority: 'primary',
-		iconSide: 'left',
-		nudgeIcon: false,
-	},
 };
 
 export * from '../../../src-button/Button.stories';

--- a/packages/@guardian/source-react-components/src/stories/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Button.stories.tsx
@@ -1,0 +1,28 @@
+import { SvgCross } from '@guardian/src-icons';
+import { Button } from '../../../src-button/Button';
+
+export default {
+	title: 'Source v4/source-react-components/Button',
+	component: Button,
+	argTypes: {
+		icon: {
+			options: ['undefined', 'cross'],
+			mapping: {
+				undefined: undefined,
+				cross: <SvgCross />,
+			},
+			control: { type: 'radio' },
+		},
+	},
+	args: {
+		children: 'Button',
+		size: 'default',
+		hideLabel: false,
+		icon: undefined,
+		priority: 'primary',
+		iconSide: 'left',
+		nudgeIcon: false,
+	},
+};
+
+export * from '../../../src-button/Button.stories';

--- a/packages/@guardian/source-react-components/src/stories/ButtonLink.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/ButtonLink.stories.tsx
@@ -1,25 +1,8 @@
-import { SvgExternal } from '@guardian/src-icons';
-import { ButtonLink } from '../../../src-link/ButtonLink';
+import defaultStoryConfig from '../../../src-link/ButtonLink.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/ButtonLink',
-	component: ButtonLink,
-	args: {
-		priority: 'primary',
-		subdued: false,
-		icon: <SvgExternal />,
-		iconSide: 'left',
-	},
-	argTypes: {
-		icon: {
-			options: ['undefined', 'SvgExternal'],
-			mapping: {
-				undefined: undefined,
-				SvgExternal: <SvgExternal />,
-			},
-			control: { type: 'radio' },
-		},
-	},
 };
 
 export * from '../../../src-link/ButtonLink.stories';

--- a/packages/@guardian/source-react-components/src/stories/ButtonLink.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/ButtonLink.stories.tsx
@@ -1,0 +1,25 @@
+import { SvgExternal } from '@guardian/src-icons';
+import { ButtonLink } from '../../../src-link/ButtonLink';
+
+export default {
+	title: 'Source v4/source-react-components/ButtonLink',
+	component: ButtonLink,
+	args: {
+		priority: 'primary',
+		subdued: false,
+		icon: <SvgExternal />,
+		iconSide: 'left',
+	},
+	argTypes: {
+		icon: {
+			options: ['undefined', 'SvgExternal'],
+			mapping: {
+				undefined: undefined,
+				SvgExternal: <SvgExternal />,
+			},
+			control: { type: 'radio' },
+		},
+	},
+};
+
+export * from '../../../src-link/ButtonLink.stories';

--- a/packages/@guardian/source-react-components/src/stories/Checkbox.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Checkbox.stories.tsx
@@ -1,0 +1,14 @@
+import { Checkbox } from '../../../src-checkbox/Checkbox';
+
+export default {
+	title: 'Source v4/source-react-components/Checkbox',
+	component: Checkbox,
+	argTypes: {},
+	args: {
+		label: 'Checkbox',
+		checked: true,
+		supporting: '',
+	},
+};
+
+export * from '../../../src-checkbox/Checkbox.stories';

--- a/packages/@guardian/source-react-components/src/stories/Checkbox.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Checkbox.stories.tsx
@@ -1,14 +1,8 @@
-import { Checkbox } from '../../../src-checkbox/Checkbox';
+import defaultStoryConfig from '../../../src-checkbox/Checkbox.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Checkbox',
-	component: Checkbox,
-	argTypes: {},
-	args: {
-		label: 'Checkbox',
-		checked: true,
-		supporting: '',
-	},
 };
 
 export * from '../../../src-checkbox/Checkbox.stories';

--- a/packages/@guardian/source-react-components/src/stories/CheckboxGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/CheckboxGroup.stories.tsx
@@ -1,0 +1,18 @@
+import { Checkbox } from '../../../src-checkbox/Checkbox';
+import { CheckboxGroup } from '../../../src-checkbox/CheckboxGroup';
+
+export default {
+	title: 'Source v4/source-react-components/CheckboxGroup',
+	component: CheckboxGroup,
+	subcomponents: { Checkbox },
+	argTypes: {},
+	args: {
+		name: 'checkbox-group',
+		label: 'Checkbox group',
+		supporting: '',
+		hideLabel: false,
+		error: undefined,
+	},
+};
+
+export * from '../../../src-checkbox/CheckboxGroup.stories';

--- a/packages/@guardian/source-react-components/src/stories/CheckboxGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/CheckboxGroup.stories.tsx
@@ -1,18 +1,8 @@
-import { Checkbox } from '../../../src-checkbox/Checkbox';
-import { CheckboxGroup } from '../../../src-checkbox/CheckboxGroup';
+import defaultStoryConfig from '../../../src-checkbox/CheckboxGroup.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/CheckboxGroup',
-	component: CheckboxGroup,
-	subcomponents: { Checkbox },
-	argTypes: {},
-	args: {
-		name: 'checkbox-group',
-		label: 'Checkbox group',
-		supporting: '',
-		hideLabel: false,
-		error: undefined,
-	},
 };
 
 export * from '../../../src-checkbox/CheckboxGroup.stories';

--- a/packages/@guardian/source-react-components/src/stories/ChoiceCard.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/ChoiceCard.stories.tsx
@@ -1,0 +1,39 @@
+import { SvgCamera } from '@guardian/src-icons';
+import { ChoiceCard } from '../../../src-choice-card/ChoiceCard';
+
+export default {
+	title: 'Source v4/source-react-components/ChoiceCard',
+	component: ChoiceCard,
+	args: {
+		id: 'option-1-id',
+		value: 'option-1',
+		label: 'string',
+	},
+	argTypes: {
+		// sorted by required,alpha
+		id: undefined,
+		label: {
+			options: ['string', 'JSX element'],
+			mapping: {
+				string: 'Option 1',
+				'JSX element': <em>Option 1</em>,
+			},
+		},
+		value: undefined,
+		checked: undefined,
+		defaultChecked: {
+			control: { disable: true },
+		},
+		icon: {
+			options: ['undefined', 'JSX element'],
+			mapping: {
+				undefined: undefined,
+				'JSX element': <SvgCamera />,
+			},
+			control: { type: 'radio' },
+		},
+		onChange: { action: 'choice changed' },
+	},
+};
+
+export * from '../../../src-choice-card/ChoiceCard.stories';

--- a/packages/@guardian/source-react-components/src/stories/ChoiceCard.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/ChoiceCard.stories.tsx
@@ -1,39 +1,8 @@
-import { SvgCamera } from '@guardian/src-icons';
-import { ChoiceCard } from '../../../src-choice-card/ChoiceCard';
+import defaultStoryConfig from '../../../src-choice-card/ChoiceCard.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/ChoiceCard',
-	component: ChoiceCard,
-	args: {
-		id: 'option-1-id',
-		value: 'option-1',
-		label: 'string',
-	},
-	argTypes: {
-		// sorted by required,alpha
-		id: undefined,
-		label: {
-			options: ['string', 'JSX element'],
-			mapping: {
-				string: 'Option 1',
-				'JSX element': <em>Option 1</em>,
-			},
-		},
-		value: undefined,
-		checked: undefined,
-		defaultChecked: {
-			control: { disable: true },
-		},
-		icon: {
-			options: ['undefined', 'JSX element'],
-			mapping: {
-				undefined: undefined,
-				'JSX element': <SvgCamera />,
-			},
-			control: { type: 'radio' },
-		},
-		onChange: { action: 'choice changed' },
-	},
 };
 
 export * from '../../../src-choice-card/ChoiceCard.stories';

--- a/packages/@guardian/source-react-components/src/stories/ChoiceCardGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/ChoiceCardGroup.stories.tsx
@@ -1,31 +1,8 @@
-import { ChoiceCard } from '../../../src-choice-card/ChoiceCard';
-import { ChoiceCardGroup } from '../../../src-choice-card/ChoiceCardGroup';
+import defaultStoryConfig from '../../../src-choice-card/ChoiceCardGroup.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/ChoiceCardGroup',
-	component: ChoiceCardGroup,
-	subcomponents: { ChoiceCard },
-	args: {
-		name: 'colours',
-		label: 'Choose an option',
-		supporting: 'These are your options',
-		multi: false,
-	},
-	argTypes: {
-		// sorted by required,alpha
-		name: undefined,
-		columns: {
-			options: [undefined, 2, 3, 4, 5],
-			control: { type: 'select' },
-		},
-		error: {
-			options: [undefined, 'Please select a choice card to continue'],
-			control: { type: 'select' },
-		},
-		label: undefined,
-		multi: undefined,
-		supporting: undefined,
-	},
 };
 
 export * from '../../../src-choice-card/ChoiceCardGroup.stories';

--- a/packages/@guardian/source-react-components/src/stories/ChoiceCardGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/ChoiceCardGroup.stories.tsx
@@ -1,0 +1,31 @@
+import { ChoiceCard } from '../../../src-choice-card/ChoiceCard';
+import { ChoiceCardGroup } from '../../../src-choice-card/ChoiceCardGroup';
+
+export default {
+	title: 'Source v4/source-react-components/ChoiceCardGroup',
+	component: ChoiceCardGroup,
+	subcomponents: { ChoiceCard },
+	args: {
+		name: 'colours',
+		label: 'Choose an option',
+		supporting: 'These are your options',
+		multi: false,
+	},
+	argTypes: {
+		// sorted by required,alpha
+		name: undefined,
+		columns: {
+			options: [undefined, 2, 3, 4, 5],
+			control: { type: 'select' },
+		},
+		error: {
+			options: [undefined, 'Please select a choice card to continue'],
+			control: { type: 'select' },
+		},
+		label: undefined,
+		multi: undefined,
+		supporting: undefined,
+	},
+};
+
+export * from '../../../src-choice-card/ChoiceCardGroup.stories';

--- a/packages/@guardian/source-react-components/src/stories/Columns.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Columns.stories.tsx
@@ -1,0 +1,10 @@
+import { Column } from '../../../src-layout/Columns/Column';
+import { Columns } from '../../../src-layout/Columns/Columns';
+
+export default {
+	title: 'Source v4/source-react-components/Columns',
+	component: Columns,
+	subcomponents: { Column },
+};
+
+export * from '../../../src-layout/Columns/Columns.stories';

--- a/packages/@guardian/source-react-components/src/stories/Columns.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Columns.stories.tsx
@@ -1,10 +1,8 @@
-import { Column } from '../../../src-layout/Columns/Column';
-import { Columns } from '../../../src-layout/Columns/Columns';
+import defaultStoryConfig from '../../../src-layout/Columns/Columns.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Columns',
-	component: Columns,
-	subcomponents: { Column },
 };
 
 export * from '../../../src-layout/Columns/Columns.stories';

--- a/packages/@guardian/source-react-components/src/stories/Container.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Container.stories.tsx
@@ -1,0 +1,19 @@
+import { Container } from '../../../src-layout/Container/Container';
+
+export default {
+	title: 'Source v4/source-react-components/Container',
+	component: Container,
+	argTypes: {
+		border: {
+			control: {
+				disable: true,
+			},
+		},
+	},
+	args: {
+		sideBorders: false,
+		topBorder: false,
+	},
+};
+
+export * from '../../../src-layout/Container/Container.stories';

--- a/packages/@guardian/source-react-components/src/stories/Container.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Container.stories.tsx
@@ -1,19 +1,8 @@
-import { Container } from '../../../src-layout/Container/Container';
+import defaultStoryConfig from '../../../src-layout/Container/Container.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Container',
-	component: Container,
-	argTypes: {
-		border: {
-			control: {
-				disable: true,
-			},
-		},
-	},
-	args: {
-		sideBorders: false,
-		topBorder: false,
-	},
 };
 
 export * from '../../../src-layout/Container/Container.stories';

--- a/packages/@guardian/source-react-components/src/stories/Footer.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Footer.stories.tsx
@@ -1,30 +1,8 @@
-import { Footer } from '../../../src-footer/Footer';
+import defaultStoryConfig from '../../../src-footer/Footer.stories';
 
 export default {
-	component: Footer,
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Footer',
-	argTypes: {
-		children: {
-			options: ['with', 'without'],
-			mapping: {
-				without: undefined,
-				with: (
-					<p>
-						<strong>
-							Lorem ipsum dolor sit amet, consectetur adipiscing
-							elit.
-						</strong>
-						<br />
-						Ut proverbia non nulla veriora sint quam vestra dogmata.
-						Ampulla enim sit necne sit, quis non iure optimo
-						irrideatur, si laboret? Quae quo sunt excelsiores, eo
-						dant clariora indicia naturae.
-					</p>
-				),
-			},
-			control: { type: 'radio' },
-		},
-	},
 };
 
 export * from '../../../src-footer/Footer.stories';

--- a/packages/@guardian/source-react-components/src/stories/Footer.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Footer.stories.tsx
@@ -1,0 +1,30 @@
+import { Footer } from '../../../src-footer/Footer';
+
+export default {
+	component: Footer,
+	title: 'Source v4/source-react-components/Footer',
+	argTypes: {
+		children: {
+			options: ['with', 'without'],
+			mapping: {
+				without: undefined,
+				with: (
+					<p>
+						<strong>
+							Lorem ipsum dolor sit amet, consectetur adipiscing
+							elit.
+						</strong>
+						<br />
+						Ut proverbia non nulla veriora sint quam vestra dogmata.
+						Ampulla enim sit necne sit, quis non iure optimo
+						irrideatur, si laboret? Quae quo sunt excelsiores, eo
+						dant clariora indicia naturae.
+					</p>
+				),
+			},
+			control: { type: 'radio' },
+		},
+	},
+};
+
+export * from '../../../src-footer/Footer.stories';

--- a/packages/@guardian/source-react-components/src/stories/Hide.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Hide.stories.tsx
@@ -1,16 +1,8 @@
-import { Hide } from '../../../src-layout/Hide/Hide';
+import defaultStoryConfig from '../../../src-layout/Hide/Hide.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Hide',
-	component: Hide,
-	argTypes: {
-		above: {
-			control: { disable: true },
-		},
-		below: {
-			control: { disable: true },
-		},
-	},
 };
 
 export * from '../../../src-layout/Hide/Hide.stories';

--- a/packages/@guardian/source-react-components/src/stories/Hide.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Hide.stories.tsx
@@ -1,0 +1,16 @@
+import { Hide } from '../../../src-layout/Hide/Hide';
+
+export default {
+	title: 'Source v4/source-react-components/Hide',
+	component: Hide,
+	argTypes: {
+		above: {
+			control: { disable: true },
+		},
+		below: {
+			control: { disable: true },
+		},
+	},
+};
+
+export * from '../../../src-layout/Hide/Hide.stories';

--- a/packages/@guardian/source-react-components/src/stories/Icons.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Icons.stories.tsx
@@ -1,4 +1,7 @@
+import defaultStoryConfig from '../../../src-icons/Icons.stories';
+
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Icons',
 };
 

--- a/packages/@guardian/source-react-components/src/stories/Icons.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Icons.stories.tsx
@@ -1,0 +1,5 @@
+export default {
+	title: 'Source v4/source-react-components/Icons',
+};
+
+export * from '../../../src-icons/Icons.stories';

--- a/packages/@guardian/source-react-components/src/stories/Inline.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Inline.stories.tsx
@@ -1,0 +1,8 @@
+import { Inline } from '../../../src-layout/Inline/Inline';
+
+export default {
+	title: 'Source v4/source-react-components/Inline',
+	component: Inline,
+};
+
+export * from '../../../src-layout/Inline/Inline.stories';

--- a/packages/@guardian/source-react-components/src/stories/Inline.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Inline.stories.tsx
@@ -1,8 +1,8 @@
-import { Inline } from '../../../src-layout/Inline/Inline';
+import defaultStoryConfig from '../../../src-layout/Inline/Inline.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Inline',
-	component: Inline,
 };
 
 export * from '../../../src-layout/Inline/Inline.stories';

--- a/packages/@guardian/source-react-components/src/stories/InlineError.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/InlineError.stories.tsx
@@ -1,8 +1,8 @@
-import { InlineError } from '../../../src-user-feedback/InlineError';
+import defaultStoryConfig from '../../../src-user-feedback/InlineError.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/InlineError',
-	component: InlineError,
 };
 
 export * from '../../../src-user-feedback/InlineError.stories';

--- a/packages/@guardian/source-react-components/src/stories/InlineError.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/InlineError.stories.tsx
@@ -1,0 +1,8 @@
+import { InlineError } from '../../../src-user-feedback/InlineError';
+
+export default {
+	title: 'Source v4/source-react-components/InlineError',
+	component: InlineError,
+};
+
+export * from '../../../src-user-feedback/InlineError.stories';

--- a/packages/@guardian/source-react-components/src/stories/InlineSuccess.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/InlineSuccess.stories.tsx
@@ -1,8 +1,8 @@
-import { InlineSuccess } from '../../../src-user-feedback/InlineSuccess';
+import defaultStoryConfig from '../../../src-user-feedback/InlineSuccess.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/InlineSuccess',
-	component: InlineSuccess,
 };
 
 export * from '../../../src-user-feedback/InlineSuccess.stories';

--- a/packages/@guardian/source-react-components/src/stories/InlineSuccess.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/InlineSuccess.stories.tsx
@@ -1,0 +1,8 @@
+import { InlineSuccess } from '../../../src-user-feedback/InlineSuccess';
+
+export default {
+	title: 'Source v4/source-react-components/InlineSuccess',
+	component: InlineSuccess,
+};
+
+export * from '../../../src-user-feedback/InlineSuccess.stories';

--- a/packages/@guardian/source-react-components/src/stories/Label.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Label.stories.tsx
@@ -1,0 +1,13 @@
+import { Label } from '../../../src-label/Label';
+
+export default {
+	title: 'Source v4/source-react-components/Label',
+	args: {
+		text: 'Email',
+		optional: false,
+		hideLabel: false,
+	},
+	component: Label,
+};
+
+export * from '../../../src-label/Label.stories';

--- a/packages/@guardian/source-react-components/src/stories/Label.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Label.stories.tsx
@@ -1,13 +1,8 @@
-import { Label } from '../../../src-label/Label';
+import defaultStoryConfig from '../../../src-label/Label.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Label',
-	args: {
-		text: 'Email',
-		optional: false,
-		hideLabel: false,
-	},
-	component: Label,
 };
 
 export * from '../../../src-label/Label.stories';

--- a/packages/@guardian/source-react-components/src/stories/Legend.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Legend.stories.tsx
@@ -1,29 +1,8 @@
-import { Legend } from '../../../src-label/Legend';
+import defaultStoryConfig from '../../../src-label/Legend.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Legend',
-	args: {
-		text: 'Email',
-		supporting: 'undefined',
-		optional: false,
-		hideLabel: false,
-	},
-	argTypes: {
-		supporting: {
-			options: ['undefined', 'text', 'component'],
-			mapping: {
-				undefined: undefined,
-				text: 'alex@example.com',
-				component: (
-					<span role="img" aria-label="Image of a letter">
-						💌
-					</span>
-				),
-			},
-			control: { type: 'radio' },
-		},
-	},
-	component: Legend,
 };
 
 export * from '../../../src-label/Legend.stories';

--- a/packages/@guardian/source-react-components/src/stories/Legend.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Legend.stories.tsx
@@ -1,0 +1,29 @@
+import { Legend } from '../../../src-label/Legend';
+
+export default {
+	title: 'Source v4/source-react-components/Legend',
+	args: {
+		text: 'Email',
+		supporting: 'undefined',
+		optional: false,
+		hideLabel: false,
+	},
+	argTypes: {
+		supporting: {
+			options: ['undefined', 'text', 'component'],
+			mapping: {
+				undefined: undefined,
+				text: 'alex@example.com',
+				component: (
+					<span role="img" aria-label="Image of a letter">
+						💌
+					</span>
+				),
+			},
+			control: { type: 'radio' },
+		},
+	},
+	component: Legend,
+};
+
+export * from '../../../src-label/Legend.stories';

--- a/packages/@guardian/source-react-components/src/stories/Link.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Link.stories.tsx
@@ -1,0 +1,25 @@
+import { SvgExternal } from '@guardian/src-icons';
+import { Link } from '../../../src-link/Link';
+
+export default {
+	title: 'Source v4/source-react-components/Link',
+	component: Link,
+	args: {
+		priority: 'primary',
+		subdued: false,
+		icon: <SvgExternal />,
+		iconSide: 'left',
+	},
+	argTypes: {
+		icon: {
+			options: ['undefined', 'SvgExternal'],
+			mapping: {
+				undefined: undefined,
+				SvgExternal: <SvgExternal />,
+			},
+			control: { type: 'radio' },
+		},
+	},
+};
+
+export * from '../../../src-link/Link.stories';

--- a/packages/@guardian/source-react-components/src/stories/Link.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Link.stories.tsx
@@ -1,25 +1,8 @@
-import { SvgExternal } from '@guardian/src-icons';
-import { Link } from '../../../src-link/Link';
+import defaultStoryConfig from '../../../src-link/Link.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Link',
-	component: Link,
-	args: {
-		priority: 'primary',
-		subdued: false,
-		icon: <SvgExternal />,
-		iconSide: 'left',
-	},
-	argTypes: {
-		icon: {
-			options: ['undefined', 'SvgExternal'],
-			mapping: {
-				undefined: undefined,
-				SvgExternal: <SvgExternal />,
-			},
-			control: { type: 'radio' },
-		},
-	},
 };
 
 export * from '../../../src-link/Link.stories';

--- a/packages/@guardian/source-react-components/src/stories/LinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/LinkButton.stories.tsx
@@ -1,28 +1,8 @@
-import { SvgArrowRightStraight } from '@guardian/src-icons';
-import { LinkButton } from '../../../src-button/LinkButton';
+import defaultStoryConfig from '../../../src-button/LinkButton.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/LinkButton',
-	component: LinkButton,
-	argTypes: {
-		icon: {
-			options: ['undefined', 'arrow'],
-			mapping: {
-				undefined: undefined,
-				arrow: <SvgArrowRightStraight />,
-			},
-			control: { type: 'radio' },
-		},
-	},
-	args: {
-		children: 'Link Button',
-		size: 'default',
-		hideLabel: false,
-		icon: undefined,
-		priority: 'primary',
-		iconSide: 'left',
-		nudgeIcon: false,
-	},
 };
 
 export * from '../../../src-button/LinkButton.stories';

--- a/packages/@guardian/source-react-components/src/stories/LinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/LinkButton.stories.tsx
@@ -1,0 +1,28 @@
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { LinkButton } from '../../../src-button/LinkButton';
+
+export default {
+	title: 'Source v4/source-react-components/LinkButton',
+	component: LinkButton,
+	argTypes: {
+		icon: {
+			options: ['undefined', 'arrow'],
+			mapping: {
+				undefined: undefined,
+				arrow: <SvgArrowRightStraight />,
+			},
+			control: { type: 'radio' },
+		},
+	},
+	args: {
+		children: 'Link Button',
+		size: 'default',
+		hideLabel: false,
+		icon: undefined,
+		priority: 'primary',
+		iconSide: 'left',
+		nudgeIcon: false,
+	},
+};
+
+export * from '../../../src-button/LinkButton.stories';

--- a/packages/@guardian/source-react-components/src/stories/Radio.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Radio.stories.tsx
@@ -1,29 +1,8 @@
-import { Radio } from '../../../src-radio/Radio';
+import defaultStoryConfig from '../../../src-radio/Radio.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Radio',
-	component: Radio,
-	argTypes: {
-		label: {
-			control: {
-				type: 'text',
-			},
-		},
-		supporting: {
-			control: {
-				type: 'text',
-			},
-		},
-		cssOverrides: {
-			control: null,
-		},
-	},
-	args: {
-		label: 'Red',
-		value: 'red',
-		supporting: '',
-		checked: true,
-	},
 };
 
 export * from '../../../src-radio/Radio.stories';

--- a/packages/@guardian/source-react-components/src/stories/Radio.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Radio.stories.tsx
@@ -1,0 +1,29 @@
+import { Radio } from '../../../src-radio/Radio';
+
+export default {
+	title: 'Source v4/source-react-components/Radio',
+	component: Radio,
+	argTypes: {
+		label: {
+			control: {
+				type: 'text',
+			},
+		},
+		supporting: {
+			control: {
+				type: 'text',
+			},
+		},
+		cssOverrides: {
+			control: null,
+		},
+	},
+	args: {
+		label: 'Red',
+		value: 'red',
+		supporting: '',
+		checked: true,
+	},
+};
+
+export * from '../../../src-radio/Radio.stories';

--- a/packages/@guardian/source-react-components/src/stories/RadioGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/RadioGroup.stories.tsx
@@ -1,29 +1,8 @@
-import { Radio } from '../../../src-radio/Radio';
-import { RadioGroup } from '../../../src-radio/RadioGroup';
+import defaultStoryConfig from '../../../src-radio/RadioGroup.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/RadioGroup',
-	component: RadioGroup,
-	subcomponents: { Radio },
-	args: {
-		name: 'colours',
-		label: 'Select your preferred colour',
-		supporting: '',
-		hideLabel: false,
-		orientation: 'vertical',
-		error: '',
-	},
-	argTypes: {
-		// Override the control so that users can try entering a string in the Storybook canvas
-		supporting: {
-			control: {
-				type: 'text',
-			},
-		},
-		id: { control: null },
-		className: { control: null },
-		cssOverrides: { control: null },
-	},
 };
 
 export * from '../../../src-radio/RadioGroup.stories';

--- a/packages/@guardian/source-react-components/src/stories/RadioGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/RadioGroup.stories.tsx
@@ -1,0 +1,29 @@
+import { Radio } from '../../../src-radio/Radio';
+import { RadioGroup } from '../../../src-radio/RadioGroup';
+
+export default {
+	title: 'Source v4/source-react-components/RadioGroup',
+	component: RadioGroup,
+	subcomponents: { Radio },
+	args: {
+		name: 'colours',
+		label: 'Select your preferred colour',
+		supporting: '',
+		hideLabel: false,
+		orientation: 'vertical',
+		error: '',
+	},
+	argTypes: {
+		// Override the control so that users can try entering a string in the Storybook canvas
+		supporting: {
+			control: {
+				type: 'text',
+			},
+		},
+		id: { control: null },
+		className: { control: null },
+		cssOverrides: { control: null },
+	},
+};
+
+export * from '../../../src-radio/RadioGroup.stories';

--- a/packages/@guardian/source-react-components/src/stories/Select.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Select.stories.tsx
@@ -1,0 +1,36 @@
+import { Option } from '../../../src-select/Option';
+import { Select } from '../../../src-select/Select';
+
+export default {
+	title: 'Source v4/source-react-components/Select',
+	component: Select,
+	subcomponents: { Option },
+	argTypes: {
+		error: {
+			options: ['undefined', 'error'],
+			mapping: {
+				undefined: undefined,
+				error: 'Please select your home state. This service is unavailable outside of the US.',
+			},
+			control: { type: 'radio' },
+		},
+		success: {
+			options: ['undefined', 'success'],
+			mapping: {
+				undefined: undefined,
+				success: 'This service is available in your state',
+			},
+			control: { type: 'radio' },
+		},
+	},
+	args: {
+		label: 'State',
+		optional: false,
+		hideLabel: false,
+		supporting: '',
+		error: '',
+		success: '',
+	},
+};
+
+export * from '../../../src-select/Select.stories';

--- a/packages/@guardian/source-react-components/src/stories/Select.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Select.stories.tsx
@@ -1,36 +1,8 @@
-import { Option } from '../../../src-select/Option';
-import { Select } from '../../../src-select/Select';
+import defaultStoryConfig from '../../../src-select/Select.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Select',
-	component: Select,
-	subcomponents: { Option },
-	argTypes: {
-		error: {
-			options: ['undefined', 'error'],
-			mapping: {
-				undefined: undefined,
-				error: 'Please select your home state. This service is unavailable outside of the US.',
-			},
-			control: { type: 'radio' },
-		},
-		success: {
-			options: ['undefined', 'success'],
-			mapping: {
-				undefined: undefined,
-				success: 'This service is available in your state',
-			},
-			control: { type: 'radio' },
-		},
-	},
-	args: {
-		label: 'State',
-		optional: false,
-		hideLabel: false,
-		supporting: '',
-		error: '',
-		success: '',
-	},
 };
 
 export * from '../../../src-select/Select.stories';

--- a/packages/@guardian/source-react-components/src/stories/Stack.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Stack.stories.tsx
@@ -1,8 +1,8 @@
-import { Stack } from '../../../src-layout/Stack/Stack';
+import defaultStoryConfig from '../../../src-layout/Stack/Stack.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Stack',
-	component: Stack,
 };
 
 export * from '../../../src-layout/Stack/Stack.stories';

--- a/packages/@guardian/source-react-components/src/stories/Stack.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Stack.stories.tsx
@@ -1,0 +1,8 @@
+import { Stack } from '../../../src-layout/Stack/Stack';
+
+export default {
+	title: 'Source v4/source-react-components/Stack',
+	component: Stack,
+};
+
+export * from '../../../src-layout/Stack/Stack.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgGuardianLiveLogo.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgGuardianLiveLogo.stories.tsx
@@ -1,0 +1,13 @@
+import { SvgGuardianLiveLogo } from '../../../src-brand/SvgGuardianLiveLogo';
+
+export default {
+	title: 'Source v4/source-react-components/SvgGuardianLiveLogo',
+	component: SvgGuardianLiveLogo,
+	argTypes: {
+		width: {
+			control: { type: 'range', min: 10, max: 600 },
+		},
+	},
+};
+
+export * from '../../../src-brand/SvgGuardianLiveLogo.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgGuardianLiveLogo.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgGuardianLiveLogo.stories.tsx
@@ -1,13 +1,8 @@
-import { SvgGuardianLiveLogo } from '../../../src-brand/SvgGuardianLiveLogo';
+import defaultStoryConfig from '../../../src-brand/SvgGuardianLiveLogo.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/SvgGuardianLiveLogo',
-	component: SvgGuardianLiveLogo,
-	argTypes: {
-		width: {
-			control: { type: 'range', min: 10, max: 600 },
-		},
-	},
 };
 
 export * from '../../../src-brand/SvgGuardianLiveLogo.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgGuardianLogo.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgGuardianLogo.stories.tsx
@@ -1,0 +1,13 @@
+import { SvgGuardianLogo } from '../../../src-brand/SvgGuardianLogo';
+
+export default {
+	title: 'Source v4/source-react-components/SvgGuardianLogo',
+	component: SvgGuardianLogo,
+	argTypes: {
+		width: {
+			control: { type: 'range', min: 10, max: 600 },
+		},
+	},
+};
+
+export * from '../../../src-brand/SvgGuardianLogo.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgGuardianLogo.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgGuardianLogo.stories.tsx
@@ -1,13 +1,8 @@
-import { SvgGuardianLogo } from '../../../src-brand/SvgGuardianLogo';
+import defaultStoryConfig from '../../../src-brand/SvgGuardianLogo.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/SvgGuardianLogo',
-	component: SvgGuardianLogo,
-	argTypes: {
-		width: {
-			control: { type: 'range', min: 10, max: 600 },
-		},
-	},
 };
 
 export * from '../../../src-brand/SvgGuardianLogo.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelBrand.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelBrand.stories.tsx
@@ -1,0 +1,13 @@
+import { SvgRoundelBrand } from '../../../src-brand/SvgRoundelBrand';
+
+export default {
+	title: 'Source v4/source-react-components/SvgRoundelBrand',
+	component: SvgRoundelBrand,
+	argTypes: {
+		width: {
+			control: { type: 'range', min: 10, max: 600 },
+		},
+	},
+};
+
+export * from '../../../src-brand/SvgRoundelBrand.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelBrand.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelBrand.stories.tsx
@@ -1,13 +1,8 @@
-import { SvgRoundelBrand } from '../../../src-brand/SvgRoundelBrand';
+import defaultStoryConfig from '../../../src-brand/SvgRoundelBrand.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/SvgRoundelBrand',
-	component: SvgRoundelBrand,
-	argTypes: {
-		width: {
-			control: { type: 'range', min: 10, max: 600 },
-		},
-	},
 };
 
 export * from '../../../src-brand/SvgRoundelBrand.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelBrandInverse.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelBrandInverse.stories.tsx
@@ -1,13 +1,8 @@
-import { SvgRoundelBrandInverse } from '../../../src-brand/SvgRoundelBrandInverse';
+import defaultStoryConfig from '../../../src-brand/SvgRoundelBrandInverse.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/SvgRoundelBrandInverse',
-	component: SvgRoundelBrandInverse,
-	argTypes: {
-		width: {
-			control: { type: 'range', min: 10, max: 600 },
-		},
-	},
 };
 
 export * from '../../../src-brand/SvgRoundelBrandInverse.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelBrandInverse.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelBrandInverse.stories.tsx
@@ -1,0 +1,13 @@
+import { SvgRoundelBrandInverse } from '../../../src-brand/SvgRoundelBrandInverse';
+
+export default {
+	title: 'Source v4/source-react-components/SvgRoundelBrandInverse',
+	component: SvgRoundelBrandInverse,
+	argTypes: {
+		width: {
+			control: { type: 'range', min: 10, max: 600 },
+		},
+	},
+};
+
+export * from '../../../src-brand/SvgRoundelBrandInverse.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelDefault.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelDefault.stories.tsx
@@ -1,13 +1,8 @@
-import { SvgRoundelDefault } from '../../../src-brand/SvgRoundelDefault';
+import defaultStoryConfig from '../../../src-brand/SvgRoundelDefault.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/SvgRoundelDefault',
-	component: SvgRoundelDefault,
-	argTypes: {
-		width: {
-			control: { type: 'range', min: 10, max: 600 },
-		},
-	},
 };
 
 export * from '../../../src-brand/SvgRoundelDefault.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelDefault.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelDefault.stories.tsx
@@ -1,0 +1,13 @@
+import { SvgRoundelDefault } from '../../../src-brand/SvgRoundelDefault';
+
+export default {
+	title: 'Source v4/source-react-components/SvgRoundelDefault',
+	component: SvgRoundelDefault,
+	argTypes: {
+		width: {
+			control: { type: 'range', min: 10, max: 600 },
+		},
+	},
+};
+
+export * from '../../../src-brand/SvgRoundelDefault.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelInverse.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelInverse.stories.tsx
@@ -1,0 +1,13 @@
+import { SvgRoundelInverse } from '../../../src-brand/SvgRoundelInverse';
+
+export default {
+	title: 'Source v4/source-react-components/SvgRoundelInverse',
+	component: SvgRoundelInverse,
+	argTypes: {
+		width: {
+			control: { type: 'range', min: 10, max: 600 },
+		},
+	},
+};
+
+export * from '../../../src-brand/SvgRoundelInverse.stories';

--- a/packages/@guardian/source-react-components/src/stories/SvgRoundelInverse.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/SvgRoundelInverse.stories.tsx
@@ -1,13 +1,8 @@
-import { SvgRoundelInverse } from '../../../src-brand/SvgRoundelInverse';
+import defaultStoryConfig from '../../../src-brand/SvgRoundelInverse.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/SvgRoundelInverse',
-	component: SvgRoundelInverse,
-	argTypes: {
-		width: {
-			control: { type: 'range', min: 10, max: 600 },
-		},
-	},
 };
 
 export * from '../../../src-brand/SvgRoundelInverse.stories';

--- a/packages/@guardian/source-react-components/src/stories/TextArea.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/TextArea.stories.tsx
@@ -1,25 +1,8 @@
-import { TextArea } from '../../../src-text-area/TextArea';
+import defaultStoryConfig from '../../../src-text-area/TextArea.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/TextArea',
-	component: TextArea,
-	argTypes: {
-		error: {
-			options: ['undefined', 'error'],
-			mapping: {
-				undefined: undefined,
-				error: 'Please tell us your views',
-			},
-			control: { type: 'radio' },
-		},
-	},
-	args: {
-		label: 'Comments',
-		optional: false,
-		hideLabel: false,
-		supporting: '',
-		error: undefined,
-	},
 };
 
 export * from '../../../src-text-area/TextArea.stories';

--- a/packages/@guardian/source-react-components/src/stories/TextArea.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/TextArea.stories.tsx
@@ -1,0 +1,25 @@
+import { TextArea } from '../../../src-text-area/TextArea';
+
+export default {
+	title: 'Source v4/source-react-components/TextArea',
+	component: TextArea,
+	argTypes: {
+		error: {
+			options: ['undefined', 'error'],
+			mapping: {
+				undefined: undefined,
+				error: 'Please tell us your views',
+			},
+			control: { type: 'radio' },
+		},
+	},
+	args: {
+		label: 'Comments',
+		optional: false,
+		hideLabel: false,
+		supporting: '',
+		error: undefined,
+	},
+};
+
+export * from '../../../src-text-area/TextArea.stories';

--- a/packages/@guardian/source-react-components/src/stories/TextInput.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/TextInput.stories.tsx
@@ -1,0 +1,35 @@
+import { TextInput } from '../../../src-text-input/TextInput';
+
+export default {
+	title: 'Source v4/source-react-components/TextInput',
+	component: TextInput,
+	args: {
+		label: 'Email',
+		optional: false,
+		hideLabel: false,
+		supporting: '',
+		error: undefined,
+		success: undefined,
+	},
+	argTypes: {
+		error: {
+			options: ['undefined', 'error'],
+			mapping: {
+				undefined: undefined,
+				error: 'The email address entered is not valid',
+			},
+			control: { type: 'radio' },
+		},
+		success: {
+			options: ['undefined', 'success'],
+			mapping: {
+				undefined: undefined,
+				success: 'Your email address has been registered successfully',
+			},
+			control: { type: 'radio' },
+		},
+		id: { control: null },
+	},
+};
+
+export * from '../../../src-text-input/TextInput.stories';

--- a/packages/@guardian/source-react-components/src/stories/TextInput.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/TextInput.stories.tsx
@@ -1,35 +1,8 @@
-import { TextInput } from '../../../src-text-input/TextInput';
+import defaultStoryConfig from '../../../src-text-input/TextInput.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/TextInput',
-	component: TextInput,
-	args: {
-		label: 'Email',
-		optional: false,
-		hideLabel: false,
-		supporting: '',
-		error: undefined,
-		success: undefined,
-	},
-	argTypes: {
-		error: {
-			options: ['undefined', 'error'],
-			mapping: {
-				undefined: undefined,
-				error: 'The email address entered is not valid',
-			},
-			control: { type: 'radio' },
-		},
-		success: {
-			options: ['undefined', 'success'],
-			mapping: {
-				undefined: undefined,
-				success: 'Your email address has been registered successfully',
-			},
-			control: { type: 'radio' },
-		},
-		id: { control: null },
-	},
 };
 
 export * from '../../../src-text-input/TextInput.stories';

--- a/packages/@guardian/source-react-components/src/stories/Tiles.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Tiles.stories.tsx
@@ -1,0 +1,11 @@
+import { Tiles } from '../../../src-layout/Tiles/Tiles';
+
+export default {
+	title: 'Source v4/source-react-components/Tiles',
+	component: Tiles,
+	args: {
+		columns: '2',
+	},
+};
+
+export * from '../../../src-layout/Tiles/Tiles.stories';

--- a/packages/@guardian/source-react-components/src/stories/Tiles.stories.tsx
+++ b/packages/@guardian/source-react-components/src/stories/Tiles.stories.tsx
@@ -1,11 +1,8 @@
-import { Tiles } from '../../../src-layout/Tiles/Tiles';
+import defaultStoryConfig from '../../../src-layout/Tiles/Tiles.stories';
 
 export default {
+	...defaultStoryConfig,
 	title: 'Source v4/source-react-components/Tiles',
-	component: Tiles,
-	args: {
-		columns: '2',
-	},
 };
 
 export * from '../../../src-layout/Tiles/Tiles.stories';

--- a/scripts/story-sync/README.md
+++ b/scripts/story-sync/README.md
@@ -1,0 +1,11 @@
+# Story Sync
+
+This script is used to compare and sync the v3 and v4 stories during migration. Currently v4 stories just export everything from their v3 equivalents but override the name.
+
+You can run the scripts using:
+
+`yarn workspace story-sync compare`
+
+and
+
+`yarn workspace story-sync sync`

--- a/scripts/story-sync/compare.ts
+++ b/scripts/story-sync/compare.ts
@@ -14,7 +14,7 @@ const v4StoriesNotInV3 = v4Stories.filter(
 );
 
 if (v3StoriesNotInV4.length || v4StoriesNotInV3.length) {
-	console.error('v4 and v4 stories are out of sync');
+	console.error('v3 and v4 stories are out of sync');
 	if (v3StoriesNotInV4.length)
 		console.error(
 			'The following stories are present in v3 but not v4: ',

--- a/scripts/story-sync/compare.ts
+++ b/scripts/story-sync/compare.ts
@@ -1,0 +1,32 @@
+import { getV3Stories, getV4Stories } from './get-stories';
+
+console.log('Comparing v3 and v4 stories');
+
+const v3Stories = Object.keys(getV3Stories());
+const v4Stories = getV4Stories();
+
+const v3StoriesNotInV4 = v3Stories.filter(
+	(story) => !v4Stories.includes(story),
+);
+
+const v4StoriesNotInV3 = v4Stories.filter(
+	(story) => !v3Stories.includes(story),
+);
+
+if (v3StoriesNotInV4.length || v4StoriesNotInV3.length) {
+	console.error('v4 and v4 stories are out of sync');
+	if (v3StoriesNotInV4.length)
+		console.error(
+			'The following stories are present in v3 but not v4: ',
+			v3StoriesNotInV4.join(', '),
+		);
+	if (v4StoriesNotInV3.length)
+		console.error(
+			'The following stories are present in v4 but not v3: ',
+			v4StoriesNotInV3.join(', '),
+		);
+	process.exit(1);
+} else {
+	console.log('v3 and v4 stories are in sync');
+	process.exit(0);
+}

--- a/scripts/story-sync/config.ts
+++ b/scripts/story-sync/config.ts
@@ -1,0 +1,4 @@
+export const v4StoriesDirectory =
+	'../../packages/@guardian/source-react-components/src/stories';
+
+export const guardianPackagesDirectory = '../../packages/@guardian';

--- a/scripts/story-sync/get-stories.ts
+++ b/scripts/story-sync/get-stories.ts
@@ -1,0 +1,40 @@
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { guardianPackagesDirectory, v4StoriesDirectory } from './config';
+
+const getStoryFilesInDirectory = (dir: string) => {
+	let stories: Record<string, string> = {};
+
+	readdirSync(dir, { withFileTypes: true }).forEach((item) => {
+		if (item.name.endsWith('.stories.tsx'))
+			stories[item.name] = join(dir, item.name);
+		else if (item.isDirectory())
+			stories = {
+				...stories,
+				...getStoryFilesInDirectory(join(dir, item.name)),
+			};
+	});
+
+	return stories;
+};
+
+export const getV3Stories = () => {
+	const srcPackages = readdirSync(guardianPackagesDirectory)
+		.filter((pkg) => pkg.startsWith('src-'))
+		.reduce(
+			(stories, component) =>
+				(stories = {
+					...stories,
+					...getStoryFilesInDirectory(
+						join(guardianPackagesDirectory, component),
+					),
+				}),
+			{},
+		);
+
+	return srcPackages;
+};
+
+export const getV4Stories = () => {
+	return readdirSync(v4StoriesDirectory).sort();
+};

--- a/scripts/story-sync/package.json
+++ b/scripts/story-sync/package.json
@@ -7,12 +7,5 @@
   "scripts": {
     "compare": "ts-node ./compare.ts",
     "sync": "ts-node ./sync.ts"
-  },
-  "dependencies": {
-    "react-scanner": "^1.0.0",
-    "rimraf": "^3.0.2"
-  },
-  "devDependencies": {
-    "@types/rimraf": "^3.0.2"
   }
 }

--- a/scripts/story-sync/package.json
+++ b/scripts/story-sync/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "story-sync",
+  "version": "1.0.0",
+  "private": true,
+  "description": "This script compares and syncs the stories between v3 and v4",
+  "license": "Apache-2.0",
+  "scripts": {
+    "compare": "ts-node ./compare.ts",
+    "sync": "ts-node ./sync.ts"
+  },
+  "dependencies": {
+    "react-scanner": "^1.0.0",
+    "rimraf": "^3.0.2"
+  },
+  "devDependencies": {
+    "@types/rimraf": "^3.0.2"
+  }
+}

--- a/scripts/story-sync/sync.ts
+++ b/scripts/story-sync/sync.ts
@@ -1,0 +1,8 @@
+import { getV3Stories } from './get-stories';
+import { writeStories } from './write-stories';
+
+console.log('Syncing v3 and v4 stories');
+
+const v3Stories = getV3Stories();
+
+writeStories(v3Stories);

--- a/scripts/story-sync/write-stories.ts
+++ b/scripts/story-sync/write-stories.ts
@@ -1,0 +1,29 @@
+import { v4StoriesDirectory } from './config';
+import { join } from 'path';
+import { writeFileSync } from 'fs';
+
+const getStoryFileContents = (file: string, path: string) => {
+	const pathWithoutExtension = path.replace('.tsx', '');
+	const importPath = pathWithoutExtension.replace(
+		'../../packages/@guardian/',
+		'../../../',
+	);
+	return `import defaultStoryConfig from '${importPath}';
+
+export default {
+	...defaultStoryConfig,
+	title: 'Source v4/source-react-components/${file.split('.')[0]}',
+};
+
+export * from '${importPath}';
+`;
+};
+
+export const writeStories = (v3Stories: Record<string, string>) => {
+	Object.entries(v3Stories).forEach(([file, path]) => {
+		writeFileSync(
+			join(v4StoriesDirectory, file),
+			getStoryFileContents(file, path),
+		);
+	});
+};


### PR DESCRIPTION
## What is the purpose of this change?

This change adds stories for the v4 components so that the documentation is clear for users of the new `source-*` packages.

## What does this change?

- Update the title of kitchen stories to be `Source v4/source-react-components-development-kitchen/*`  
- Create story files for v4 that re-export everything from their v3 equivalents but with the correct v4 title
- Add a script to compare and sync the v3 and v4 stories
- Add a CI check to run the story comparison
