### PR TITLE
feat: change text colour of input with error to be neutral.7

### DIFF
--- a/packages/@guardian/source-foundations/src/palette.ts
+++ b/packages/@guardian/source-foundations/src/palette.ts
@@ -289,6 +289,7 @@ export const text = {
 	anchorSecondary: neutral[7],
 	userInput: neutral[7],
 	inputLabel: neutral[7],
+	inputError: neutral[7],
 	inputLabelSupporting: neutral[46],
 	inputChecked: brand[400], //choice card only
 	inputHover: brand[400], //choice card only

--- a/packages/@guardian/src-foundations/src/themes/text-input.ts
+++ b/packages/@guardian/src-foundations/src/themes/text-input.ts
@@ -7,7 +7,7 @@ export const textInputDefault = {
 		textLabel: text.inputLabel,
 		textLabelOptional: text.supporting,
 		textLabelSupporting: text.supporting,
-		textError: text.error,
+		textError: text.inputError,
 		textSuccess: text.success,
 		backgroundInput: background.input,
 		border: border.input,


### PR DESCRIPTION
## What is the purpose of this change?
After checking internally with design & ux I'm making this change to the input error text so that it's `neutral.7` instead of `error.400`

## Before
<img width="452" alt="Screenshot 2021-11-04 at 12 03 05" src="https://user-images.githubusercontent.com/1771189/140310263-ec74e609-806f-4bc2-b9da-9d3634e0c829.png">

## After
<img width="420" alt="Screenshot 2021-11-04 at 12 01 19" src="https://user-images.githubusercontent.com/1771189/140310272-4ee66a0e-c732-430b-963f-d49e399a0168.png">
