### PR TITLE
Adding hideLabel prop to choice card group

### DIFF
--- a/packages/@guardian/src-choice-card/ChoiceCardGroup.stories.tsx
+++ b/packages/@guardian/src-choice-card/ChoiceCardGroup.stories.tsx
@@ -14,6 +14,7 @@ export default {
 		label: 'Choose an option',
 		supporting: 'These are your options',
 		multi: false,
+		hideLabel: false,
 	},
 	argTypes: {
 		// sorted by required,alpha
@@ -27,6 +28,7 @@ export default {
 			control: { type: 'select' },
 		},
 		label: undefined,
+		hideLabel: undefined,
 		multi: undefined,
 		supporting: undefined,
 	},

--- a/packages/@guardian/src-choice-card/ChoiceCardGroup.tsx
+++ b/packages/@guardian/src-choice-card/ChoiceCardGroup.tsx
@@ -23,6 +23,10 @@ export interface ChoiceCardGroupProps
 	 */
 	label?: string;
 	/**
+	 * Hide the label text visually
+	 */
+	hideLabel?: boolean;
+	/**
 	 * Additional text that appears below the `label` (does nothing without one).
 	 */
 	supporting?: string;
@@ -55,6 +59,7 @@ export const ChoiceCardGroup = ({
 	id,
 	name,
 	label,
+	hideLabel,
 	supporting,
 	multi,
 	error,
@@ -66,7 +71,15 @@ export const ChoiceCardGroup = ({
 	const groupId = id || generateSourceId();
 	return (
 		<fieldset css={[fieldset, cssOverrides]} id={groupId} {...props}>
-			{label ? <Legend text={label} supporting={supporting} /> : ''}
+			{label ? (
+				<Legend
+					text={label}
+					supporting={supporting}
+					hideLabel={hideLabel}
+				/>
+			) : (
+				''
+			)}
 			{typeof error === 'string' && (
 				<InlineError id={descriptionId(groupId)}>{error}</InlineError>
 			)}


### PR DESCRIPTION
Co-authored-by: Imogen Hardy <imogen.hardy@gmail.com>

## What is the purpose of this change?
This PR adds the hideLabel prop to the `ChoiceCardGroup` component.

## What does this change?
We recently implemented a workaround to hide the choice card group label [here](https://github.com/guardian/support-dotcom-components/pull/556). This change passes through the `hideLabel` prop to the `Legend` component where the option to hide the label already exists.

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
