### PR TITLE
Run chromatic directly on dependabot PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,11 +1,9 @@
 name: Chromatic
 on:
-  workflow_dispatch:
   push:
     branches-ignore:
       - 'gh-pages'
       - '[0-9]+.[0-9]+'
-      - 'dependabot/**'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What is the purpose of this change?

As of March 2021, workflows triggered by a push event don't have access to GitHub secrets, if that event originates from a fork of the repo. As a result, PRs raised by Dependabot are not able to trigger a Chromatic run.

In #1112 we introduced a workaround:

> Here I am creating a special workflow that completes successfully if the user raising the PR is Dependabot.
> 
> When this completes, the Chromatic workflow is triggered by the workflow_run event. Workflows triggered by this event > have access to secrets, so can successfully run Chromatic.

Recently we discovered that the chromatic workflow was running multiple times against the same commit for a dependabot PR, increasing the number of snapshots and therefore the bill for chromatic. 

#1177 updated the workflow to allow chromatic to be triggered by the `workflow_dispatch` event, i.e. manually. The hope was that this would let us manually run the step for dependabot PRs just before they were merged. Unfortunately, an error occurred when running the workflow manually.

This PR reverts those changes and returns us to the situation where chromatic will run automatically on a dependabot PR but fail due to a lack of token. Whilst this is not ideal, it is possible to manually rerun the workflow successfully. This means that we retain chromatic checks on dependabot PRs but only have to run the workflow once, reducing the number of snapshots consumer. 

