### PR TITLE
Add palette to removed imports config

### DIFF
--- a/lib/eslint/rules/valid-import-path.ts
+++ b/lib/eslint/rules/valid-import-path.ts
@@ -22,6 +22,7 @@ const removedImports: Record<string, string[]> = {
 	"'@guardian/source-foundations/utils'": ['InteractionModeEngine'],
 	"'@guardian/src-foundations/size/global'": ['remSize', 'remIconSize'],
 	"'@guardian/src-foundations/themes'": ['defaultTheme', 'brand', 'brandAlt'],
+	"'@guardian/src-foundations'": ['palette'],
 	"'@guardian/src-helpers'": [
 		'storybookBackgrounds',
 		'ThemeName',


### PR DESCRIPTION
## What is the purpose of this change?

The `palette` import has been removed in `@guardian/source-foundations`. This PR updates the `@guardian/eslint-plugin-source-foundations` config to account for that.