### PR TITLE
Strip extraneous commas when combining duplicate imports

### DIFF
--- a/scripts/eslint-integration-test/test-config.ts
+++ b/scripts/eslint-integration-test/test-config.ts
@@ -37,6 +37,20 @@ const foundationsTestConfig: Test[] = [
 			`Importing * from @guardian/src-* and @guardian/source-* packages is not recommended. Use named imports instead`,
 		],
 	},
+	{
+		name: 'Handles multiple lines',
+		contents: `import { space } from '@guardian/src-foundations';
+import {
+	brandText,
+	brandAlt,
+	neutral,
+} from '@guardian/src-foundations/palette';
+import { textSans, headline } from '@guardian/src-foundations/typography';
+import { from, until } from '@guardian/src-foundations/mq';`,
+		eslintConfig: foundationsEslintConfig,
+		fix: true,
+		expectedOutput: `import { space, brandText, brandAlt, neutral, textSans, headline, from, until } from '@guardian/source-foundations';`,
+	},
 ];
 
 const componentsTestConfig: Test[] = [


### PR DESCRIPTION
## What is the purpose of this change?

When we convert a bunch of imports from various foundations sub-paths, sometimes some extra commas get left in and everything falls over. This PR fixes\* that. 

_\* It doesn't yet but hopefully it will at some point_

For example:


```tsx
import { space } from '@guardian/src-foundations';
import {
	brandText,
	brandAlt,
	neutral,
} from '@guardian/src-foundations/palette';
import { textSans, headline } from '@guardian/src-foundations/typography';
import { from, until } from '@guardian/src-foundations/mq';
```

should end up looking something like

```tsx
import { 
    space,
    brandText,
    brandAlt,
    neutral,
    textSans,
    headline,
    from,
    until
} from '@guardian/source-foundations';
```

but currently looks something like

```tsx
import { space ,
	brandText,
	brandAlt,
	neutral,
, textSans, headline , from, until } from '@guardian/source-foundations';
```

## What does this change?

-   Add an integration test to cover this case

