### PR TITLE
Add CheckboxGroup docstring

### DIFF
--- a/packages/@guardian/src-checkbox/CheckboxGroup.tsx
+++ b/packages/@guardian/src-checkbox/CheckboxGroup.tsx
@@ -34,6 +34,17 @@ export interface CheckboxGroupProps extends Props {
 	children: JSX.Element | JSX.Element[];
 }
 
+/**
+ * [Storybook](https://guardian.github.io/source/?path=/docs/source-src-checkbox-checkboxgroup--playground) •
+ * [Design System](https://theguardian.design/2a1e5182b/p/466fad-checkbox/b/33fc2f) •
+ * [GitHub](https://github.com/guardian/source/tree/main/packages/%40guardian/src-checkbox) •
+ * [NPM](https://www.npmjs.com/package/@guardian/src-checkbox)
+ *
+ * Checkboxes allow users to select multiple options from a list of individual
+ * items or to indicate agreement of terms and  services.
+ *
+ * The following themes are supported: `default`, `brand`
+ */
 export const CheckboxGroup = ({
 	id,
 	name,


### PR DESCRIPTION
## What is the purpose of this change?

This PR adds the standard component docstring to the CheckboxGroup component, which didn't previously have one.
