### PR TITLE
Kitchen | Summary components: Allow `message` to be passed as `ReactNode`

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
@@ -35,6 +35,18 @@ asChromaticStory(ErrorOnly);
 
 // *****************************************************************************
 
+export const ErrorOnlyAsReactNode = Template.bind({});
+ErrorOnlyAsReactNode.args = {
+	message: (
+		<>
+			This is the error message as a <s>ReactNode</s>
+		</>
+	),
+};
+asChromaticStory(ErrorOnlyAsReactNode);
+
+// *****************************************************************************
+
 export const WithContext = Template.bind({});
 WithContext.args = {
 	message: 'Here is an error',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.stories.tsx
@@ -34,6 +34,18 @@ asChromaticStory(InfoOnly);
 
 // *****************************************************************************
 
+export const InfoOnlyAsReactNode = Template.bind({});
+InfoOnlyAsReactNode.args = {
+	message: (
+		<>
+			This is the info message as a <s>ReactNode</s>
+		</>
+	),
+};
+asChromaticStory(InfoOnlyAsReactNode);
+
+// *****************************************************************************
+
 export const WithContext = Template.bind({});
 WithContext.args = {
 	message: 'It was insightful',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.stories.tsx
@@ -32,6 +32,16 @@ SuccessOnly.args = {
 };
 asChromaticStory(SuccessOnly);
 
+export const SuccessOnlyAsReactNode = Template.bind({});
+SuccessOnlyAsReactNode.args = {
+	message: (
+		<>
+			This is the success message as a <s>ReactNode</s>
+		</>
+	),
+};
+asChromaticStory(SuccessOnlyAsReactNode);
+
 // *****************************************************************************
 
 export const WithContext = Template.bind({});

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/index.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/index.tsx
@@ -5,7 +5,7 @@ export interface SummaryProps extends Props {
 	 * The main message of the component
 	 * e.g. the main error message, success message etc.
 	 */
-	message: string;
+	message: React.ReactNode;
 	/**
 	 * Optional context information about the message
 	 */


### PR DESCRIPTION
## What is the purpose of this change?
We've come across a design where we want to add a `Link` to the message part of a component:

![chrome_CGzNQlBzPe](https://user-images.githubusercontent.com/13315440/141152315-f89f387a-5698-4874-aade-328165824312.png)

By allowing the `message` prop to be a `ReactNode` it's possible to pass in a `string` or JSX if needed.

## Screenshots
### `ErrorSummary` with `message` as ReactNode
![chrome_7GiRlepaTJ](https://user-images.githubusercontent.com/13315440/141153334-b720d5e6-be1d-4bbc-9ef6-50fa34273fb2.png)

### `SuccessSummary` with `message` as ReactNode
![chrome_0WIK8SN3dj](https://user-images.githubusercontent.com/13315440/141153353-21ff7904-34ed-47d4-8e68-15b22c773dfb.png)

### `InfoSummary` with `message` as ReactNode
![chrome_6Ya43liaQR](https://user-images.githubusercontent.com/13315440/141153365-46a42851-ad36-44e3-96b8-33deddef5d93.png)
