### PR TITLE
Handle lack of FIGMA_TOKEN more gracefully

### DIFF
--- a/scripts/get-icons/index.ts
+++ b/scripts/get-icons/index.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { formatSVG } from './format';
 import { FIGMA_OPTIONS, ICON_FILE, ICON_FRAMES, OUTPUT_DIR } from './config';
 import { stripAttributes } from './process';
+import { Log } from './log';
 
 interface FigmaComponentsResponse {
 	meta: {
@@ -59,6 +60,10 @@ if (!existsSync(OUTPUT_DIR)) {
 	mkdirSync(OUTPUT_DIR);
 }
 
+if (!process.env.FIGMA_TOKEN) {
+	Log.error('\x1b[31mFIGMA_TOKEN env var not set\x1b[0m');
+	process.exit(1);
+}
 axios
 	.get<FigmaComponentsResponse>(
 		`https://api.figma.com/v1/files/${ICON_FILE}/components`,

--- a/scripts/get-icons/index.ts
+++ b/scripts/get-icons/index.ts
@@ -61,7 +61,7 @@ if (!existsSync(OUTPUT_DIR)) {
 }
 
 if (!process.env.FIGMA_TOKEN) {
-	Log.error('\x1b[31mFIGMA_TOKEN env var not set\x1b[0m');
+	Log.error('FIGMA_TOKEN env var not set');
 	process.exit(1);
 }
 axios

--- a/scripts/get-icons/log.ts
+++ b/scripts/get-icons/log.ts
@@ -1,0 +1,5 @@
+export class Log {
+	static error = (message: string) => {
+		console.error(`\x1b[31m${message}\x1b[0m`);
+	};
+}


### PR DESCRIPTION
## What is the purpose of this change?

The `get-icons` scripts relies on a `FIGMA_TOKEN` env var being present. Currently if this is not set, the resultant error is unhandled and it is not immediately obvious what the problem is. This PR adds a check to ensure that it has been set at the beginning of the process and throws an appropriate error if not. 

## What does this change?

-  Add a `Log.error` method which prints red text
-   Check if `FIGMA_TOKEN` is present and error if not
