### PR TITLE
Update kitchen to use Source v4

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -39,6 +39,14 @@ module.exports = ({ config, mode }) => {
 
 	config.resolve.extensions.push('.ts', '.tsx');
 	config.resolve.alias = {
+		'@guardian/source-foundations': path.resolve(
+			__dirname,
+			'../packages/@guardian/source-foundations/src',
+		),
+		'@guardian/source-react-components': path.resolve(
+			__dirname,
+			'../packages/@guardian/source-react-components/src',
+		),
 		'@guardian/src-foundations': path.resolve(
 			__dirname,
 			'../packages/@guardian/src-foundations/src',

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:eslint": "yarn workspace @guardian/eslint-plugin-source-foundations build && yarn workspace @guardian/eslint-plugin-source-react-components build",
     "build:foundations": "yarn workspace @guardian/source-foundations build",
     "build:kitchen": "yarn workspace @guardian/source-react-components-development-kitchen build",
-    "build:packages": "npm-run-all build:src -p build:kitchen build:foundations build:react-components build:eslint",
+    "build:packages": "npm-run-all build:src -p build:foundations build:react-components build:eslint -s build:kitchen",
     "build:react-components": "yarn workspace @guardian/source-react-components build",
     "build:src": "ts-node ./scripts/build-src",
     "build:storybook": "build-storybook -o dist",

--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -17,6 +17,9 @@
     "build": "rollup -c",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "mini-svg-data-uri": "^1.3.3"
+  },
   "devDependencies": {
     "@guardian/eslint-config": "^0.7.0",
     "@guardian/eslint-config-typescript": "^0.7.0",

--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-foundations",
-  "version": "4.0.0-rc.2",
+  "version": "4.0.0-rc.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/guardian/source.git"

--- a/packages/@guardian/source-foundations/tsconfig.json
+++ b/packages/@guardian/source-foundations/tsconfig.json
@@ -22,9 +22,7 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "esnext",
-    "composite": true,
-    "emitDeclarationOnly": true
+    "target": "esnext"
   },
   "exclude": ["node_modules", "dist"],
   "include": ["."],

--- a/packages/@guardian/source-foundations/tsconfig.json
+++ b/packages/@guardian/source-foundations/tsconfig.json
@@ -23,7 +23,8 @@
     "strict": true,
     "strictNullChecks": true,
     "target": "esnext",
-    "composite": true
+    "composite": true,
+    "emitDeclarationOnly": true
   },
   "exclude": ["node_modules", "dist"],
   "include": ["."],

--- a/packages/@guardian/source-foundations/tsconfig.json
+++ b/packages/@guardian/source-foundations/tsconfig.json
@@ -22,7 +22,8 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "esnext"
+    "target": "esnext",
+    "composite": true
   },
   "exclude": ["node_modules", "dist"],
   "include": ["."],

--- a/packages/@guardian/source-react-components-development-kitchen/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/README.md
@@ -58,7 +58,7 @@ By providing an agile mechanism for iterating and improving, components can be b
 
 ## Publishing
 
-The Development Kitchen is published as its own package, independent of the stable components in the `@guardian/src-*` packages. This:
+The Development Kitchen is published as its own package, independent of the stable components in the `@guardian/source-react-components` package. This:
 
 -   Allows the kitchen to move faster than stable
 -   Allows us to make frequent breaking changes while preserving semver. The kitchen can often release new major versions, whereas with the stable library it is desirable for major versions to change at a slower pace, in order to set expectations and preserve developer confidence.

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^3.2.1",
-    "@guardian/source-foundations": "^4.0.0-rc.2",
+    "@guardian/source-foundations": "^4.0.0-rc.3",
     "@guardian/source-react-components": "^4.0.0-rc.2",
     "react": "^17.0.1"
   },

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -13,10 +13,6 @@
     "build": "rollup -c",
     "clean": "rm -rf dist"
   },
-  "dependencies": {
-    "@guardian/src-button": "^3.12.0",
-    "@guardian/src-helpers": "^3.12.0"
-  },
   "devDependencies": {
     "@guardian/eslint-config": "^0.7.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
@@ -31,8 +27,8 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^3.2.1",
-    "@guardian/src-foundations": "^3.9.1",
-    "@guardian/src-icons": "^3.9.1",
+    "@guardian/source-foundations": "^4.0.0-rc.1",
+    "@guardian/source-react-components": "^4.0.0-rc.2",
     "react": "^17.0.1"
   },
   "publishConfig": {

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.1.2",
     "@guardian/libs": "^3.2.1",
-    "@guardian/source-foundations": "^4.0.0-rc.1",
+    "@guardian/source-foundations": "^4.0.0-rc.2",
     "@guardian/source-react-components": "^4.0.0-rc.2",
     "react": "^17.0.1"
   },

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "0.0.23",
+  "version": "1.0.0-rc.0",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/divider/Divider.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/divider/Divider.tsx
@@ -1,10 +1,8 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { space } from '@guardian/src-foundations';
-import { border, text } from '@guardian/src-foundations/palette';
-import { textSans } from '@guardian/src-foundations/typography';
-import type { Props } from '@guardian/src-helpers';
+import { border, space, text, textSans } from '@guardian/source-foundations';
+import type { Props } from '@guardian/source-react-components';
 import { fullStyles, partialStyles } from './styles';
 
 type Size = 'full' | 'partial';

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialButton.stories.tsx
@@ -5,7 +5,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { SvgCross } from '@guardian/src-icons';
+import { SvgCross } from '@guardian/source-react-components';
 import type { Story } from '../../../../../../lib/@types/storybook-emotion-10-fixes';
 import {
 	asChromaticStory,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialButton.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialButton.tsx
@@ -1,6 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import type { ButtonProps as CoreButtonProps } from '@guardian/src-button';
-import { Button as CoreButton } from '@guardian/src-button';
+import type { ButtonProps as CoreButtonProps } from '@guardian/source-react-components';
+import { Button as CoreButton } from '@guardian/source-react-components';
 import {
 	decideBackground,
 	decideBorder,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialLinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialLinkButton.stories.tsx
@@ -5,7 +5,7 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import { SvgCross } from '@guardian/src-icons';
+import { SvgCross } from '@guardian/source-react-components';
 import type { Story } from '../../../../../../lib/@types/storybook-emotion-10-fixes';
 import {
 	asChromaticStory,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialLinkButton.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialLinkButton.tsx
@@ -1,6 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import type { LinkButtonProps as CoreLinkButtonProps } from '@guardian/src-button';
-import { LinkButton as CoreLinkButton } from '@guardian/src-button';
+import type { LinkButtonProps as CoreLinkButtonProps } from '@guardian/source-react-components';
+import { LinkButton as CoreLinkButton } from '@guardian/source-react-components';
 import {
 	decideBackground,
 	decideBorder,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/styles.ts
@@ -7,7 +7,6 @@ import {
 	ArticlePillar,
 	ArticleSpecial,
 } from '@guardian/libs';
-import type { ButtonPriority } from '@guardian/src-button';
 import {
 	culture,
 	labs,
@@ -17,7 +16,8 @@ import {
 	opinion,
 	specialReport,
 	sport,
-} from '@guardian/src-foundations';
+} from '@guardian/source-foundations';
+import type { ButtonPriority } from '@guardian/source-react-components';
 
 export const defaultFormat = {
 	display: ArticleDisplay.Standard,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/lines/Lines.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/lines/Lines.tsx
@@ -1,6 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { line } from '@guardian/src-foundations/palette';
-import type { Props } from '@guardian/src-helpers';
+import { line } from '@guardian/source-foundations';
+import type { Props } from '@guardian/source-react-components';
 import {
 	dashedLines,
 	dottedLines,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/lines/dashed.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/lines/dashed.ts
@@ -1,5 +1,4 @@
-import { space } from '@guardian/src-foundations';
-import { svgBackgroundImage } from '@guardian/src-helpers';
+import { space, svgBackgroundImage } from '@guardian/source-foundations';
 import type { LineCount } from '.';
 
 const thickness = 1;

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/lines/dotted.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/lines/dotted.ts
@@ -1,4 +1,4 @@
-import { svgBackgroundImage } from '@guardian/src-helpers';
+import { svgBackgroundImage } from '@guardian/source-foundations';
 import type { LineCount } from '.';
 
 const dotRadius = 1;

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/lines/squiggly.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/lines/squiggly.ts
@@ -1,4 +1,4 @@
-import { svgBackgroundImage } from '@guardian/src-helpers';
+import { svgBackgroundImage } from '@guardian/source-foundations';
 import type { LineCount } from '.';
 
 const wavelength = 12;

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/lines/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/lines/styles.ts
@@ -1,6 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { remSpace } from '@guardian/src-foundations';
+import { remSpace } from '@guardian/source-foundations';
 import { dashedImage, height as labsImageHeight } from './dashed';
 import { dottedImage, height as dottedImageHeight } from './dotted';
 import { squigglyImage, height as squigglyImageHeight } from './squiggly';

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/logo/Logo.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/logo/Logo.tsx
@@ -1,10 +1,13 @@
 import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { SvgGuardianLogo } from '@guardian/src-brand';
-import { visuallyHidden } from '@guardian/src-foundations/accessibility';
-import { from } from '@guardian/src-foundations/mq';
-import { brandAlt, brandText } from '@guardian/src-foundations/palette';
-import type { Props } from '@guardian/src-helpers';
+import {
+	brandAlt,
+	brandText,
+	from,
+	visuallyHidden,
+} from '@guardian/source-foundations';
+import { SvgGuardianLogo } from '@guardian/source-react-components';
+import type { Props } from '@guardian/source-react-components';
 
 type LogoType = 'standard' | 'anniversary' | 'bestWebsite';
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/quote-icon/QuoteIcon.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/quote-icon/QuoteIcon.tsx
@@ -10,8 +10,8 @@ import {
 	opinion,
 	specialReport,
 	sport,
-} from '@guardian/src-foundations';
-import { SvgQuote } from '@guardian/src-icons';
+} from '@guardian/source-foundations';
+import { SvgQuote } from '@guardian/source-react-components';
 
 const quoteColor = (format: ArticleFormat) => {
 	switch (format.theme) {

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/star-rating/StarRating.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/star-rating/StarRating.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { remSpace } from '@guardian/src-foundations';
-import type { Props } from '@guardian/src-helpers';
+import { remSpace } from '@guardian/source-foundations';
+import type { Props } from '@guardian/source-react-components';
 import { starBackground } from './star';
 
 // https://docs.google.com/spreadsheets/d/1QUa5Kh734J4saFc8ERjCYHZu10_-Hj7llNa2rr8urNg/edit?usp=sharing

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/star-rating/star.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/star-rating/star.ts
@@ -1,5 +1,4 @@
-import { neutral } from '@guardian/src-foundations/palette';
-import { svgBackgroundImage } from '@guardian/src-helpers';
+import { neutral, svgBackgroundImage } from '@guardian/source-foundations';
 
 const spacing = 15;
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.tsx
@@ -1,6 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { error as errorColors } from '@guardian/src-foundations';
-import { SvgAlertTriangle } from '@guardian/src-icons';
+import { error as errorColors } from '@guardian/source-foundations';
+import { SvgAlertTriangle } from '@guardian/source-react-components';
 import {
 	contextStyles,
 	iconStyles,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.tsx
@@ -1,6 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { brand as brandColors, text } from '@guardian/src-foundations';
-import { SvgInfo } from '@guardian/src-icons';
+import { brand as brandColors, text } from '@guardian/source-foundations';
+import { SvgInfo } from '@guardian/source-react-components';
 import {
 	contextStyles,
 	iconStyles,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.tsx
@@ -1,6 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { success as successColors } from '@guardian/src-foundations';
-import { SvgTickRound } from '@guardian/src-icons';
+import { success as successColors } from '@guardian/source-foundations';
+import { SvgTickRound } from '@guardian/source-react-components';
 import {
 	contextStyles,
 	iconStyles,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/index.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/index.tsx
@@ -1,4 +1,4 @@
-import type { Props } from '@guardian/src-helpers';
+import type { Props } from '@guardian/source-react-components';
 
 export interface SummaryProps extends Props {
 	/**

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/styles.ts
@@ -1,8 +1,6 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { space } from '@guardian/src-foundations';
-import { size } from '@guardian/src-foundations/size';
-import { textSans } from '@guardian/src-foundations/typography';
+import { size, space, textSans } from '@guardian/source-foundations';
 
 export const wrapperStyles = (color: string): SerializedStyles => css`
 	border: 4px solid ${color};

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import type { Props } from '@guardian/src-helpers';
+import type { Props } from '@guardian/source-react-components';
 import {
 	buttonStyles,
 	labelStyles,

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
-import { neutral, success } from '@guardian/src-foundations';
-import { textSans } from '@guardian/src-foundations/typography';
+import { neutral, success, textSans } from '@guardian/source-foundations';
 
 export const toggleSwitchStyles = css`
 	display: flex;

--- a/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
+++ b/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
@@ -3,16 +3,12 @@
   "compilerOptions": {
     "outDir": "dist/types",
     "declaration": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "paths": {
+      "@guardian/source-foundations": ["../source-foundations/index"],
+      "@guardian/source-react-components": ["../source-react-components/index"]
+    }
   },
   "include": ["src"],
-  "exclude": ["dist", "src/**/*.stories.tsx"],
-  "references": [
-    {
-      "path": "../src-foundations"
-    },
-    {
-      "path": "../src-helpers"
-    }
-  ]
+  "exclude": ["dist", "src/**/*.stories.tsx"]
 }

--- a/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
+++ b/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
@@ -6,13 +6,5 @@
     "emitDeclarationOnly": true
   },
   "include": ["src"],
-  "exclude": ["dist", "src/**/*.stories.tsx"],
-  "references": [
-    {
-      "path": "../source-foundations"
-    },
-    {
-      "path": "../source-react-components"
-    }
-  ]
+  "exclude": ["dist", "src/**/*.stories.tsx"]
 }

--- a/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
+++ b/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
@@ -3,12 +3,16 @@
   "compilerOptions": {
     "outDir": "dist/types",
     "declaration": true,
-    "emitDeclarationOnly": true,
-    "paths": {
-      "@guardian/source-foundations": ["../source-foundations/index"],
-      "@guardian/source-react-components": ["../source-react-components/index"]
-    }
+    "emitDeclarationOnly": true
   },
   "include": ["src"],
-  "exclude": ["dist", "src/**/*.stories.tsx"]
+  "exclude": ["dist", "src/**/*.stories.tsx"],
+  "references": [
+    {
+      "path": "../source-foundations"
+    },
+    {
+      "path": "../source-react-components"
+    }
+  ]
 }

--- a/packages/@guardian/source-react-components/tsconfig.json
+++ b/packages/@guardian/source-react-components/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
+    "composite": true,
     "paths": {
       "@guardian/src-accordion": ["../src-accordion/index"],
       "@guardian/src-brand": ["../src-brand/index"],

--- a/packages/@guardian/source-react-components/tsconfig.json
+++ b/packages/@guardian/source-react-components/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
+    "emitDeclarationOnly": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,

--- a/packages/@guardian/source-react-components/tsconfig.json
+++ b/packages/@guardian/source-react-components/tsconfig.json
@@ -4,7 +4,6 @@
     "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
-    "emitDeclarationOnly": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
@@ -19,7 +18,6 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "composite": true,
     "paths": {
       "@guardian/src-accordion": ["../src-accordion/index"],
       "@guardian/src-brand": ["../src-brand/index"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@guardian/source-foundations": [
+        "packages/@guardian/source-foundations/src"
+      ],
+      "@guardian/source-react-components": [
+        "packages/@guardian/source-react-components/src"
+      ],
       "@guardian/src-foundations": ["packages/@guardian/src-foundations/src"],
       "@guardian/src-foundations/mq": [
         "packages/@guardian/src-foundations/src/mq"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,11 +27,7 @@
       "@guardian/src-label": ["packages/@guardian/src-label"],
       "@guardian/src-user-feedback": ["packages/@guardian/src-user-feedback"],
       "@guardian/src-helpers": ["packages/@guardian/src-helpers"],
-      "@guardian/src-icons": ["packages/@guardian/src-icons"],
-      "@guardian/source-foundations": ["packages/@guardian/source-foundations"],
-      "@guardian/source-react-components": [
-        "packages/@guardian/source-reat-components"
-      ]
+      "@guardian/src-icons": ["packages/@guardian/src-icons"]
     },
     "outDir": "dist",
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,11 @@
       "@guardian/src-label": ["packages/@guardian/src-label"],
       "@guardian/src-user-feedback": ["packages/@guardian/src-user-feedback"],
       "@guardian/src-helpers": ["packages/@guardian/src-helpers"],
-      "@guardian/src-icons": ["packages/@guardian/src-icons"]
+      "@guardian/src-icons": ["packages/@guardian/src-icons"],
+      "@guardian/source-foundations": ["packages/@guardian/source-foundations"],
+      "@guardian/source-react-components": [
+        "packages/@guardian/source-reat-components"
+      ]
     },
     "outDir": "dist",
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1490,16 +1490,16 @@
     eslint-plugin-prettier "3.4.0"
 
 "@guardian/eslint-plugin-source-foundations@file:packages/@guardian/eslint-plugin-source-foundations":
-  version "4.0.0-rc.1"
+  version "4.0.0-rc.2"
   dependencies:
     "@typescript-eslint/eslint-plugin" "4.33.0"
     "@typescript-eslint/parser" "4.29.2"
     eslint-plugin-import "2.24.0"
 
 "@guardian/eslint-plugin-source-react-components@file:packages/@guardian/eslint-plugin-source-react-components":
-  version "4.0.0-rc.1"
+  version "4.0.0-rc.2"
   dependencies:
-    "@guardian/eslint-plugin-source-foundations" "^4.0.0-rc.1"
+    "@guardian/eslint-plugin-source-foundations" "^4.0.0-rc.2"
     "@typescript-eslint/eslint-plugin" "4.29.2"
     "@typescript-eslint/parser" "4.29.2"
 


### PR DESCRIPTION
## What is the purpose of this change?

Update the kitchen to use Source v4 so that projects that are updating can drop all dependencies on `src-*` packages.

## What does this change?

-   Update the dependencies
-   Update the `tsconfig.json`
- Update all imports
