### PR TITLE
Refactor theming functions

### DIFF
--- a/.storybook/preview/ThemeProviderDecorator.tsx
+++ b/.storybook/preview/ThemeProviderDecorator.tsx
@@ -1,9 +1,7 @@
 import { ThemeProvider } from '@emotion/react';
 
 export const ThemeProviderDecorator = (storyFn, context) => {
-	const theme = {
-		// accordion: undefined,
-	};
+	const theme = context.parameters.theme;
 	return theme ? (
 		<ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>
 	) : (

--- a/.storybook/preview/ThemeProviderDecorator.tsx
+++ b/.storybook/preview/ThemeProviderDecorator.tsx
@@ -1,7 +1,9 @@
 import { ThemeProvider } from '@emotion/react';
 
 export const ThemeProviderDecorator = (storyFn, context) => {
-	const theme = context.parameters.theme;
+	const theme = {
+		// accordion: undefined,
+	};
 	return theme ? (
 		<ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>
 	) : (

--- a/packages/@guardian/src-accordion/Accordion.tsx
+++ b/packages/@guardian/src-accordion/Accordion.tsx
@@ -29,7 +29,7 @@ export const Accordion = ({
 	// AUDIT https://www.sarasoueidan.com/blog/accordion-markup/
 	return (
 		<div
-			css={(theme) => [accordion(theme.accordion && theme), cssOverrides]}
+			css={(theme) => [accordion(theme.accordion), cssOverrides]}
 			{...props}
 		>
 			{Children.map(children, (child) => {

--- a/packages/@guardian/src-accordion/AccordionRow.tsx
+++ b/packages/@guardian/src-accordion/AccordionRow.tsx
@@ -63,18 +63,13 @@ export const AccordionRow = ({
 
 	if (isBrowser) {
 		return (
-			<div
-				css={(theme) => [
-					accordionRow(theme.accordion && theme),
-					cssOverrides,
-				]}
-			>
+			<div css={(theme) => [accordionRow(theme.accordion), cssOverrides]}>
 				<button
 					type="button"
 					aria-expanded={expanded}
 					onClick={handleClick}
 					css={(theme) => [
-						button(theme.accordion && theme),
+						button(theme.accordion),
 						expanded ? chevronIconUp : chevronIconDown,
 						!hideToggleLabel ? toggleIconWithLabel : '',
 					]}

--- a/packages/@guardian/src-accordion/AccordionRowNoJS.tsx
+++ b/packages/@guardian/src-accordion/AccordionRowNoJS.tsx
@@ -29,16 +29,13 @@ export const AccordionRowNoJS = ({
 }: AccordionRowProps) => {
 	return (
 		<div
-			css={(theme) => [
-				accordionRow(theme.accordion && theme),
-				cssOverrides,
-			]}
+			css={(theme) => [accordionRow(theme.accordion), cssOverrides]}
 			{...props}
 		>
 			<label>
 				<input type="checkbox" css={noJsInput} role="button" />
 				<div
-					css={(theme) => noJsButton(theme.accordion && theme)}
+					css={(theme) => noJsButton(theme.accordion)}
 					data-target="label"
 				>
 					<strong css={labelText}>{label}</strong>

--- a/packages/@guardian/src-accordion/styles.ts
+++ b/packages/@guardian/src-accordion/styles.ts
@@ -6,11 +6,11 @@ import { until, from } from '@guardian/src-foundations/mq';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { accordionDefault } from '@guardian/src-foundations/themes';
 
-export const accordion = ({ accordion } = accordionDefault) => css`
+export const accordion = (accordion = accordionDefault.accordion) => css`
 	border-bottom: 1px solid ${accordion.borderPrimary};
 `;
 
-export const accordionRow = ({ accordion } = accordionDefault) => css`
+export const accordionRow = (accordion = accordionDefault.accordion) => css`
 	border-top: 1px solid ${accordion.borderPrimary};
 `;
 
@@ -23,7 +23,7 @@ const buttonStyles = css`
 	cursor: pointer;
 `;
 
-export const button = ({ accordion } = accordionDefault) => css`
+export const button = (accordion = accordionDefault.accordion) => css`
 	${buttonStyles};
 	color: ${accordion.textPrimary};
 
@@ -38,7 +38,7 @@ export const button = ({ accordion } = accordionDefault) => css`
 	}
 `;
 
-export const noJsButton = ({ accordion } = accordionDefault) => css`
+export const noJsButton = (accordion = accordionDefault.accordion) => css`
 	${buttonStyles};
 	color: ${accordion.textPrimary};
 `;

--- a/packages/@guardian/src-button/styles.ts
+++ b/packages/@guardian/src-button/styles.ts
@@ -1,4 +1,4 @@
-import { css, SerializedStyles } from '@emotion/react';
+import { css, SerializedStyles, Theme } from '@emotion/react';
 import { space, transitions } from '@guardian/src-foundations';
 import { height, width } from '@guardian/src-foundations/size';
 import { buttonDefault, ButtonTheme } from '@guardian/src-foundations/themes';
@@ -29,7 +29,7 @@ const button = css`
 	}
 `;
 
-const primary = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
+const primary = (button: ButtonTheme = buttonDefault.button) => css`
 	background-color: ${button.backgroundPrimary};
 	color: ${button.textPrimary};
 
@@ -38,7 +38,7 @@ const primary = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
 	}
 `;
 
-const secondary = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
+const secondary = (button: ButtonTheme = buttonDefault.button) => css`
 	background-color: ${button.backgroundSecondary};
 	color: ${button.textSecondary};
 
@@ -47,7 +47,7 @@ const secondary = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
 	}
 `;
 
-const tertiary = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
+const tertiary = (button: ButtonTheme = buttonDefault.button) => css`
 	color: ${button.textTertiary};
 	border: 1px solid ${button.borderTertiary};
 
@@ -56,7 +56,7 @@ const tertiary = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
 	}
 `;
 
-const subdued = ({ button }: { button: ButtonTheme } = buttonDefault) => css`
+const subdued = (button: ButtonTheme = buttonDefault.button) => css`
 	padding: 0;
 	background-color: transparent;
 	color: ${button.textSubdued};
@@ -201,11 +201,7 @@ const iconNudgeAnimation = css`
 `;
 
 const priorities: {
-	[key in ButtonPriority]: ({
-		button,
-	}: {
-		button: ButtonTheme;
-	}) => SerializedStyles;
+	[key in ButtonPriority]: (button?: ButtonTheme) => SerializedStyles;
 } = {
 	primary,
 	secondary,
@@ -252,12 +248,11 @@ export const buttonStyles =
 		nudgeIcon,
 		cssOverrides,
 	}: SharedButtonProps) =>
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-	(theme: any) =>
+	(theme: Theme) =>
 		[
 			button,
 			sizes[size],
-			priorities[priority](theme.button && theme),
+			priorities[priority](theme.button),
 			iconSvg ? iconSizes[size] : '',
 			iconSvg && !hideLabel ? iconSides[iconSide] : '',
 			nudgeIcon ? iconNudgeAnimation : '',

--- a/packages/@guardian/src-checkbox/Checkbox.tsx
+++ b/packages/@guardian/src-checkbox/Checkbox.tsx
@@ -101,8 +101,8 @@ export const Checkbox = ({
 			<input
 				type="checkbox"
 				css={(theme) => [
-					checkbox(theme.checkbox && theme),
-					error ? errorCheckbox(theme.checkbox && theme) : '',
+					checkbox(theme.checkbox),
+					error ? errorCheckbox(theme.checkbox) : '',
 					cssOverrides,
 				]}
 				aria-invalid={!!error}
@@ -116,7 +116,7 @@ export const Checkbox = ({
 			/>
 			<span
 				css={(theme) => [
-					tick(theme.checkbox && theme),
+					tick(theme.checkbox),
 					labelContent || supporting ? tickWithLabelText : '',
 					supporting ? tickWithSupportingText : '',
 				]}
@@ -127,7 +127,7 @@ export const Checkbox = ({
 	const labelledBox = (
 		<label
 			css={(theme) => [
-				label(theme.checkbox && theme),
+				label(theme.checkbox),
 				supporting ? labelWithSupportingText : '',
 			]}
 		>

--- a/packages/@guardian/src-checkbox/LabelText.tsx
+++ b/packages/@guardian/src-checkbox/LabelText.tsx
@@ -11,7 +11,7 @@ export const LabelText = ({
 	return (
 		<div
 			css={(theme) => [
-				labelText(theme.checkbox && theme),
+				labelText(theme.checkbox),
 				hasSupportingText ? labelTextWithSupportingText : '',
 			]}
 		>

--- a/packages/@guardian/src-checkbox/SupportingText.tsx
+++ b/packages/@guardian/src-checkbox/SupportingText.tsx
@@ -3,8 +3,6 @@ import { supportingText } from './styles';
 
 export const SupportingText = ({ children }: { children: ReactNode }) => {
 	return (
-		<div css={(theme) => supportingText(theme.checkbox && theme)}>
-			{children}
-		</div>
+		<div css={(theme) => supportingText(theme.checkbox)}>{children}</div>
 	);
 };

--- a/packages/@guardian/src-checkbox/styles.ts
+++ b/packages/@guardian/src-checkbox/styles.ts
@@ -13,7 +13,7 @@ export const fieldset = css`
 	flex-direction: column;
 `;
 
-export const label = ({ checkbox } = checkboxDefault) => css`
+export const label = (checkbox = checkboxDefault.checkbox) => css`
 	position: relative;
 	display: flex;
 	align-items: center;
@@ -32,7 +32,7 @@ export const labelWithSupportingText = css`
 	margin-bottom: ${space[3]}px;
 `;
 
-export const checkbox = ({ checkbox } = checkboxDefault) => css`
+export const checkbox = (checkbox = checkboxDefault.checkbox) => css`
 	flex: 0 0 auto;
 	box-sizing: border-box;
 	display: inline-block;
@@ -79,7 +79,7 @@ export const checkbox = ({ checkbox } = checkboxDefault) => css`
 	}
 `;
 
-export const labelText = ({ checkbox } = checkboxDefault) => css`
+export const labelText = (checkbox = checkboxDefault.checkbox) => css`
 	${textSans.medium({ lineHeight: 'regular' })};
 	color: ${checkbox.textLabel};
 	width: 100%;
@@ -89,12 +89,12 @@ export const labelTextWithSupportingText = css`
 	${textSans.medium({ lineHeight: 'regular' })};
 `;
 
-export const supportingText = ({ checkbox } = checkboxDefault) => css`
+export const supportingText = (checkbox = checkboxDefault.checkbox) => css`
 	${textSans.small({ lineHeight: 'regular' })};
 	color: ${checkbox.textLabelSupporting};
 `;
 
-export const tick = ({ checkbox } = checkboxDefault) => css`
+export const tick = (checkbox = checkboxDefault.checkbox) => css`
 	@supports (
 		(appearance: none) or (-webkit-appearance: none) or
 			(-moz-appearance: none)
@@ -159,6 +159,6 @@ export const tickWithSupportingText = css`
 	}
 `;
 
-export const errorCheckbox = ({ checkbox } = checkboxDefault) => css`
+export const errorCheckbox = (checkbox = checkboxDefault.checkbox) => css`
 	border: 4px solid ${checkbox.borderError};
 `;

--- a/packages/@guardian/src-choice-card/ChoiceCard.tsx
+++ b/packages/@guardian/src-choice-card/ChoiceCard.tsx
@@ -83,7 +83,7 @@ export const ChoiceCard = ({
 			{/* eslint-disable-next-line jsx-a11y/role-supports-aria-props*/}
 			<input
 				css={(theme) => [
-					input(theme.choiceCard && theme),
+					input(theme.choiceCard),
 					userChanged ? tickAnimation : '',
 					cssOverrides,
 				]}
@@ -106,8 +106,8 @@ export const ChoiceCard = ({
 			/>
 			<label
 				css={(theme) => [
-					choiceCard(theme.choiceCard && theme),
-					error ? errorChoiceCard(theme.choiceCard && theme) : '',
+					choiceCard(theme.choiceCard),
+					error ? errorChoiceCard(theme.choiceCard) : '',
 				]}
 				htmlFor={id}
 			>
@@ -120,7 +120,7 @@ export const ChoiceCard = ({
 					{iconSvg ? iconSvg : ''}
 					<div>{labelContent}</div>
 				</div>
-				<span css={(theme) => [tick(theme.checkbox && theme)]} />
+				<span css={(theme) => [tick(theme.choiceCard)]} />
 			</label>
 		</>
 	);

--- a/packages/@guardian/src-choice-card/styles.ts
+++ b/packages/@guardian/src-choice-card/styles.ts
@@ -52,7 +52,7 @@ export const gridColumns: { [key in ChoiceCardColumns]: SerializedStyles } = {
 	5: gridColumnsStyle(5),
 };
 
-export const input = ({ choiceCard } = choiceCardDefault) => css`
+export const input = (choiceCard = choiceCardDefault.choiceCard) => css`
 	${visuallyHidden};
 
 	&:focus + label {
@@ -120,7 +120,7 @@ export const tickAnimation = css`
 	}
 `;
 
-export const choiceCard = ({ choiceCard } = choiceCardDefault) => css`
+export const choiceCard = (choiceCard = choiceCardDefault.choiceCard) => css`
 	flex: 1;
 	display: flex;
 	justify-content: center;
@@ -190,7 +190,7 @@ export const contentWrapperLabelOnly = css`
 
 // TODO: most of this is duplicated in the checkbox component
 // We should extract it into its own module somewhere
-export const tick = ({ choiceCard } = choiceCardDefault) => css`
+export const tick = (choiceCard = choiceCardDefault.choiceCard) => css`
 	/* overall positional properties */
 	position: absolute;
 	top: 50%;
@@ -229,7 +229,9 @@ export const tick = ({ choiceCard } = choiceCardDefault) => css`
 	}
 `;
 
-export const errorChoiceCard = ({ choiceCard } = choiceCardDefault) => css`
+export const errorChoiceCard = (
+	choiceCard = choiceCardDefault.choiceCard,
+) => css`
 	box-shadow: inset 0 0 0 4px ${choiceCard.borderError};
 
 	& > * {

--- a/packages/@guardian/src-footer/BackToTop.tsx
+++ b/packages/@guardian/src-footer/BackToTop.tsx
@@ -4,9 +4,9 @@ import { SvgChevronUpSingle } from '@guardian/src-icons';
 export { footerBrand } from '@guardian/src-foundations/themes';
 
 export const BackToTop = (
-	<a href="#top" css={(theme) => backToTop(theme.footer && theme)}>
+	<a href="#top" css={(theme) => backToTop(theme.footer)}>
 		Back to top
-		<div css={(theme) => backToTopIcon(theme.footer && theme)}>
+		<div css={(theme) => backToTopIcon(theme.footer)}>
 			<SvgChevronUpSingle />
 		</div>
 	</a>

--- a/packages/@guardian/src-footer/Footer.tsx
+++ b/packages/@guardian/src-footer/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer = ({
 }: FooterProps) => {
 	return (
 		<footer
-			css={(theme) => [footer(theme.footer && theme), cssOverrides]}
+			css={(theme) => [footer(theme.footer), cssOverrides]}
 			{...props}
 		>
 			<div
@@ -44,9 +44,7 @@ export const Footer = ({
 						: linksWrapperSpace,
 				]}
 			>
-				<div css={(theme) => links(theme.footer && theme)}>
-					{children}
-				</div>
+				<div css={(theme) => links(theme.footer)}>{children}</div>
 				{showBackToTop ? BackToTop : ''}
 			</div>
 			<small

--- a/packages/@guardian/src-footer/styles.ts
+++ b/packages/@guardian/src-footer/styles.ts
@@ -6,7 +6,7 @@ import { height, width } from '@guardian/src-foundations/size';
 import { textSans } from '@guardian/src-foundations/typography';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 
-export const footer = ({ footer } = footerBrand) => css`
+export const footer = (footer = footerBrand.footer) => css`
 	color: ${footer.text};
 	background-color: ${footer.background};
 	padding: 0 ${space[3]}px ${space[3]}px ${space[3]}px;
@@ -37,7 +37,7 @@ export const linksWrapperSpaceWithBackToTop = css`
 	}
 `;
 
-export const links = ({ footer } = footerBrand) => css`
+export const links = (footer = footerBrand.footer) => css`
 	border-style: solid;
 	border-color: ${footer.border};
 	border-width: 0 0 1px 0;
@@ -63,7 +63,7 @@ export const copyrightExtraPadding = css`
 	}
 `;
 
-export const backToTop = ({ footer } = footerBrand) => css`
+export const backToTop = (footer = footerBrand.footer) => css`
 	display: flex;
 	align-items: center;
 	height: ${height.ctaMedium}px;
@@ -83,7 +83,7 @@ export const backToTop = ({ footer } = footerBrand) => css`
 	}
 `;
 
-export const backToTopIcon = ({ footer } = footerBrand) => css`
+export const backToTopIcon = (footer = footerBrand.footer) => css`
 	height: ${height.ctaMedium}px;
 	width: ${width.ctaMedium}px;
 	display: flex;

--- a/packages/@guardian/src-foundations/types/themes.d.ts
+++ b/packages/@guardian/src-foundations/types/themes.d.ts
@@ -1,5 +1,4 @@
 import '@emotion/react';
-
 import {
 	accordionDefault,
 	buttonDefault,
@@ -13,21 +12,20 @@ import {
 	textInputDefault,
 	userFeedbackDefault,
 } from '@guardian/src-foundations/themes';
-
 declare module '@emotion/react' {
 	export interface Theme {
-		accordion: typeof accordionDefault.accordion;
-		button: typeof buttonDefault.button;
-		checkbox: typeof checkboxDefault.checkbox;
-		choiceCard: typeof choiceCardDefault.choiceCard;
-		footer: typeof footerBrand.footer;
-		label: typeof labelDefault.label;
-		layout: {};
-		link: typeof linkDefault.link;
-		radio: typeof radioDefault.radio;
-		select: typeof selectDefault.select;
-		textArea: {};
-		textInput: typeof textInputDefault.textInput;
-		userFeedback: typeof userFeedbackDefault.userFeedback;
+		accordion?: typeof accordionDefault.accordion;
+		button?: typeof buttonDefault.button;
+		checkbox?: typeof checkboxDefault.checkbox;
+		choiceCard?: typeof choiceCardDefault.choiceCard;
+		footer?: typeof footerBrand.footer;
+		label?: typeof labelDefault.label;
+		layout?: {};
+		link?: typeof linkDefault.link;
+		radio?: typeof radioDefault.radio;
+		select?: typeof selectDefault.select;
+		textArea?: {};
+		textInput?: typeof textInputDefault.textInput;
+		userFeedback?: typeof userFeedbackDefault.userFeedback;
 	}
 }

--- a/packages/@guardian/src-label/SupportingText.tsx
+++ b/packages/@guardian/src-label/SupportingText.tsx
@@ -17,7 +17,7 @@ export const SupportingText = ({
 	return (
 		<p
 			css={(theme) => [
-				supportingText(theme.label && theme),
+				supportingText(theme.label),
 				hideLabel ? visuallyHidden : '',
 			]}
 		>

--- a/packages/@guardian/src-label/Text.tsx
+++ b/packages/@guardian/src-label/Text.tsx
@@ -10,15 +10,13 @@ const visuallyHidden = css`
 export const Text = ({ text, optional, hideLabel }: LabelProps) => (
 	<div
 		css={(theme) => [
-			labelText(theme.label && theme),
+			labelText(theme.label),
 			hideLabel ? visuallyHidden : '',
 		]}
 	>
 		{text}{' '}
 		{optional ? (
-			<span css={(theme) => optionalText(theme.label && theme)}>
-				Optional
-			</span>
+			<span css={(theme) => optionalText(theme.label)}>Optional</span>
 		) : (
 			''
 		)}

--- a/packages/@guardian/src-label/styles.ts
+++ b/packages/@guardian/src-label/styles.ts
@@ -7,18 +7,18 @@ export const legend = css`
 	${resets.legend};
 `;
 
-export const labelText = ({ label } = labelDefault) => css`
+export const labelText = (label = labelDefault.label) => css`
 	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
 	color: ${label.textLabel};
 `;
 
-export const optionalText = ({ label } = labelDefault) => css`
+export const optionalText = (label = labelDefault.label) => css`
 	${textSans.small({ lineHeight: 'regular' })};
 	color: ${label.textOptional};
 	font-style: italic;
 `;
 
-export const supportingText = ({ label } = labelDefault) => css`
+export const supportingText = (label = labelDefault.label) => css`
 	${textSans.small({ lineHeight: 'regular' })};
 	color: ${label.textSupporting};
 	margin: 2px 0 0;

--- a/packages/@guardian/src-link/styles.ts
+++ b/packages/@guardian/src-link/styles.ts
@@ -112,7 +112,7 @@ export const linkStyles = ({
 	return (theme: any) => [
 		link,
 		isButton ? buttonLink : '',
-		priorities[priority](theme.link && theme),
+		priorities[priority](theme.link),
 		isSubdued ? subdued : '',
 		iconSvg ? icon : '',
 		iconSvg ? iconSides[iconSide] : '',

--- a/packages/@guardian/src-link/styles.ts
+++ b/packages/@guardian/src-link/styles.ts
@@ -1,4 +1,4 @@
-import { css, SerializedStyles } from '@emotion/react';
+import { css, SerializedStyles, Theme } from '@emotion/react';
 import { width } from '@guardian/src-foundations/size';
 import { linkDefault, LinkTheme } from '@guardian/src-foundations/themes';
 import { textSans } from '@guardian/src-foundations/typography';
@@ -28,7 +28,7 @@ export const buttonLink = css`
 	padding: 0;
 `;
 
-export const primary = ({ link }: { link: LinkTheme } = linkDefault) => css`
+export const primary = (link: LinkTheme = linkDefault.link) => css`
 	color: ${link.textPrimary};
 
 	&:hover {
@@ -36,7 +36,7 @@ export const primary = ({ link }: { link: LinkTheme } = linkDefault) => css`
 	}
 `;
 
-export const secondary = ({ link }: { link: LinkTheme } = linkDefault) => css`
+export const secondary = (link: LinkTheme = linkDefault.link) => css`
 	color: ${link.textSecondary};
 
 	&:hover {
@@ -80,7 +80,7 @@ export const iconLeft = css`
 `;
 
 const priorities: {
-	[key in LinkPriority]: ({ link }: { link: LinkTheme }) => SerializedStyles;
+	[key in LinkPriority]: (link?: LinkTheme) => SerializedStyles;
 } = {
 	primary,
 	secondary,
@@ -109,7 +109,7 @@ export const linkStyles = ({
 	cssOverrides?: SerializedStyles | SerializedStyles[];
 }) => {
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-	return (theme: any) => [
+	return (theme: Theme) => [
 		link,
 		isButton ? buttonLink : '',
 		priorities[priority](theme.link),

--- a/packages/@guardian/src-radio/Radio.tsx
+++ b/packages/@guardian/src-radio/Radio.tsx
@@ -20,7 +20,7 @@ const LabelText = ({
 		<div
 			css={(theme) => [
 				hasSupportingText ? labelTextWithSupportingText : '',
-				labelText(theme.radio && theme),
+				labelText(theme.radio),
 			]}
 			className="src-radio-label-text"
 		>
@@ -30,11 +30,7 @@ const LabelText = ({
 };
 
 const SupportingText = ({ children }: { children: ReactNode }) => {
-	return (
-		<div css={(theme) => supportingText(theme.radio && theme)}>
-			{children}
-		</div>
-	);
+	return <div css={(theme) => supportingText(theme.radio)}>{children}</div>;
 };
 
 export interface RadioProps
@@ -96,7 +92,7 @@ export const Radio = ({
 	const radioControl = (
 		<input
 			type="radio"
-			css={(theme) => [radio(theme.radio && theme), cssOverrides]}
+			css={(theme) => [radio(theme.radio), cssOverrides]}
 			value={value}
 			aria-checked={isChecked()}
 			defaultChecked={defaultChecked != null ? defaultChecked : undefined}
@@ -108,7 +104,7 @@ export const Radio = ({
 	const labelledRadioControl = (
 		<label
 			css={(theme) => [
-				label(theme.radio && theme),
+				label(theme.radio),
 				supporting ? labelWithSupportingText : '',
 			]}
 		>

--- a/packages/@guardian/src-radio/RadioGroup.tsx
+++ b/packages/@guardian/src-radio/RadioGroup.tsx
@@ -78,7 +78,7 @@ export const RadioGroup = ({
 			aria-invalid={!!error}
 			id={groupId}
 			css={(theme) => [
-				fieldset(theme.radio && theme),
+				fieldset(theme.radio),
 				orientationStyles[orientation],
 				cssOverrides,
 			]}

--- a/packages/@guardian/src-radio/styles.ts
+++ b/packages/@guardian/src-radio/styles.ts
@@ -6,7 +6,7 @@ import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { radioDefault } from '@guardian/src-foundations/themes';
 import { appearance, resets } from '@guardian/src-foundations/utils';
 
-export const fieldset = ({ radio } = radioDefault) => css`
+export const fieldset = (radio = radioDefault.radio) => css`
 	${resets.fieldset};
 	display: flex;
 	justify-content: flex-start;
@@ -16,7 +16,7 @@ export const fieldset = ({ radio } = radioDefault) => css`
 	}
 `;
 
-export const label = ({ radio } = radioDefault) => css`
+export const label = (radio = radioDefault.radio) => css`
 	cursor: pointer;
 	display: flex;
 	align-items: center;
@@ -34,7 +34,7 @@ export const labelWithSupportingText = css`
 	margin-bottom: ${space[3]}px;
 `;
 
-export const radio = ({ radio } = radioDefault) => css`
+export const radio = (radio = radioDefault.radio) => css`
 	flex: 0 0 auto;
 	cursor: pointer;
 	box-sizing: border-box;
@@ -91,7 +91,7 @@ export const radio = ({ radio } = radioDefault) => css`
 	}
 `;
 
-export const labelText = ({ radio } = radioDefault) => css`
+export const labelText = (radio = radioDefault.radio) => css`
 	${textSans.medium({ lineHeight: 'regular' })};
 	color: ${radio.textLabel};
 	width: 100%;
@@ -101,7 +101,7 @@ export const labelTextWithSupportingText = css`
 	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
 `;
 
-export const supportingText = ({ radio } = radioDefault) => css`
+export const supportingText = (radio = radioDefault.radio) => css`
 	${textSans.small({ lineHeight: 'regular' })};
 	color: ${radio.textLabelSupporting};
 `;

--- a/packages/@guardian/src-select/Select.tsx
+++ b/packages/@guardian/src-select/Select.tsx
@@ -89,20 +89,16 @@ export const Select = ({
 			)}
 			<div
 				css={(theme) => [
-					selectWrapper(theme.select && theme),
-					error ? errorChevron(theme.select && theme) : '',
-					!error && success
-						? successChevron(theme.select && theme)
-						: '',
+					selectWrapper(theme.select),
+					error ? errorChevron(theme.select) : '',
+					!error && success ? successChevron(theme.select) : '',
 				]}
 			>
 				<select
 					css={(theme) => [
-						select(theme.select && theme),
-						error ? errorInput(theme.select && theme) : '',
-						!error && success
-							? successInput(theme.select && theme)
-							: '',
+						select(theme.select),
+						error ? errorInput(theme.select) : '',
+						!error && success ? successInput(theme.select) : '',
 						cssOverrides,
 					]}
 					aria-required={!optional}

--- a/packages/@guardian/src-select/styles.ts
+++ b/packages/@guardian/src-select/styles.ts
@@ -6,7 +6,7 @@ import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { selectDefault } from '@guardian/src-foundations/themes';
 import { appearance } from '@guardian/src-foundations/utils';
 
-export const errorInput = ({ select } = selectDefault) => css`
+export const errorInput = (select = selectDefault.select) => css`
 	border: 4px solid ${select.borderError};
 	color: ${select.textError};
 	/* When select is active and in an error state, we want the border to remain the same. */
@@ -15,7 +15,7 @@ export const errorInput = ({ select } = selectDefault) => css`
 	}
 `;
 
-export const successInput = ({ select } = selectDefault) => css`
+export const successInput = (select = selectDefault.select) => css`
 	border: 4px solid ${select.borderSuccess};
 	color: ${select.textSuccess};
 	/* When select is active and in an success state, we want the border to remain the same. */
@@ -24,19 +24,19 @@ export const successInput = ({ select } = selectDefault) => css`
 	}
 `;
 
-export const errorChevron = ({ select } = selectDefault) => css`
+export const errorChevron = (select = selectDefault.select) => css`
 	svg {
 		fill: ${select.textError};
 	}
 `;
 
-export const successChevron = ({ select } = selectDefault) => css`
+export const successChevron = (select = selectDefault.select) => css`
 	svg {
 		fill: ${select.textSuccess};
 	}
 `;
 
-export const selectWrapper = ({ select } = selectDefault) => css`
+export const selectWrapper = (select = selectDefault.select) => css`
 	position: relative;
 
 	svg {
@@ -51,9 +51,7 @@ export const selectWrapper = ({ select } = selectDefault) => css`
 	}
 `;
 
-export const select = (theme = selectDefault) => {
-	const { select } = theme;
-
+export const select = (select = selectDefault.select) => {
 	return css`
 		color: ${select.textUserInput};
 		box-sizing: border-box;
@@ -82,7 +80,7 @@ export const select = (theme = selectDefault) => {
 		}
 
 		&:invalid {
-			${errorInput(theme)};
+			${errorInput(select)};
 		}
 	`;
 };

--- a/packages/@guardian/src-text-input/TextInput.tsx
+++ b/packages/@guardian/src-text-input/TextInput.tsx
@@ -120,12 +120,10 @@ export const TextInput = ({
 			<input
 				css={(theme) => [
 					width ? widths[width] : widthFluid,
-					textInput(theme.textInput && theme),
+					textInput(theme.textInput),
 					supporting ? supportingTextMargin : labelMargin,
-					error ? errorInput(theme.textInput && theme) : '',
-					!error && success
-						? successInput(theme.textInput && theme)
-						: '',
+					error ? errorInput(theme.textInput) : '',
+					!error && success ? successInput(theme.textInput) : '',
 					cssOverrides,
 				]}
 				type="text"

--- a/packages/@guardian/src-text-input/styles.ts
+++ b/packages/@guardian/src-text-input/styles.ts
@@ -6,7 +6,7 @@ import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { textInputDefault } from '@guardian/src-foundations/themes';
 import { resets } from '@guardian/src-foundations/utils';
 
-export const errorInput = ({ textInput } = textInputDefault) => css`
+export const errorInput = (textInput = textInputDefault.textInput) => css`
 	border: 4px solid ${textInput.borderError};
 	color: ${textInput.textError};
 	margin-top: 0;
@@ -16,7 +16,7 @@ export const errorInput = ({ textInput } = textInputDefault) => css`
 	}
 `;
 
-export const successInput = ({ textInput } = textInputDefault) => css`
+export const successInput = (textInput = textInputDefault.textInput) => css`
 	border: 4px solid ${textInput.borderSuccess};
 	color: ${textInput.textSuccess};
 	margin-top: 0;
@@ -26,9 +26,7 @@ export const successInput = ({ textInput } = textInputDefault) => css`
 	}
 `;
 
-export const textInput = (theme = textInputDefault) => {
-	const { textInput } = theme;
-
+export const textInput = (textInput = textInputDefault.textInput) => {
 	return css`
 		${resets.input};
 		box-sizing: border-box;
@@ -53,7 +51,7 @@ export const textInput = (theme = textInputDefault) => {
 			but stop short of applying it to empty required fields.
 			*/
 			&[value]:not([value='']) {
-				${errorInput(theme)};
+				${errorInput(textInput)};
 			}
 		}
 	`;

--- a/packages/@guardian/src-user-feedback/InlineError.tsx
+++ b/packages/@guardian/src-user-feedback/InlineError.tsx
@@ -19,10 +19,7 @@ export const InlineError = ({
 	...props
 }: UserFeedbackProps) => (
 	<span
-		css={(theme) => [
-			inlineError(theme.userFeedback && theme),
-			cssOverrides,
-		]}
+		css={(theme) => [inlineError(theme.userFeedback), cssOverrides]}
 		{...props}
 	>
 		<SvgAlertTriangle />

--- a/packages/@guardian/src-user-feedback/InlineSuccess.tsx
+++ b/packages/@guardian/src-user-feedback/InlineSuccess.tsx
@@ -19,10 +19,7 @@ export const InlineSuccess = ({
 	...props
 }: UserFeedbackProps) => (
 	<span
-		css={(theme) => [
-			inlineSuccess(theme.userFeedback && theme),
-			cssOverrides,
-		]}
+		css={(theme) => [inlineSuccess(theme.userFeedback), cssOverrides]}
 		{...props}
 	>
 		<SvgTickRound />

--- a/packages/@guardian/src-user-feedback/styles.ts
+++ b/packages/@guardian/src-user-feedback/styles.ts
@@ -23,12 +23,16 @@ const inlineMessage = css`
 	}
 `;
 
-export const inlineError = ({ userFeedback } = userFeedbackDefault) => css`
+export const inlineError = (
+	userFeedback = userFeedbackDefault.userFeedback,
+) => css`
 	${inlineMessage};
 	color: ${userFeedback.textError};
 `;
 
-export const inlineSuccess = ({ userFeedback } = userFeedbackDefault) => css`
+export const inlineSuccess = (
+	userFeedback = userFeedbackDefault.userFeedback,
+) => css`
 	${inlineMessage};
 	color: ${userFeedback.textSuccess};
 `;


### PR DESCRIPTION
## Setting the scene 🖼
Across Source, we use some nifty individual component-level theming functions.

They accept the `theme` object passed to us from emotion. They then destructure that object into the single component level theme object that it needs. If we pass in `undefined`, a default theming object is returned.

Here's an example of how that works right now to help illustrate:

```typescript
// Theming function for the accordion
export const accordion = ({ accordion } = accordionDefault) => css`
  border-bottom: 1px solid ${accordion.borderPrimary};
`;

// Examples

const customTheme = {
  accordion: {
    borderPrimary: '#FF00FF',
  }
}

accordion(customTheme) // This would work, and `borderPrimary` would equal '#FF00FF'
accordion(undefined) // This would work, and `borderPrimary` would equal the value set in `accordionDefault.borderPrimary`
```

.. and the consumer uses it like this:
```typescript
<div css={(theme) => [accordion(theme.accordion && theme), cssOverrides]}></div>
```

As you might have spotted, this implementation comes with the caveat that we must check that `theme.accordion` is defined before we pass in `theme`.

This makes a lot of sense! It's saying, **_"if accordion is defined on our `theme` object, go ahead and pass `theme` in"_**.

..  it then follows that: **_"if accordion is not defined, pass in `undefined` and fall back on the default `accordionDefault` value for `theme.accordion` "_**.


**To conclude this bit:** This logic handily avoids circumstances where `theme.accordion` is not defined on the custom theme. This happens often, because not everybody wants to customise everything that Source offers!

## So what needs doing here? 🔧
Simon 👨‍🎨 , our developer, is sitting down to make a shiny new variation of the **Accordion** component. Simon sets about using the `accordion` theming function defined above like this:

```typescript
// note the difference here vs accordion(theme.accordion && theme)
<div css={(theme) => [accordion(theme), cssOverrides]}></div>
```

As far as Simon is concerned, everything is fine.. it all makes sense! The `accordion` method should destructure the theme into the `accordion` theming object and fall back to the default: `accordionDefault` if it's not found.. 
...
**even the type checking passes**!
...
 Everything is looking great, this component will be ready to ship in no time ! 🥇 ☕️

Sadly, without the `theme.accordion && theme` check, poor Simon could easily hit a runtime error.

Let's look at why this is!

The error we just described will happen if `accordion` has not been defined on the users' custom theme. In this scenario, the `accordion` method is unable to fall back on its default value, because an object is being passed instead of undefined.

To illustrate, here's an example of a common case that could happen at runtime:
```typescript
// Theming function for the accordion (same as before)
export const accordion = ({ accordion } = accordionDefault) => css`
  border-bottom: 1px solid ${accordion.borderPrimary};
`;

// A custom theme, but without accordion defined this time!
const unhappyCustomTheme = {
  button: {
    borderPrimary: '#FF00FF',
  }
}

// This would not work despite passing the type checker!
// At runtime, we would try to evaluate: `unhappyCustomTheme.accordion.borderPrimary`.
// This which would error due to `accordion` being undefined.
accordion(unhappyCustomTheme) 
```

...culminating in this delightful error, ruining Simons' otherwise tranquil Monday morning:

![Screenshot 2021-11-29 at 22 35 09](https://user-images.githubusercontent.com/1771189/143953604-35667eee-1536-4917-97d5-ed6c62235a20.png)

## A Proposed Solution 🚙
The solution proposed here reworks our theming functions a little, making a few key changes. Instead of accepting the **whole** theme object, they have been refactored so that they only accept the theming object that they need to render.

With this approach, `accordion` only accepts the `theme.accordion` object OR `undefined` (in that case falling back to `accordionDefault.accordion`):
 
```typescript
export const accordion = (accordion = accordionDefault.accordion) => css`
  border-bottom: 1px solid ${accordion.borderPrimary};
`;
```

and Simon is able to call the `accordion` theming function like this:

```typescript
<div css={(theme) => [accordion(theme.accordion), cssOverrides]}></div>
```

This approach leaves no room for ambiguity! `theme.accordion` will be either defined or undefined [^1]

This is great, it means that we can't pass in a `theme` where `theme.accordion` could possibly be `undefined` as we could before without the type checker erroring. 🎉

So, following this approach, the core changes made in this pull request change all of our theming functions to accept only the single theming object that is relevant to them as an optional parameter, which defaults to the default already defined.

## Notes
This builds upon #1161

[^1]: This is supported thanks to this change: https://github.com/guardian/source/pull/1195/files#diff-06f78fe3b5cad62762cc5b85c0f25c385f5065842bb33f4b3b44de3066e4b57fR17-R29 which builds upon #1161 

