### PR TITLE
Move `get-icons` config to separate file

### DIFF
--- a/scripts/get-icons/config.ts
+++ b/scripts/get-icons/config.ts
@@ -1,0 +1,11 @@
+export const ICON_FILE = 'Ai7AELHC6KCz38qKZkvuHo';
+
+export const ICON_FRAMES = ['UI icons 24(w)x24(w)', 'Payment icons 24 x 24'];
+
+export const OUTPUT_DIR = '../../packages/@guardian/src-icons/svgs';
+
+export const FIGMA_OPTIONS = {
+	headers: {
+		'X-Figma-Token': process.env.FIGMA_TOKEN ?? 'ADD ME!!!',
+	},
+};

--- a/scripts/get-icons/index.ts
+++ b/scripts/get-icons/index.ts
@@ -1,17 +1,6 @@
 import axios from 'axios';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-
-const ICON_FILE = 'Ai7AELHC6KCz38qKZkvuHo';
-
-const ICON_FRAMES = ['UI icons 24(w)x24(w)', 'Payment icons 24 x 24'];
-
-const OUTPUT_DIR = '../../packages/@guardian/src-icons/svgs';
-
-const FIGMA_OPTIONS = {
-	headers: {
-		'X-Figma-Token': process.env.FIGMA_TOKEN ?? 'ADD ME!!!',
-	},
-};
+import { FIGMA_OPTIONS, ICON_FILE, ICON_FRAMES, OUTPUT_DIR } from './config';
 
 interface FigmaComponentsResponse {
 	meta: {


### PR DESCRIPTION
## What is the purpose of this change?

This change does some tidying up of the `get-icons` script to make it a bit easier to understand and maintain.