### PR TITLE
Make running chromatic on dependabot a manual process

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,6 @@
 name: Chromatic
 on:
-  workflow_run:
-    workflows: ['Dependabot PR Check']
-    types:
-      - completed
+  workflow_dispatch:
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,8 +1,0 @@
-name: Dependabot PR Check
-on: push
-jobs:
-  check-dependabot:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - run: echo "PR created by Dependabot"


### PR DESCRIPTION
## What is the purpose of this change?

Currently chromatic runs on dependabot PRs via a workaround where a workflow runs on all dependabot PRs and, when it completes, that triggers the chromatic workflow. We are seeing lots of runs of the chromatic workflow, partly as dependabot rebases PRs on each merge to main, and maybe also because of an issue with this approach.

This PR makes it a manual process to run chromatic on dependabot PRs. As chromatic is a required check, it will have to be run before the PR is merged but this means it can be run once just before merging.

## What does this change?

-   Remove the `Dependabot PR Check` workflow
-   Add `workflow_dispatch` as a trigger to the chromatic workflow
