### PR TITLE
Add mini-svg-data-uri dependency

### DIFF
--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -17,6 +17,9 @@
     "build": "rollup -c",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "mini-svg-data-uri": "^1.3.3"
+  },
   "devDependencies": {
     "@guardian/eslint-config": "^0.7.0",
     "@guardian/eslint-config-typescript": "^0.7.0",


### PR DESCRIPTION
## What is the purpose of this change?

In #1166 we exported `svgBackgroundImage` from the new `@guardian/source-foundations` package. That feature relies on the `mini-svg-data-url` package which was not added as a dependency at the same time. This PR corrects that.