### PR TITLE
Foundations docstrings

### DIFF
--- a/packages/@guardian/source-foundations/src/accessibility.ts
+++ b/packages/@guardian/source-foundations/src/accessibility.ts
@@ -31,7 +31,7 @@ export const focusHalo = `
 `;
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-accessibility-helpers--page#focus-halo)
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-accessibility-helpers--page#description-id)
  *
  * Takes the ID of an element and generates a new ID. This should be set as the ID of an element that describes the first element. The generated ID should also be passed to the `aria-describedby` attribute on the first element.
  *

--- a/packages/@guardian/source-foundations/src/accessibility.ts
+++ b/packages/@guardian/source-foundations/src/accessibility.ts
@@ -4,6 +4,11 @@
 
 import { border } from './palette';
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-accessibility-helpers--page#visually-hidden-elements)
+ *
+ * For elements that need to be hidden from sighted users and displayed to screen reader users.
+ */
 export const visuallyHidden = `
 	position: absolute;
 	opacity: 0;
@@ -13,6 +18,11 @@ export const visuallyHidden = `
 	left: 0;
 `;
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-accessibility-helpers--page#focus-halo)
+ *
+ * Provides a clear focus state to support keyboard navigation.
+ */
 export const focusHalo = `
 	outline: 0;
 	html:not(.src-focus-disabled) & {
@@ -20,6 +30,20 @@ export const focusHalo = `
 	}
 `;
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-accessibility-helpers--page#focus-halo)
+ *
+ * Takes the ID of an element and generates a new ID. This should be set as the ID of an element that describes the first element. The generated ID should also be passed to the `aria-describedby` attribute on the first element.
+ *
+ * @param {string} id - ID of an element
+ * @returns {string} ID of an element that describes the first element
+ *
+ * @example
+ *		<form>
+ *			<input id={id} type="text" aria-describedby={descriptionId(id)} />
+ *			<p class="error" id={descriptionId(id)} />
+ *		</form>
+ */
 export const descriptionId = (id: string): string => `${id}_description`;
 
 let sourceIdIndex = 0;

--- a/packages/@guardian/source-foundations/src/breakpoints.ts
+++ b/packages/@guardian/source-foundations/src/breakpoints.ts
@@ -12,6 +12,27 @@ export type Breakpoint =
 	| 'leftCol'
 	| 'wide';
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-media-queries--page#breakpoints) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/41be19-grids)
+ *
+ *	`breakpoints.mobile` -> 320px
+ *
+ *	`breakpoints.mobileMedium` -> 375px
+ *
+ *	`breakpoints.mobileLandscape` -> 480px
+ *
+ *	`breakpoints.phablet` -> 660px
+ *
+ *	`breakpoints.tablet` -> 740px
+ *
+ *	`breakpoints.desktop` -> 980px
+ *
+ *	`breakpoints.leftCol` -> 1140px
+ *
+ *	`breakpoints.wide` -> 1300px
+ *
+ */
 export const breakpoints = {
 	mobile: 320,
 	mobileMedium: 375,

--- a/packages/@guardian/source-foundations/src/mq.ts
+++ b/packages/@guardian/source-foundations/src/mq.ts
@@ -17,7 +17,16 @@ const maxWidth = (until: number): string =>
 const minWidthMaxWidth = (from: number, until: number): string =>
 	`@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
 
-// e.g. from.*
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-media-queries--page#from)
+ *
+ * @example
+ *	const styles = css`
+ *		${from.mobileLandscape} {
+ *			padding: 0 20px;
+ *		}
+ * `;
+ */
 export const from: BreakpointMap = {
 	mobile: minWidth(breakpoints.mobile),
 	mobileMedium: minWidth(breakpoints.mobileMedium),
@@ -29,7 +38,16 @@ export const from: BreakpointMap = {
 	wide: minWidth(breakpoints.wide),
 };
 
-// e.g. until.*
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-media-queries--page#until)
+ *
+ * @example
+ *	const styles = css`
+ *		${until.wide} {
+ *			padding: 0 40px;
+ *		}
+ * `;
+ */
 export const until: BreakpointMap = {
 	mobile: maxWidth(breakpoints.mobile),
 	mobileMedium: maxWidth(breakpoints.mobileMedium),
@@ -41,7 +59,16 @@ export const until: BreakpointMap = {
 	wide: maxWidth(breakpoints.wide),
 };
 
-// e.g. between.*.and.*
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-media-queries--page#betweenand)
+ *
+ * @example
+ *	const styles = css`
+ *		${between.phablet.and.desktop} {
+ *			padding: 0 32px;
+ *		}
+ * `;
+ */
 export const between = {
 	mobile: {
 		and: {

--- a/packages/@guardian/source-foundations/src/palette.ts
+++ b/packages/@guardian/source-foundations/src/palette.ts
@@ -98,6 +98,12 @@ const colors = {
 	],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/66411c)
+ *
+ * Our core brand colour – `brand[400]` – and extended brand colours
+ */
 export const brand = {
 	100: colors.blues[7],
 	300: colors.blues[8],
@@ -106,11 +112,25 @@ export const brand = {
 	600: colors.blues[11],
 	800: colors.blues[12],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/32d461)
+ *
+ * Our alternative brand colours
+ */
 export const brandAlt = {
 	200: colors.yellows[0],
 	300: colors.yellows[1],
 	400: colors.yellows[2],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/70dd5c)
+ *
+ * Neutral colours
+ */
 export const neutral = {
 	0: colors.grays[0],
 	7: colors.grays[1],
@@ -123,14 +143,35 @@ export const neutral = {
 	97: colors.grays[8],
 	100: colors.grays[9],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/98b901)
+ *
+ * Error colours
+ */
 export const error = {
 	400: colors.reds[3],
 	500: colors.reds[5],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/82798f)
+ *
+ * Success colours
+ */
 export const success = {
 	400: colors.greens[1],
 	500: colors.greens[2],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/97d77e)
+ *
+ * News colours
+ */
 export const news = {
 	100: colors.reds[0],
 	200: colors.reds[1],
@@ -141,6 +182,13 @@ export const news = {
 	600: colors.reds[6],
 	800: colors.reds[7],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/0539ef)
+ *
+ * Opinion colours
+ */
 export const opinion = {
 	100: colors.oranges[0],
 	200: colors.oranges[1],
@@ -151,6 +199,13 @@ export const opinion = {
 	600: colors.oranges[6],
 	800: colors.oranges[7],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/957a45)
+ *
+ * Sport colours
+ */
 export const sport = {
 	100: colors.blues[0],
 	200: colors.blues[1],
@@ -160,6 +215,13 @@ export const sport = {
 	600: colors.blues[5],
 	800: colors.blues[6],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/068eb2)
+ *
+ * Culture colours
+ */
 export const culture = {
 	50: colors.browns[0],
 	100: colors.browns[1],
@@ -172,6 +234,13 @@ export const culture = {
 	700: colors.browns[8],
 	800: colors.browns[9],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/2236b4)
+ *
+ * Lifestyle colours
+ */
 export const lifestyle = {
 	100: colors.pinks[0],
 	200: colors.pinks[1],
@@ -181,12 +250,25 @@ export const lifestyle = {
 	600: colors.pinks[5],
 	800: colors.pinks[6],
 };
+
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/59b08c)
+ *
+ * Labs colours
+ */
 export const labs = {
 	200: colors.greens[3],
 	300: colors.greens[4],
 	400: colors.greens[5],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/31c634)
+ *
+ * Special report colours
+ */
 export const specialReport = {
 	100: colors.grays[10],
 	200: colors.grays[11],
@@ -198,6 +280,12 @@ export const specialReport = {
 	800: colors.grays[17],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/492a30-light-palette/t/188e86)
+ *
+ * Focus state colour
+ */
 export const focus = {
 	400: colors.blues[13],
 };
@@ -205,6 +293,12 @@ export const focus = {
 // Hover colours are snowflakes as they are manipulations of colours from the
 // main palette.
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/9280ee)
+ *
+ * Default theme background colours
+ */
 export const background = {
 	primary: neutral[100],
 	secondary: neutral[97],
@@ -218,6 +312,12 @@ export const background = {
 	inputChecked: brand[500],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/63cc10)
+ *
+ * Brand theme background colours
+ */
 export const brandBackground = {
 	primary: brand[400],
 	inputChecked: neutral[100],
@@ -228,6 +328,12 @@ export const brandBackground = {
 	ctaTertiaryHover: brand[300],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/743232)
+ *
+ * Alternative brand theme background colours
+ */
 export const brandAltBackground = {
 	primary: brandAlt[400],
 	ctaPrimary: neutral[7],
@@ -237,6 +343,12 @@ export const brandAltBackground = {
 	ctaTertiaryHover: '#FFD213',
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/69c92f)
+ *
+ * Default theme border colours
+ */
 export const border = {
 	primary: neutral[60],
 	secondary: neutral[86],
@@ -250,6 +362,12 @@ export const border = {
 	focusHalo: focus[400],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/04883b)
+ *
+ * Brand theme border colours
+ */
 export const brandBorder = {
 	primary: brand[600],
 	secondary: brand[600],
@@ -261,22 +379,52 @@ export const brandBorder = {
 	inputHover: neutral[100],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/b/21c6cc)
+ *
+ * Alternative brand theme border colours
+ */
 export const brandAltBorder = {
 	ctaTertiary: neutral[7],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/593cc9)
+ *
+ * Default theme line colours
+ */
 export const line = {
 	primary: neutral[86],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/66455d)
+ *
+ * Brand theme line colours
+ */
 export const brandLine = {
 	primary: brand[600],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/89955e)
+ *
+ * Alternative brand theme line colours
+ */
 export const brandAltLine = {
 	primary: neutral[7],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/85d3b0)
+ *
+ * Default theme text colours
+ */
 export const text = {
 	primary: neutral[7],
 	supporting: neutral[46],
@@ -297,6 +445,12 @@ export const text = {
 	newsInverse: news[550],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/244480)
+ *
+ * Brand theme text colours
+ */
 export const brandText = {
 	primary: neutral[100],
 	supporting: brand[800],
@@ -312,6 +466,12 @@ export const brandText = {
 	inputLabelSupporting: brand[800],
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/11d5fd)
+ *
+ * Alternative brand theme text colours
+ */
 export const brandAltText = {
 	primary: neutral[7],
 	supporting: neutral[60],

--- a/packages/@guardian/source-foundations/src/size.stories.mdx
+++ b/packages/@guardian/source-foundations/src/size.stories.mdx
@@ -38,27 +38,26 @@ Tokens on the `height` and `width` objects return `px` values. The equivalent
 `rem` values for each token are available from `remHeight` and `remWidth`.
 
 -   `height.ctaMedium`: call to action buttons and links. This size
-    meets the [WCAG 2.1 AAA success criterion for target size](https://www.w3.org/TR/WCAG21/#target-size).
+    meets the [WCAG 2.1 AAA success criterion for target size](https://www.w3.org/TR/WCAG21/#target-size)
 -   `height.ctaSmall`: secondary calls to action that need less visual
     prominance or where there is limited space.
 -   `height.ctaXsmall`: calls to action where there is very
-    limited space.
+    limited space
 -   `height.inputMedium`: single-line text input fields, as well as
     radio and checkbox labels
 -   `height.inputXsmall`: checkable components such as checkboxes or
-    radio buttons.
+    radio buttons
 -   `height.iconMedium`
 -   `height.iconSmall`
 -   `height.iconXsmall`
--   `width.ctaMedium`: medium height call to action buttons and links w
-    hen there is no visible text (e.g. icon only buttons)
+-   `width.ctaMedium`: medium height call to action buttons and links when there is no visible text (e.g. icon only buttons)
 -   `width.ctaSmall`: small height call to action buttons and links when
     there is no visible text (e.g. icon only buttons)
 -   `width.ctaXsmall`: extra small height call to action buttons and
     links when there is no visible text (e.g. icon only buttons)
 -   `width.inputMedium`
 -   `width.inputXsmall`: checkable components such as checkboxes or
-    radio buttons.
+    radio buttons
 -   `width.iconMedium`
 -   `width.iconSmall`
 -   `width.iconXsmall`

--- a/packages/@guardian/source-foundations/src/size.ts
+++ b/packages/@guardian/source-foundations/src/size.ts
@@ -4,17 +4,32 @@
 
 import { pxToRem } from './utils/px-to-rem';
 
-/*
-   The size scale is based entirely on the medium, small and
-   xsmall buttons. The medium size meets WCAG 2.1 AAA compliance
-   for touch targets.
-*/
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#global-size-values) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/24a3ec-size/t/329aef)
+ *
+ * May be used for call to action buttons and user input fields.
+ *
+ ** `size.medium` -> 44px
+ ** `size.small` -> 36px
+ ** `size.xsmall` -> 24px
+ */
 export const size = {
 	xsmall: 24,
 	small: 36,
-	medium: 44,
+	medium: 44, // meets WCAG 2.1 AAA compliance for touch targets.
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#global-size-values) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/24a3ec-size/t/329aef)
+ *
+ * May be used for call to action buttons and user input fields.
+ *
+ ** `remSize.medium` -> 2.75rem
+ ** `remSize.small` -> 2.25rem
+ ** `remSize.xsmall` -> 1.5rem
+ */
 const remSize: { [K in keyof typeof size]: number } = {
 	xsmall: pxToRem(size.xsmall),
 	small: pxToRem(size.small),
@@ -39,6 +54,21 @@ const remIconSize: { [K in keyof typeof iconSize]: number } = {
 	medium: pxToRem(iconSize.medium),
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#tokens) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/24a3ec-size/t/329aef)
+ *
+ * Height tokens expressed in px
+ *
+ ** `height.ctaMedium`: call to action buttons and links
+ ** `height.ctaSmall`: secondary calls to action
+ ** `height.ctaXsmall`: calls to action where there is very limited space
+ ** `height.inputMedium`: text input fields, radio and checkbox labels
+ ** `height.inputXsmall`: checkables such as checkboxes or radio buttons
+ ** `height.iconMedium`
+ ** `height.iconSmall`
+ ** `height.iconXsmall`
+ */
 export const height = {
 	ctaMedium: size.medium,
 	ctaSmall: size.small,
@@ -50,6 +80,21 @@ export const height = {
 	iconXsmall: iconSize.xsmall,
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#tokens) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/24a3ec-size/t/329aef)
+ *
+ * Height tokens expressed in rem
+ *
+ ** `remHeight.ctaMedium`: call to action buttons and links
+ ** `remHeight.ctaSmall`: secondary calls to action
+ ** `remHeight.ctaXsmall`: calls to action where there is very limited space
+ ** `remHeight.inputMedium`: text input fields, radio and checkbox labels
+ ** `remHeight.inputXsmall`: checkables such as checkboxes or radio buttons
+ ** `remHeight.iconMedium`
+ ** `remHeight.iconSmall`
+ ** `remHeight.iconXsmall`
+ */
 export const remHeight = {
 	ctaMedium: remSize.medium,
 	ctaSmall: remSize.small,
@@ -61,6 +106,23 @@ export const remHeight = {
 	iconXsmall: remIconSize.xsmall,
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#tokens) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/00ddcb-tokens/t/797660)
+ *
+ * Width tokens expressed in px
+ *
+ ** `width.ctaMedium`: medium height call to action buttons and links
+ ** `width.ctaSmall`: small height call to action buttons and links
+ ** `width.ctaXsmall`: xsmall height call to action buttons and links
+ ** `width.inputMedium`: text input fields, radio and checkbox labels
+ ** `width.inputXsmall`: checkables such as checkboxes or radio buttons
+ ** `width.inputMedium`
+ ** `width.inputXsmall`: checkables such as checkboxes or radio buttons
+ ** `width.iconMedium`
+ ** `width.iconSmall`
+ ** `width.iconXsmall`
+ */
 export const width = {
 	ctaMedium: size.medium,
 	ctaSmall: size.small,
@@ -71,6 +133,23 @@ export const width = {
 	iconXsmall: iconSize.xsmall,
 };
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#tokens) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/00ddcb-tokens/t/797660)
+ *
+ * Width tokens expressed in rem
+ *
+ ** `remWidth.ctaMedium`: medium height call to action buttons and links
+ ** `remWidth.ctaSmall`: small height call to action buttons and links
+ ** `remWidth.ctaXsmall`: xsmall height call to action buttons and links
+ ** `remWidth.inputMedium`: text input fields, radio and checkbox labels
+ ** `remWidth.inputXsmall`: checkables such as checkboxes or radio buttons
+ ** `remWidth.inputMedium`
+ ** `remWidth.inputXsmall`: checkables such as checkboxes or radio buttons
+ ** `remWidth.iconMedium`
+ ** `remWidth.iconSmall`
+ ** `remWidth.iconXsmall`
+ */
 export const remWidth = {
 	ctaMedium: remSize.medium,
 	ctaSmall: remSize.small,

--- a/packages/@guardian/source-foundations/src/space.ts
+++ b/packages/@guardian/source-foundations/src/space.ts
@@ -5,21 +5,20 @@
 import { pxToRem } from './utils/px-to-rem';
 
 /**
- * Space
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-space--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/05f835-space)
  *
- * The following units can be applied to margin or padding properties, vertically or horizontally.
- * @see https://theguardian.design/2a1e5182b/p/449bd5-space
+ * Can be applied to margin or padding properties, vertically or horizontally.
  *
- * Space scale
- * 1 -> 4px
- * 2 -> 8px
- * 3 -> 12px
- * 4 -> 16px
- * 5 -> 20px
- * 6 -> 24px
- * 9 -> 36px
- * 12 -> 48px
- * 24 -> 96px
+ ** `space[1]` -> 4px
+ ** `space[2]` -> 8px
+ ** `space[3]` -> 12px
+ ** `space[4]` -> 16px
+ ** `space[5]` -> 20px
+ ** `space[6]` -> 24px
+ ** `space[9]` -> 36px
+ ** `space[12]` -> 48px
+ ** `space[24]` -> 96px
  */
 export const space = {
 	1: 4,
@@ -33,8 +32,22 @@ export const space = {
 	24: 96,
 } as const;
 
-/* TODO: this should be exposed as a number instead of a string,
-   so consumers can perform calculations on it */
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-space--page) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/05f835-space)
+ *
+ * Can be applied to margin or padding properties, vertically or horizontally.
+ *
+ ** `remSpace[1]` -> 0.25rem
+ ** `remSpace[2]` -> 0.5rem
+ ** `remSpace[3]` -> 0.75rem
+ ** `remSpace[4]` -> 1rem
+ ** `remSpace[5]` -> 1.25rem
+ ** `remSpace[6]` -> 1.5rem
+ ** `remSpace[9]` -> 2.25rem
+ ** `remSpace[12]` -> 3rem
+ ** `remSpace[24]` -> 6rem
+ */
 export const remSpace: { [K in keyof typeof space]: string } = {
 	1: `${pxToRem(space[1])}rem`,
 	2: `${pxToRem(space[2])}rem`,
@@ -46,3 +59,6 @@ export const remSpace: { [K in keyof typeof space]: string } = {
 	12: `${pxToRem(space[12])}rem`,
 	24: `${pxToRem(space[24])}rem`,
 };
+
+/* TODO: this should be exposed as a number instead of a string,
+   so consumers can perform calculations on it */

--- a/packages/@guardian/source-foundations/src/utils/resets.ts
+++ b/packages/@guardian/source-foundations/src/utils/resets.ts
@@ -112,6 +112,11 @@ const resetCSS = `
 	${defaults}
 `;
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-css-reset--page)
+ *
+ * `resets.resetCSS`: sensible default CSS rules to provide a base for a consistent environment across projects and browsers.
+ */
 export const resets = {
 	legend,
 	fieldset,


### PR DESCRIPTION
## What is the purpose of this change?

Docstrings are useful for inline documentation (see also #1132)

## What does this change?

Adds docstrings to all Foundations exports
