### PR TITLE
Refactor `Summary` components and add `InfoSummary` to kitchen

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
@@ -10,7 +10,7 @@ export default {
 	title: 'Kitchen/source-react-components-development-kitchen/Error Summary',
 	component: ErrorSummary,
 	args: {
-		error: 'There has been a problem',
+		message: 'There has been a problem',
 		context: '',
 		errorReportUrl: '',
 	} as ErrorSummaryProps,
@@ -29,7 +29,7 @@ asPlayground(Playground);
 
 export const ErrorOnly = Template.bind({});
 ErrorOnly.args = {
-	error: 'This is an example with an error message only',
+	message: 'This is an example with an error message only',
 };
 asChromaticStory(ErrorOnly);
 
@@ -37,16 +37,29 @@ asChromaticStory(ErrorOnly);
 
 export const WithContext = Template.bind({});
 WithContext.args = {
-	error: 'Here is an error',
+	message: 'Here is an error',
 	context: 'This is some more information about this error message',
 };
 asChromaticStory(WithContext);
 
 // *****************************************************************************
 
+export const WithContextAsReactNode = Template.bind({});
+WithContextAsReactNode.args = {
+	message: 'Here is an error',
+	context: (
+		<>
+			This is the context as a <b>ReactNode</b>
+		</>
+	),
+};
+asChromaticStory(WithContextAsReactNode);
+
+// *****************************************************************************
+
 export const WithReportLink = Template.bind({});
 WithReportLink.args = {
-	error: 'Here is an error',
+	message: 'Here is an error',
 	context: 'This is some more information about this error message',
 	errorReportUrl: 'https://www.theguardian.com/info/tech-feedback',
 };

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.tsx
@@ -1,6 +1,5 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { error as errorColors } from '@guardian/src-foundations';
-import type { Props } from '@guardian/src-helpers';
 import { SvgAlertTriangle } from '@guardian/src-icons';
 import {
 	contextStyles,
@@ -9,24 +8,17 @@ import {
 	messageWrapperStyles,
 	wrapperStyles,
 } from './styles';
+import type { SummaryProps } from '.';
 
-export interface ErrorSummaryProps extends Props {
-	/**
-	 * The main error message
-	 */
-	error: string;
+export interface ErrorSummaryProps extends SummaryProps {
 	/**
 	 * The error report link URL
 	 */
 	errorReportUrl?: string;
-	/**
-	 * Optional context information about the error
-	 */
-	context?: React.ReactNode | string;
 }
 
 export const ErrorSummary = ({
-	error,
+	message,
 	errorReportUrl,
 	context,
 	cssOverrides,
@@ -37,7 +29,7 @@ export const ErrorSummary = ({
 			<SvgAlertTriangle />
 		</div>
 		<div css={messageWrapperStyles}>
-			<div css={messageStyles(errorColors[400])}>{error}</div>
+			<div css={messageStyles(errorColors[400])}>{message}</div>
 			{errorReportUrl && (
 				<a
 					css={messageStyles(errorColors[400], false)}

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.stories.tsx
@@ -3,20 +3,20 @@ import {
 	asChromaticStory,
 	asPlayground,
 } from '../../../../../../lib/story-intents';
-import type { SuccessSummaryProps } from './SuccessSummary';
-import { SuccessSummary } from './SuccessSummary';
+import type { InfoSummaryProps } from './InfoSummary';
+import { InfoSummary } from './InfoSummary';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Success Summary',
-	component: SuccessSummary,
+	title: 'Kitchen/source-react-components-development-kitchen/Info Summary',
+	component: InfoSummary,
 	args: {
-		message: 'Your request was successful',
+		message: 'Here is some information',
 		context: '',
 	},
 };
 
-const Template: Story<SuccessSummaryProps> = (args: SuccessSummaryProps) => (
-	<SuccessSummary {...args} />
+const Template: Story<InfoSummaryProps> = (args: InfoSummaryProps) => (
+	<InfoSummary {...args} />
 );
 
 // *****************************************************************************
@@ -26,18 +26,18 @@ asPlayground(Playground);
 
 // *****************************************************************************
 
-export const SuccessOnly = Template.bind({});
-SuccessOnly.args = {
-	message: 'This is an example with a success message only',
+export const InfoOnly = Template.bind({});
+InfoOnly.args = {
+	message: 'This is an example with a info message only',
 };
-asChromaticStory(SuccessOnly);
+asChromaticStory(InfoOnly);
 
 // *****************************************************************************
 
 export const WithContext = Template.bind({});
 WithContext.args = {
-	message: 'It was successful',
-	context: 'This is some more information about this success message',
+	message: 'It was insightful',
+	context: 'This is some more information about this info message',
 };
 asChromaticStory(WithContext);
 
@@ -45,7 +45,7 @@ asChromaticStory(WithContext);
 
 export const WithContextAsReactNode = Template.bind({});
 WithContextAsReactNode.args = {
-	message: 'It was successful',
+	message: 'It was insightful',
 	context: (
 		<>
 			This is the context as a <b>ReactNode</b>

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.tsx
@@ -1,0 +1,30 @@
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { brand as brandColors, text } from '@guardian/src-foundations';
+import { SvgInfo } from '@guardian/src-icons';
+import {
+	contextStyles,
+	iconStyles,
+	messageStyles,
+	messageWrapperStyles,
+	wrapperStyles,
+} from './styles';
+import type { SummaryProps } from '.';
+
+export type InfoSummaryProps = SummaryProps;
+
+export const InfoSummary = ({
+	message,
+	context,
+	cssOverrides,
+	...props
+}: InfoSummaryProps): EmotionJSX.Element => (
+	<div css={[wrapperStyles(brandColors[500]), cssOverrides]} {...props}>
+		<div css={iconStyles(brandColors[500])}>
+			<SvgInfo />
+		</div>
+		<div css={messageWrapperStyles}>
+			<div css={messageStyles(text.primary)}>{message}</div>
+			{context && <div css={contextStyles}>{context}</div>}
+		</div>
+	</div>
+);

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/README.md
@@ -2,7 +2,7 @@
 
 Summary messages appear at the top of a group of content to summarise any actions that the user has taken or errors that have occurred.
 
-There are two components available, `ErrorSummary` and `SuccessSummary`.
+There are three components available, `ErrorSummary`, `SuccessSummary`, and `InfoSummary`.
 
 ## Install
 
@@ -27,6 +27,10 @@ See [storybook](https://guardian.github.io/source/?path=/docs/kitchen-source-rea
 #### `Success Summary`
 
 See [storybook](https://guardian.github.io/source/?path=/docs/kitchen-source-react-components-development-kitchen-success-summary--playground)
+
+#### `Info Summary`
+
+See [storybook](https://guardian.github.io/source/?path=/docs/kitchen-source-react-components-development-kitchen-info-summary--playground)
 
 ### How to use
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.tsx
@@ -1,6 +1,5 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { success as successColors } from '@guardian/src-foundations';
-import type { Props } from '@guardian/src-helpers';
 import { SvgTickRound } from '@guardian/src-icons';
 import {
 	contextStyles,
@@ -9,20 +8,12 @@ import {
 	messageWrapperStyles,
 	wrapperStyles,
 } from './styles';
+import type { SummaryProps } from '.';
 
-export interface SuccessSummaryProps extends Props {
-	/**
-	 * The main success message
-	 */
-	success: string;
-	/**
-	 * Optional context information about the success
-	 */
-	context?: string;
-}
+export type SuccessSummaryProps = SummaryProps;
 
 export const SuccessSummary = ({
-	success,
+	message,
 	context,
 	cssOverrides,
 	...props
@@ -32,7 +23,7 @@ export const SuccessSummary = ({
 			<SvgTickRound />
 		</div>
 		<div css={messageWrapperStyles}>
-			<div css={messageStyles(successColors[400])}>{success}</div>
+			<div css={messageStyles(successColors[400])}>{message}</div>
 			{context && <div css={contextStyles}>{context}</div>}
 		</div>
 	</div>

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/index.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/index.tsx
@@ -1,4 +1,20 @@
+import type { Props } from '@guardian/src-helpers';
+
+export interface SummaryProps extends Props {
+	/**
+	 * The main message of the component
+	 * e.g. the main error message, success message etc.
+	 */
+	message: string;
+	/**
+	 * Optional context information about the message
+	 */
+	context?: React.ReactNode;
+}
+
 export type { ErrorSummaryProps } from './ErrorSummary';
 export { ErrorSummary } from './ErrorSummary';
 export type { SuccessSummaryProps } from './SuccessSummary';
 export { SuccessSummary } from './SuccessSummary';
+export type { InfoSummaryProps } from './InfoSummary';
+export { InfoSummary } from './InfoSummary';

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.ts
@@ -22,10 +22,15 @@ export type { HeadlineSize, QuoteIconProps } from './components/quote-icon';
 export { StarRating } from './components/star-rating';
 export type { StarRatingProps } from './components/star-rating';
 
-export { ErrorSummary, SuccessSummary } from './components/summary';
+export {
+	ErrorSummary,
+	SuccessSummary,
+	InfoSummary,
+} from './components/summary';
 export type {
 	ErrorSummaryProps,
 	SuccessSummaryProps,
+	InfoSummaryProps,
 } from './components/summary';
 
 export { ToggleSwitch } from './components/toggle-switch';

--- a/scripts/validate-dist/source-package-exports.test.ts
+++ b/scripts/validate-dist/source-package-exports.test.ts
@@ -84,6 +84,7 @@ describe('No exports have changed in the ', () => {
 				'EditorialButton',
 				'EditorialLinkButton',
 				'ErrorSummary',
+				'InfoSummary',
 				'Lines',
 				'Logo',
 				'QuoteIcon',


### PR DESCRIPTION
## What is the purpose of this change?

![chrome_7lYscBgRp2](https://user-images.githubusercontent.com/13315440/139707927-a0898058-0f4b-4658-be41-cbd80428bdca.png)

To add a component which summarizes information that isn't a success or error message.

Also refactor the summary components so that props are shared between them

## What does this change?

- Refactor `Summary` shared props into single `SummaryProps`
  - Update `SuccessSummary` and `ErrorSummary` to use `SummaryProps`
  - **Breaking Change**: the messages for the components `success` and `error` are now just `message`
- Add `InfoSummary` component
  - Similar to `ErrorSummary` and `SuccessSummary`, but a neutral kind

## Screenshots
![localhost_6006_iframe html_id=kitchen-source-react-components-development-kitchen-info-summary--with-context-as-react-node args= viewMode=story(Pixel 2)](https://user-images.githubusercontent.com/13315440/139709208-b3279696-0930-4fa7-9f6b-21df8a1dac40.png)


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
