### PR TITLE
Expose more typography primitives

### DIFF
--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -20,9 +20,15 @@ import {
 import { objectStylesToString } from './object-styles-to-string';
 import type {
 	BodySizes,
+	Category,
 	FontScaleArgs,
 	FontScaleFunctionStr,
+	FontStyle,
+	FontWeight,
+	FontWeightDefinition,
 	HeadlineSizes,
+	LineHeight,
+	ScaleUnit,
 	TextSansSizes,
 	TitlepieceSizes,
 } from './types';
@@ -155,4 +161,13 @@ export {
 	fontMapping as fonts,
 	fontWeightMapping as fontWeights,
 	lineHeightMapping as lineHeights,
+};
+
+export type {
+	ScaleUnit,
+	Category,
+	LineHeight,
+	FontWeight,
+	FontStyle,
+	FontWeightDefinition,
 };


### PR DESCRIPTION
## What is the purpose of this change?

The primitives used to build our Typography API are useful and ought to be exposed in an accessible way. There are cases where these [primitive types have been imported from the `dist` directory](https://github.com/guardian/dotcom-rendering/blob/039f40f692892d9ea870915aa40e7c13d4cbec87/apps-rendering/src/components/editions/standfirst/index.tsx#L9) of `@guardian/src-foundations`, which is [pretty wild](https://chat.google.com/room/AAAAWwBdSMs/iBf7z61U-tE)

## What does this change?

Exposes the following types

- `type ScaleUnit = 'rem' | 'px'`
- `type Category = 'titlepiece' | 'headline' | 'body' | 'textSans'`
- `type LineHeight = 'tight' | 'regular' | 'loose'`
- `type FontWeight = 'light' | 'regular' | 'medium' | 'bold'`
- `type FontStyle = 'normal' | 'italic'`
- `type FontWeightDefinition = { hasItalic: boolean }`


