### PR TITLE
Add docstrings for typography

### DIFF
--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -31,6 +31,12 @@ type TypographyApi<Sizes> = {
 	[key in keyof Sizes]: FontScaleFunctionStr;
 };
 
+/**
+ * Titlepiece is a whole load of love.
+ * The return value is 'baz' in all cases.
+ * @param {*} bar - Any argument
+ * @param {string} [optionalArg] - An optional argument that is a string
+ */
 const titlepiece = Object.fromEntries(
 	Object.entries(titlepieceAsObj).map(([key, func]) => {
 		return [

--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -32,7 +32,7 @@ type TypographyApi<Sizes> = {
 };
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#titlepiece) •
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-typography--page#titlepiece) •
  * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/358767)
  *
  * ```
@@ -55,7 +55,7 @@ const titlepiece = Object.fromEntries(
 ) as TypographyApi<TitlepieceSizes>;
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#headline) •
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-typography--page#headline) •
  * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/7310bd)
  *
  * ```
@@ -86,7 +86,7 @@ const headline = Object.fromEntries(
 ) as TypographyApi<HeadlineSizes>;
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#body) •
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-typography--page#body) •
  * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/88cd8e)
  *
  * ```
@@ -107,7 +107,7 @@ const body = Object.fromEntries(
 ) as TypographyApi<BodySizes>;
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#text-sans) •
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-typography--page#text-sans) •
  * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/076605)
  *
  * ```

--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -32,10 +32,18 @@ type TypographyApi<Sizes> = {
 };
 
 /**
- * Titlepiece is a whole load of love.
- * The return value is 'baz' in all cases.
- * @param {*} bar - Any argument
- * @param {string} [optionalArg] - An optional argument that is a string
+ * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#titlepiece) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/358767)
+ *
+ * ```
+ * font-family: 'GT Guardian Titlepiece';
+ * ```
+ *
+ * `titlepiece.small()` -> 42px
+ *
+ * `titlepiece.medium()` -> 50px
+ *
+ * `titlepiece.large()` -> 70px
  */
 const titlepiece = Object.fromEntries(
 	Object.entries(titlepieceAsObj).map(([key, func]) => {

--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -54,6 +54,28 @@ const titlepiece = Object.fromEntries(
 	}),
 ) as TypographyApi<TitlepieceSizes>;
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#headline) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/7310bd)
+ *
+ * ```
+ * font-family: 'GH Guardian Headline';
+ * ```
+ *
+ * `headline.xxxsmall()` -> 17px
+ *
+ * `headline.xxsmall()` -> 20px
+ *
+ * `headline.xsmall()` -> 24px
+ *
+ * `headline.small()` -> 28px
+ *
+ * `headline.medium()` -> 34px
+ *
+ * `headline.large()` -> 42px
+ *
+ * `headline.xlarge()` -> 50px
+ */
 const headline = Object.fromEntries(
 	Object.entries(headlineAsObj).map(([key, func]) => {
 		return [
@@ -63,6 +85,18 @@ const headline = Object.fromEntries(
 	}),
 ) as TypographyApi<HeadlineSizes>;
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#body) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/88cd8e)
+ *
+ * ```
+ * font-family: 'GuardianTextEgyptian';
+ * ```
+ *
+ * `body.small()` -> 15px
+ *
+ * `body.medium()` -> 17px
+ */
 const body = Object.fromEntries(
 	Object.entries(bodyAsObj).map(([key, func]) => {
 		return [
@@ -72,6 +106,30 @@ const body = Object.fromEntries(
 	}),
 ) as TypographyApi<BodySizes>;
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/foundations-typography--page#text-sans) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/602314-typography/t/076605)
+ *
+ * ```
+ * font-family: 'GuardianTextSans';
+ * ```
+ *
+ * `textSans.xxsmall()` -> 12px
+ *
+ * `textSans.xsmall()` -> 14px
+ *
+ * `textSans.small()` -> 15px
+ *
+ * `textSans.medium()` -> 17px
+ *
+ * `textSans.large()` -> 20px
+ *
+ * `textSans.xlarge()` -> 24px
+ *
+ * `textSans.xxlarge()` -> 28px
+ *
+ * `textSans.xxxlarge()` -> 34px
+ */
 const textSans = Object.fromEntries(
 	Object.entries(textSansAsObj).map(([key, func]) => {
 		return [

--- a/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -41,6 +41,12 @@ const h1 = {
 };
 ```
 
+## Where can I find The Guardian's fonts?
+
+The canonical source of fonts is https://github.com/guardian/fonts
+
+They should be loaded from the locations specified in [font-faces.css](https://github.com/guardian/fonts/blob/main/fonts/web/font-faces.css). This optimises for consistency and performance across The Guardian's digital products.
+
 ## Sizing scale
 
 A range of font sizes are available for each font family. The `medium` font size
@@ -50,6 +56,12 @@ Pixel values are given below for ease of understanding, but by default the
 typography API assigns font size in rems.
 
 ### Headline
+
+```css
+font-family: 'GH Guardian Headline';
+```
+
+For headlines, headings and any short form text, like standfirst, pull quotes, bylines and titles.
 
 -   `headline.xxxsmall()` -> 17px
 -   `headline.xxsmall()` -> 20px
@@ -61,10 +73,24 @@ typography API assigns font size in rems.
 
 ### Body
 
+```css
+font-family: 'GuardianTextEgyptian';
+```
+
+For multiple sentences/paragraphs of text, like the body copy in articles, or paragraphs of text on marketing pages.
+
 -   `body.small()` -> 15px
 -   `body.medium()` -> 17px
 
 ### Text sans
+
+```css
+font-family: 'GuardianTextSans';
+```
+
+For interactive page elements like buttons and text input fields and for meta information like datelines, image captions and data visualisations.
+
+Note: Text Sans is used across the board on paid content templates to help differentiate from editorial content.
 
 -   `textSans.xxsmall()` -> 12px
 -   `textSans.xsmall()` -> 14px
@@ -74,6 +100,18 @@ typography API assigns font size in rems.
 -   `textSans.xlarge()` -> 24px
 -   `textSans.xxlarge()` -> 28px
 -   `textSans.xxxlarge()` -> 34px
+
+### Titlepiece
+
+```css
+font-family: 'GT Guardian Titlepiece';
+```
+
+For impact. Ideal for marketing messages, page headers and numerals. Use sparingly and at large sizes only.
+
+-   `titlepiece.small()` -> 42px
+-   `titlepiece.medium()` -> 50px
+-   `titlepiece.large()` -> 70px
 
 ## Options
 


### PR DESCRIPTION
## What is the purpose of this change?

It would be useful to have inline documentation for our Foundations' API. This will allow developers to see API documentation within their editor while they are using the API (see screenshots below)

## What does this change?

-   Add docstrings for headline, body, textSans and titlepiece
-   Link typography docs to our fonts repo
-   Add usage guidance and font families to typography API documentation

## Screenshots

**Titlepiece**

<img width="824" alt="Screenshot 2021-11-02 at 14 23 15" src="https://user-images.githubusercontent.com/5931528/139866761-429a57fe-a2d9-4516-923a-6199ae5bd00d.png">

**Headline**

<img width="679" alt="Screenshot 2021-11-02 at 14 40 37" src="https://user-images.githubusercontent.com/5931528/139869165-55039759-8a02-496d-874b-0acc0b2b22e7.png">
