### PR TITLE
Use rollup-plugin-dts in source-react-components

### DIFF
--- a/packages/@guardian/source-react-components/package.json
+++ b/packages/@guardian/source-react-components/package.json
@@ -23,6 +23,7 @@
     "@rollup/plugin-alias": "^3.1.5",
     "@rollup/plugin-node-resolve": "^13.0.5",
     "rollup": "^2.56.3",
+    "rollup-plugin-dts": "^4.0.0",
     "rollup-plugin-ts": "^1.4.7",
     "typescript": "^4.4.3"
   },

--- a/packages/@guardian/source-react-components/rollup.config.js
+++ b/packages/@guardian/source-react-components/rollup.config.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import alias from '@rollup/plugin-alias';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import dts from 'rollup-plugin-dts';
 import ts from 'rollup-plugin-ts';
 import pkg from './package.json';
 
@@ -18,6 +19,54 @@ const paths = {
 	'@guardian/src-foundations/size': '@guardian/source-foundations',
 	'@guardian/src-foundations/typography': '@guardian/source-foundations',
 	'@guardian/src-foundations/utils': '@guardian/source-foundations',
+};
+
+// n.b. no '@guardian/src-foundations/themes',
+// we're intentionally bundling them.
+const external = [
+	'@guardian/src-foundations',
+	'@guardian/src-foundations/accessibility',
+	'@guardian/src-foundations/mq',
+	'@guardian/src-foundations/palette',
+	'@guardian/src-foundations/size',
+	'@guardian/src-foundations/typography',
+	'@guardian/src-foundations/utils',
+	'@guardian/source-foundations',
+	'react',
+	/@emotion\/react/,
+];
+
+const aliasConfig = {
+	resolver: nodeResolve({
+		extensions: ['.ts', '.tsx', '.mjs', '.jsx', '.js'],
+	}),
+	// prettier-ignore
+	entries: {
+		// special rule for themes - these are not being moved to
+		// '../source-foundations'
+		'@guardian/src-foundations/themes': path.resolve('../', 'src-foundations/src/themes'),
+
+		// this redirects all other '@guardian/src-foundations/*'
+		// imports to `source-foundations` source code
+		'@guardian/src-foundations': path.resolve('../', '../source-foundations'),
+
+		'@guardian/src-accordion': path.resolve('../','src-accordion/index'),
+		'@guardian/src-brand': path.resolve('../','src-brand/index'),
+		'@guardian/src-button': path.resolve('../','src-button/index'),
+		'@guardian/src-checkbox': path.resolve('../','src-checkbox/index'),
+		'@guardian/src-choice-card': path.resolve('../','src-choice-card/index'),
+		'@guardian/src-footer': path.resolve('../', 'src-footer/index'),
+		'@guardian/src-helpers': path.resolve('../','src-helpers/index'),
+		'@guardian/src-icons': path.resolve('../','src-icons/index'),
+		'@guardian/src-label': path.resolve('../','src-label/index'),
+		'@guardian/src-layout': path.resolve('../','src-layout/index'),
+		'@guardian/src-link': path.resolve('../', 'src-link/index'),
+		'@guardian/src-radio': path.resolve('../','src-radio/index'),
+		'@guardian/src-select': path.resolve('../','src-select/index'),
+		'@guardian/src-text-area': path.resolve('../','src-text-area/index'),
+		'@guardian/src-text-input': path.resolve('../','src-text-input/index'),
+		'@guardian/src-user-feedback': path.resolve('../','src-user-feedback/index'),
+	},
 };
 
 // eslint-disable-next-line import/no-default-export -- it's what rollup wants
@@ -38,55 +87,22 @@ export default [
 				paths,
 			},
 		],
-		external: [
-			// n.b. no '@guardian/src-foundations/themes',
-			// we're intentionally bundling them.
-			'@guardian/src-foundations',
-			'@guardian/src-foundations/accessibility',
-			'@guardian/src-foundations/mq',
-			'@guardian/src-foundations/palette',
-			'@guardian/src-foundations/size',
-			'@guardian/src-foundations/typography',
-			'@guardian/src-foundations/utils',
-			'@guardian/source-foundations',
-			'react',
-			/@emotion\/react/,
-		],
+		external,
 		plugins: [
-			alias({
-				resolver: nodeResolve({
-					extensions: ['.ts', '.tsx', '.mjs', '.jsx', '.js'],
-				}),
-				// prettier-ignore
-				entries: {
-					// special rule for themes - these are not being moved to
-					// '../source-foundations'
-					'@guardian/src-foundations/themes': path.resolve('../', 'src-foundations/src/themes'),
-
-					// this redirects all other '@guardian/src-foundations/*'
-					// imports to `source-foundations` source code
-					'@guardian/src-foundations': path.resolve('../', '../source-foundations'),
-
-					'@guardian/src-accordion': path.resolve('../','src-accordion/index'),
-					'@guardian/src-brand': path.resolve('../','src-brand/index'),
-					'@guardian/src-button': path.resolve('../','src-button/index'),
-					'@guardian/src-checkbox': path.resolve('../','src-checkbox/index'),
-					'@guardian/src-choice-card': path.resolve('../','src-choice-card/index'),
-					'@guardian/src-footer': path.resolve('../', 'src-footer/index'),
-					'@guardian/src-helpers': path.resolve('../','src-helpers/index'),
-					'@guardian/src-icons': path.resolve('../','src-icons/index'),
-					'@guardian/src-label': path.resolve('../','src-label/index'),
-					'@guardian/src-layout': path.resolve('../','src-layout/index'),
-					'@guardian/src-link': path.resolve('../', 'src-link/index'),
-					'@guardian/src-radio': path.resolve('../','src-radio/index'),
-					'@guardian/src-select': path.resolve('../','src-select/index'),
-					'@guardian/src-text-area': path.resolve('../','src-text-area/index'),
-					'@guardian/src-text-input': path.resolve('../','src-text-input/index'),
-					'@guardian/src-user-feedback': path.resolve('../','src-user-feedback/index'),
-				},
-			}),
+			alias(aliasConfig),
 			nodeResolve({ extensions: ['.ts', '.tsx', '.mjs', '.jsx', '.js'] }),
 			ts(),
 		],
+	},
+	{
+		input: 'src/index.ts',
+		output: {
+			file: pkg.types,
+			format: 'es',
+			paths,
+			sourcemap: true,
+		},
+		external,
+		plugins: [alias(aliasConfig), dts()],
 	},
 ];


### PR DESCRIPTION
## What is the purpose of this change?

`rollup-plugin-ts` currently generates `.d.ts` for `source-react-components`.

As per the rollup config, `src-foundations` imports are re-written as `source-foundations` and externalised. 

This works fine with the ESM and CJS outputs, but it doesn't work for `.d.ts` files. In this case, the original `src-foundations` paths are preserved.

`rollup-plugin-dts` correctly respects our paths in the `.d.ts` files

## What does this change?

-   Install and consume `rollup-plugin-dts` in `source-react-components`
