### PR TITLE
Use text.inputError for textarea and select

### DIFF
--- a/packages/@guardian/src-foundations/src/themes/select.ts
+++ b/packages/@guardian/src-foundations/src/themes/select.ts
@@ -7,7 +7,7 @@ export const selectDefault = {
 		textLabel: text.inputLabel,
 		textLabelOptional: text.supporting,
 		textLabelSupporting: text.supporting,
-		textError: text.error,
+		textError: text.inputError,
 		textSuccess: text.success,
 		backgroundInput: background.input,
 		border: border.input,

--- a/packages/@guardian/src-text-area/styles.ts
+++ b/packages/@guardian/src-text-area/styles.ts
@@ -7,7 +7,7 @@ import { resets } from '@guardian/src-foundations/utils';
 
 export const errorInput = css`
 	border: 4px solid ${border.error};
-	color: ${text.error};
+	color: ${text.inputError};
 	margin-top: 0;
 `;
 


### PR DESCRIPTION
## What is the purpose of this change?
Changes the text colour of the Textarea and Select components to be `neutral.7` when in an error state.

Uses the `text.inputError` colour token introduced in #1136 

## Screenshots

**Before**
![Screenshot 2021-11-08 at 11 16 49](https://user-images.githubusercontent.com/1771189/140732817-b821a434-6100-457e-9844-2b37a20e4cfc.png)
![Screenshot 2021-11-08 at 11 15 31](https://user-images.githubusercontent.com/1771189/140732841-08f9c5bf-49ca-47cd-8d74-a1fe3a975f93.png)

**After**
![Screenshot 2021-11-08 at 11 16 42](https://user-images.githubusercontent.com/1771189/140732943-b112081a-53b5-4a8d-8686-c0b6ef68c463.png)

![Screenshot 2021-11-08 at 11 15 05](https://user-images.githubusercontent.com/1771189/140732821-f1e6f853-6779-4768-af6a-7e2bb38612f4.png)

