### PR TITLE
fix: Use `as const` hint to help IDE autocomplete

### DIFF
--- a/packages/@guardian/source-foundations/src/breakpoints.ts
+++ b/packages/@guardian/source-foundations/src/breakpoints.ts
@@ -42,4 +42,4 @@ export const breakpoints = {
 	desktop: 980,
 	leftCol: 1140,
 	wide: 1300,
-};
+} as const;

--- a/packages/@guardian/source-foundations/src/breakpoints.ts
+++ b/packages/@guardian/source-foundations/src/breakpoints.ts
@@ -15,23 +15,6 @@ export type Breakpoint =
 /**
  * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-media-queries--page#breakpoints) •
  * [Design System](https://theguardian.design/2a1e5182b/p/41be19-grids)
- *
- *	`breakpoints.mobile` -> 320px
- *
- *	`breakpoints.mobileMedium` -> 375px
- *
- *	`breakpoints.mobileLandscape` -> 480px
- *
- *	`breakpoints.phablet` -> 660px
- *
- *	`breakpoints.tablet` -> 740px
- *
- *	`breakpoints.desktop` -> 980px
- *
- *	`breakpoints.leftCol` -> 1140px
- *
- *	`breakpoints.wide` -> 1300px
- *
  */
 export const breakpoints = {
 	mobile: 320,

--- a/packages/@guardian/source-foundations/src/palette.ts
+++ b/packages/@guardian/source-foundations/src/palette.ts
@@ -96,7 +96,7 @@ const colors = {
 		'#E4E5E8', //specialReport-700
 		'#EFF1F2', //specialReport-800
 	],
-};
+} as const;
 
 /**
  * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •

--- a/packages/@guardian/source-foundations/src/palette.ts
+++ b/packages/@guardian/source-foundations/src/palette.ts
@@ -96,7 +96,7 @@ const colors = {
 		'#E4E5E8', //specialReport-700
 		'#EFF1F2', //specialReport-800
 	],
-} as const;
+};
 
 /**
  * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-colour--page) •

--- a/packages/@guardian/source-foundations/src/size.ts
+++ b/packages/@guardian/source-foundations/src/size.ts
@@ -9,10 +9,6 @@ import { pxToRem } from './utils/px-to-rem';
  * [Design System](https://theguardian.design/2a1e5182b/p/24a3ec-size/t/329aef)
  *
  * May be used for call to action buttons and user input fields.
- *
- ** `size.medium` -> 44px
- ** `size.small` -> 36px
- ** `size.xsmall` -> 24px
  */
 export const size = {
 	xsmall: 24,

--- a/packages/@guardian/source-foundations/src/size.ts
+++ b/packages/@guardian/source-foundations/src/size.ts
@@ -18,7 +18,7 @@ export const size = {
 	xsmall: 24,
 	small: 36,
 	medium: 44, // meets WCAG 2.1 AAA compliance for touch targets.
-};
+} as const;
 
 /**
  * [Storybook](https://guardian.github.io/source/?path=/docs/source-v4-source-foundations-size--page#global-size-values) •
@@ -46,7 +46,7 @@ export const iconSize = {
 	xsmall: 20,
 	small: 26,
 	medium: 30,
-};
+} as const;
 
 const remIconSize: { [K in keyof typeof iconSize]: number } = {
 	xsmall: pxToRem(iconSize.xsmall),


### PR DESCRIPTION
## What is the purpose of this change?

Improve IDE experience when using Source’s core values: `breakpoints` sizes ~and `palette` colours~.

Build on top of @ob6160’s #1101. Requires less maintenance than #1138. Also mentioned in https://github.com/guardian/dotcom-rendering/pull/3490#discussion_r737389629

## What does this change?

Uses the `as const` TS assertion in
- breakpoints
- ~palette~ (It doesn’t play nice with `Theme`)

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

| Before      | After      |
|-------------|------------|
| ![before][] | ![after][] |

[before]: https://user-images.githubusercontent.com/76776/140520110-ff824c2d-ca4a-4267-b4a1-abf4df1a867b.png
[after]: https://user-images.githubusercontent.com/76776/140520210-e28454a4-1337-4d73-aa36-22d33e44230f.png

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [X] Tested at all breakpoints 😛 (not really)
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Known issues

~Colours don’t get a visual treatment, so you can only read the string.~
