### PR TITLE
Revert "Expose more typography primitives"

### DIFF
--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -20,15 +20,9 @@ import {
 import { objectStylesToString } from './object-styles-to-string';
 import type {
 	BodySizes,
-	Category,
 	FontScaleArgs,
 	FontScaleFunctionStr,
-	FontStyle,
-	FontWeight,
-	FontWeightDefinition,
 	HeadlineSizes,
-	LineHeight,
-	ScaleUnit,
 	TextSansSizes,
 	TitlepieceSizes,
 } from './types';
@@ -161,13 +155,4 @@ export {
 	fontMapping as fonts,
 	fontWeightMapping as fontWeights,
 	lineHeightMapping as lineHeights,
-};
-
-export type {
-	ScaleUnit,
-	Category,
-	LineHeight,
-	FontWeight,
-	FontStyle,
-	FontWeightDefinition,
 };


### PR DESCRIPTION
Reverts guardian/source#1153

Argh, these are already exported in the [source-foundations index](https://github.com/guardian/source/blob/9cc996250971354f78e99a11760bf037d4293dd0/packages/%40guardian/source-foundations/src/index.ts#L79-L84). No need to do it again here