### PR TITLE
Fix errors with hash links on docs pages

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -32,6 +32,7 @@ let currentPage = window.location.href;
 window.setInterval(() => {
 	if (window.location.href !== currentPage) {
 		currentPage = window.location.href;
+		if (currentPage.includes('#')) return;
 		try {
 			// Find all buttons containing the text Docs within the <div role="main"> tag
 			const docsButtonSelector = window.parent.document.evaluate(

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -51,3 +51,16 @@ window.setInterval(() => {
 		}
 	}
 }, 500);
+
+// The docs pages don't seem to respect the anchor links on load so this
+// ensures they do. This may be related to the fact that window.location.hash
+// isn't set on first page load, hence we're getting it from window.parent.location.hash
+// Something else is also going on to affect scroll, hence the need for the timeout (sorry!)
+window.addEventListener('load', () => {
+	if (window.location.hash !== window.parent.location.hash) {
+		setTimeout(
+			() => (window.location.hash = window.parent.location.hash),
+			10,
+		);
+	}
+});

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -32,7 +32,7 @@ let currentPage = window.location.href;
 window.setInterval(() => {
 	if (window.location.href !== currentPage) {
 		currentPage = window.location.href;
-		if (currentPage.includes('#')) return;
+		if (window.location.hash) return;
 		try {
 			// Find all buttons containing the text Docs within the <div role="main"> tag
 			const docsButtonSelector = window.parent.document.evaluate(


### PR DESCRIPTION
## What is the purpose of this change?

Currently when clicking an anchor link, the url shown in the browser is not updated accordingly. When navigating to a URL that includes a hash link, this is not respected. This PR fixes those problems. 

## What does this change?

-   Don't try and click the Docs button if the URL contains a hash
-   Set the `window.location.hash` value on page load
