### PR TITLE
Source 4 fixes

### DIFF
--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "@guardian/source-foundations": "4.0.0-alpha.4"
+    "@guardian/source-foundations": "^4.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@guardian/eslint-plugin-source-foundations/rollup.config.js
+++ b/packages/@guardian/eslint-plugin-source-foundations/rollup.config.js
@@ -5,7 +5,6 @@ import pkg from './package.json';
 const bundle = (config) => ({
 	...config,
 	input: 'src/index.ts',
-	external: (id) => !/^[./]/.test(id),
 });
 
 // eslint-disable-next-line import/no-default-export -- it's what rollup wants

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "@guardian/source-react-components": "4.0.0-alpha.4"
+    "@guardian/source-react-components": "^4.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@guardian/eslint-plugin-source-react-components/rollup.config.js
+++ b/packages/@guardian/eslint-plugin-source-react-components/rollup.config.js
@@ -5,7 +5,6 @@ import pkg from './package.json';
 const bundle = (config) => ({
 	...config,
 	input: 'src/index.ts',
-	external: (id) => !/^[./]/.test(id),
 });
 
 // eslint-disable-next-line import/no-default-export -- it's what rollup wants

--- a/packages/@guardian/source-react-components/package.json
+++ b/packages/@guardian/source-react-components/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
-    "@guardian/source-foundations": "4.0.0-alpha.0",
+    "@guardian/source-foundations": "^4.0.0-rc.1",
     "react": "^17.0.1"
   },
   "publishConfig": {


### PR DESCRIPTION
## What does this change?

Use correct version numbers of Source in peerDeps: we should be using release candidates, not alphas. These weren't bumped automatically by Lerna.

Don't externalise modules in ESLint plugins: this meant that consumers didn't have access to `tslib` that was being externalised and thus not bundled

