### PR TITLE
Add new eslint plugin test

### DIFF
--- a/lib/eslint/rules/valid-import-path.test.ts
+++ b/lib/eslint/rules/valid-import-path.test.ts
@@ -394,5 +394,15 @@ ruleTester.run('valid-import-path', validImportPath, {
 			],
 			output: `export { storybookBackgrounds } from '@guardian/src-helpers';`,
 		},
+		{
+			// Import something that's gone from foundations
+			code: `import { palette } from '@guardian/src-foundations';`,
+			errors: [
+				{
+					message: `The following export(s) have been removed: palette.`,
+				},
+			],
+			output: `import { palette } from '@guardian/src-foundations';`,
+		},
 	],
 });


### PR DESCRIPTION
## What is the purpose of this change?

Make sure we don't "fix" `import {palette} from '@guardian/src-foundations'`, since this import is going away

## What does this change?

-   Adds a test that catches it
