### PR TITLE
Ignore some icons completely

### DIFF
--- a/scripts/get-icons/config.ts
+++ b/scripts/get-icons/config.ts
@@ -9,3 +9,10 @@ export const FIGMA_OPTIONS = {
 		'X-Figma-Token': process.env.FIGMA_TOKEN ?? 'ADD ME!!!',
 	},
 };
+
+export const ICONS_TO_IGNORE = [
+	'apple-brand',
+	'facebook-brand',
+	'google-brand',
+	'paypal',
+];

--- a/scripts/get-icons/config.ts
+++ b/scripts/get-icons/config.ts
@@ -1,0 +1,11 @@
+export const ICON_FILE = 'Ai7AELHC6KCz38qKZkvuHo';
+
+export const ICON_FRAMES = ['UI icons 24(w)x24(w)', 'Payment icons 24 x 24'];
+
+export const OUTPUT_DIR = '../../packages/@guardian/src-icons/svgs';
+
+export const FIGMA_OPTIONS = {
+	headers: {
+		'X-Figma-Token': process.env.FIGMA_TOKEN ?? 'ADD ME!!!',
+	},
+};

--- a/scripts/get-icons/index.ts
+++ b/scripts/get-icons/index.ts
@@ -1,17 +1,6 @@
 import axios from 'axios';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-
-const ICON_FILE = 'Ai7AELHC6KCz38qKZkvuHo';
-
-const ICON_FRAMES = ['UI icons 24(w)x24(w)', 'Payment icons 24 x 24'];
-
-const OUTPUT_DIR = '../../packages/@guardian/src-icons/svgs';
-
-const FIGMA_OPTIONS = {
-	headers: {
-		'X-Figma-Token': process.env.FIGMA_TOKEN ?? 'ADD ME!!!',
-	},
-};
+import { FIGMA_OPTIONS, ICON_FILE, ICON_FRAMES, OUTPUT_DIR } from './config';
 
 interface FigmaComponentsResponse {
 	meta: {

--- a/scripts/get-icons/index.ts
+++ b/scripts/get-icons/index.ts
@@ -1,6 +1,12 @@
 import axios from 'axios';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
-import { FIGMA_OPTIONS, ICON_FILE, ICON_FRAMES, OUTPUT_DIR } from './config';
+import {
+	FIGMA_OPTIONS,
+	ICONS_TO_IGNORE,
+	ICON_FILE,
+	ICON_FRAMES,
+	OUTPUT_DIR,
+} from './config';
 
 interface FigmaComponentsResponse {
 	meta: {
@@ -63,8 +69,11 @@ axios
 		const svgNodes = res.data.meta.components
 			.filter((c) => {
 				return (
+					// Only get icons that are in a certain frame
 					c.containing_frame &&
-					ICON_FRAMES.includes(c.containing_frame.name)
+					ICON_FRAMES.includes(c.containing_frame.name) &&
+					// Ignore some icons
+					!ICONS_TO_IGNORE.includes(c.name)
 				);
 			})
 			.map(({ node_id, name }) => {


### PR DESCRIPTION
**To be merged after #1173**

## What is the purpose of this change?

There are a handful of special cases, where the icons retain some of the attributes that are typically removed. These icons are:

* apple-brand
* facebook-brand
* google-brand
* paypal

As none of these follow a consistent pattern, it is hard to automate them. This PR simply ignores them completely. For now, the process for these icons should be to pull them in manually when any changes occur. Going forwards, we should investigate whether it's possible to standardise these cases further, and thus automate them. Alternatively, we should at least improve the process by which they are pulled in.

## What does this change?

-   Add an `ICONS_TO_IGNORE` config item
-   If the icon name is in this list, skip it
