### PR TITLE
Handle theme name changes when coming from component package

### DIFF
--- a/lib/eslint/rules/valid-import-path.test.ts
+++ b/lib/eslint/rules/valid-import-path.test.ts
@@ -146,7 +146,7 @@ import {  size as s } from '@guardian/source-foundations';`,
 		output: `import { headlineObjectStyles as hl, bodySizes as bs } from '@guardian/source-foundations';`,
 	},
 	{
-		// Themes that now come from react-components
+		// Themes that now come from react-components and have changed names (from foundations)
 		code: `import { labelDefault } from '@guardian/src-foundations/themes';`,
 		errors: [
 			{
@@ -403,6 +403,17 @@ ruleTester.run('valid-import-path', validImportPath, {
 				},
 			],
 			output: `import { palette } from '@guardian/src-foundations';`,
+		},
+		{
+			// Themes that now come from react-components and have changed names (from component)
+			code: `import { buttonReaderRevenue } from '@guardian/src-button';`,
+			errors: [
+				{
+					message:
+						"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.",
+				},
+			],
+			output: `import { buttonThemeReaderRevenue } from '@guardian/source-react-components';`,
 		},
 	],
 });

--- a/lib/eslint/rules/valid-import-path.test.ts
+++ b/lib/eslint/rules/valid-import-path.test.ts
@@ -107,10 +107,10 @@ import {  size as s } from '@guardian/source-foundations';`,
 		errors: [
 			{
 				message:
-					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.",
+					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.\nThe following export(s) have been renamed [from -> to]: headline -> headlineObjectStyles",
 			},
 		],
-		output: `import { headlineObjectStyles } from '@guardian/source-foundations';`,
+		output: `import { headline } from '@guardian/source-foundations';`,
 	},
 	{
 		// Exports that have changed names, alongside some that haven't
@@ -118,10 +118,10 @@ import {  size as s } from '@guardian/source-foundations';`,
 		errors: [
 			{
 				message:
-					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.",
+					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.\nThe following export(s) have been renamed [from -> to]: headline -> headlineObjectStyles",
 			},
 		],
-		output: `import { headlineObjectStyles, bodySizes } from '@guardian/source-foundations';`,
+		output: `import { headline, bodySizes } from '@guardian/source-foundations';`,
 	},
 	{
 		// Exports that have changed names using an alias (foundations typography)
@@ -129,10 +129,10 @@ import {  size as s } from '@guardian/source-foundations';`,
 		errors: [
 			{
 				message:
-					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.",
+					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.\nThe following export(s) have been renamed [from -> to]: headline -> headlineObjectStyles",
 			},
 		],
-		output: `import { headlineObjectStyles as hl } from '@guardian/source-foundations';`,
+		output: `import { headline as hl } from '@guardian/source-foundations';`,
 	},
 	{
 		// Exports that have changed names, alongside some that haven't, using an alias
@@ -140,10 +140,10 @@ import {  size as s } from '@guardian/source-foundations';`,
 		errors: [
 			{
 				message:
-					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.",
+					"@guardian/src-* packages are deprecated. Import from '@guardian/source-foundations' instead.\nThe following export(s) have been renamed [from -> to]: headline -> headlineObjectStyles",
 			},
 		],
-		output: `import { headlineObjectStyles as hl, bodySizes as bs } from '@guardian/source-foundations';`,
+		output: `import { headline as hl, bodySizes as bs } from '@guardian/source-foundations';`,
 	},
 	{
 		// Themes that now come from react-components and have changed names (from foundations)
@@ -151,10 +151,10 @@ import {  size as s } from '@guardian/source-foundations';`,
 		errors: [
 			{
 				message:
-					"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.",
+					"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been renamed [from -> to]: labelDefault -> labelThemeDefault",
 			},
 		],
-		output: `import { labelThemeDefault } from '@guardian/source-react-components';`,
+		output: `import { labelDefault } from '@guardian/source-react-components';`,
 	},
 	{
 		// Import default
@@ -184,7 +184,7 @@ import {  size as s } from '@guardian/source-foundations';`,
 		errors: [
 			{
 				message:
-					"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.",
+					"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been renamed [from -> to]: labelBrand -> labelThemeBrand",
 			},
 		],
 		output: `import themes, {labelBrand} from '@guardian/src-foundations/themes';`,
@@ -234,52 +234,52 @@ import {  size as s } from '@guardian/source-foundations';`,
 		code: `export { headline } from '@guardian/src-foundations/typography/obj';`,
 		errors: [
 			{
-				message: `@guardian/src-* packages are deprecated. Export from '@guardian/source-foundations' instead.`,
+				message: `@guardian/src-* packages are deprecated. Export from '@guardian/source-foundations' instead.\nThe following export(s) have been renamed [from -> to]: headline -> headlineObjectStyles`,
 			},
 		],
-		output: `export { headlineObjectStyles } from '@guardian/source-foundations';`,
+		output: `export { headline } from '@guardian/source-foundations';`,
 	},
 	{
 		// Rename theme imports in imports
 		code: `import { choiceCardDefault } from '@guardian/src-foundations/themes';`,
 		errors: [
 			{
-				message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.`,
+				message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been renamed [from -> to]: choiceCardDefault -> choiceCardThemeDefault`,
 			},
 		],
-		output: `import { choiceCardThemeDefault } from '@guardian/source-react-components';`,
+		output: `import { choiceCardDefault } from '@guardian/source-react-components';`,
 	},
 	{
 		// Rename theme imports in exports
 		code: `export { choiceCardDefault } from '@guardian/src-foundations/themes';`,
 		errors: [
 			{
-				message: `@guardian/src-* packages are deprecated. Export from '@guardian/source-react-components' instead.`,
+				message: `@guardian/src-* packages are deprecated. Export from '@guardian/source-react-components' instead.\nThe following export(s) have been renamed [from -> to]: choiceCardDefault -> choiceCardThemeDefault`,
 			},
 		],
-		output: `export { choiceCardThemeDefault } from '@guardian/source-react-components';`,
+		output: `export { choiceCardDefault } from '@guardian/source-react-components';`,
 	},
 	{
 		// Rename and remove theme imports
 		code: `import { choiceCardDefault, brand } from '@guardian/src-foundations/themes';`,
 		errors: [
 			{
-				message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been removed: brand.`,
+				message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been removed: brand.\nThe following export(s) have been renamed [from -> to]: choiceCardDefault -> choiceCardThemeDefault`,
 			},
 		],
 		output: `import { brand } from '@guardian/src-foundations/themes';
-import { choiceCardThemeDefault, } from '@guardian/source-react-components';`,
+import { choiceCardDefault, } from '@guardian/source-react-components';`,
 	},
 	{
 		// Rename and remove theme imports regardless of order
 		code: `import { brand, choiceCardDefault } from '@guardian/src-foundations/themes';`,
 		errors: [
 			{
-				message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been removed: brand.`,
+				message: `@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been removed: brand.\nThe following export(s) have been renamed [from -> to]: choiceCardDefault -> choiceCardThemeDefault`,
 			},
 		],
 		output: `import { brand } from '@guardian/src-foundations/themes';
-import {  choiceCardThemeDefault } from '@guardian/source-react-components';`,
+import {  choiceCardDefault } from '@guardian/source-react-components';`,
 	},
 ];
 
@@ -410,10 +410,10 @@ ruleTester.run('valid-import-path', validImportPath, {
 			errors: [
 				{
 					message:
-						"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.",
+						"@guardian/src-* packages are deprecated. Import from '@guardian/source-react-components' instead.\nThe following export(s) have been renamed [from -> to]: buttonReaderRevenue -> buttonThemeReaderRevenue",
 				},
 			],
-			output: `import { buttonThemeReaderRevenue } from '@guardian/source-react-components';`,
+			output: `import { buttonReaderRevenue } from '@guardian/source-react-components';`,
 		},
 	],
 });

--- a/lib/eslint/rules/valid-import-path.ts
+++ b/lib/eslint/rules/valid-import-path.ts
@@ -149,24 +149,23 @@ const getRenameImportFixers = (
 	}
 
 	// Some of the theme exports have changed name
-	if (node.source.raw === "'@guardian/src-foundations/themes'") {
-		for (const i of node.specifiers) {
-			if (
-				i.type === 'ImportNamespaceSpecifier' ||
-				i.type === 'ImportDefaultSpecifier'
-			)
-				continue;
 
-			const name = getSpecifierName(i);
-			const range = getSpecifierRange(i);
-			if (name in newThemeNames) {
-				fixers.push(
-					fixer.replaceTextRange(
-						range ?? [0, 0],
-						`${newThemeNames[name]}`,
-					),
-				);
-			}
+	for (const i of node.specifiers) {
+		if (
+			i.type === 'ImportNamespaceSpecifier' ||
+			i.type === 'ImportDefaultSpecifier'
+		)
+			continue;
+
+		const name = getSpecifierName(i);
+		const range = getSpecifierRange(i);
+		if (name in newThemeNames) {
+			fixers.push(
+				fixer.replaceTextRange(
+					range ?? [0, 0],
+					`${newThemeNames[name]}`,
+				),
+			);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of this change?

This change fixes a bug in the plugin where theme exports are not correctly renamed if they are imported from a component package.

### Context

In Source v4, numerous changes have been made to the way that the packages are structured. One such change involves the theme exports for each component now coming from `@guardian/source-react-components`. Previously they were available both from `@guardian/src-foundations/themes` and the relevant `@guardian/src-<component>` package. As well as changing location, they have also been renamed to add the word `Theme`. 

To help with this change, we have created two eslint plugins that will show errors relating to specific imports and, in many cases, autofix those problems. 

### What wasn't working?

The plugins would rename the theme variables if they were imported from `@guardian/source-foundations/themes` but not if they came from a `@guardian/src-<component>` package. This PR fixes that.

## What does this change?

-   Update logic to not check for the package location when checking if the import name is one of the renamed values
-   Add a new test case to cover this

## Next steps

One consideration with this renaming functionality is that, while it renames the imports, it will not rename the variables where they are used throughout the code. This may lead to a confusing situation where all the imports are now valid but the code is not, and it is not necessarily clear to the user why that is the case. Maybe we shouldn't be renaming them, just adding some information into the error message that explains what has happened?