### PR TITLE
use `tsconfig-paths-webpack-plugin`

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,25 @@
+<script>
+	// Hacky way of making sure that we're on the docs page for playground stories.
+	// Setting viewMode: 'docs' in lib/story-intents.ts should do this, but there's a bug.
+	// https://github.com/storybookjs/storybook/issues/13128#issuecomment-798927176
+	// It's very closely bound to storybook implementation details so liable to break after updating.
+	window.onload = () => {
+		const observer = new MutationObserver((mutationsList) => {
+			for (const mutation of mutationsList) {
+				mutation.addedNodes.forEach((addedNode) => {
+					if (addedNode.matches('[href$="--playground"]')) {
+						addedNode.href = addedNode.href.replace(
+							'path=/story/',
+							'path=/docs/',
+						);
+						if (addedNode.dataset.selected) {
+							addedNode.click();
+						}
+					}
+				});
+			}
+		});
+
+		observer.observe(document.body, { childList: true, subtree: true });
+	};
+</script>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -23,35 +23,6 @@ export const parameters = {
 
 export const decorators = [FocusManagerDecorator, ThemeProviderDecorator];
 
-// Hacky way of making sure that we're on the docs page if it's available
-// Polls for href changes as there's not event emitted when changing stories
-// Inspired by https://github.com/storybookjs/storybook/issues/13128#issuecomment-798927176
-// This makes some assumptions about the Storybook markdown so if it stops working
-// then that would be a good place to start looking
-let currentPage = window.location.href;
-window.setInterval(() => {
-	if (window.location.href !== currentPage) {
-		currentPage = window.location.href;
-		if (window.location.hash) return;
-		try {
-			// Find all buttons containing the text Docs within the <div role="main"> tag
-			const docsButtonSelector = window.parent.document.evaluate(
-				"//div[@role='main']//button[contains(., 'Docs')]",
-				window.parent.document,
-				null,
-				XPathResult.ANY_TYPE,
-				null,
-			);
-
-			const button =
-				docsButtonSelector.iterateNext() as HTMLButtonElement;
-			button && button.click();
-		} catch (error) {
-			console.error(error);
-		}
-	}
-}, 500);
-
 // The docs pages don't seem to respect the anchor links on load so this
 // ensures they do. This may be related to the fact that window.location.hash
 // isn't set on first page load, hence we're getting it from window.parent.location.hash

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -6,6 +6,7 @@ const nodeModulesExclude = [
 		exclude: [/@guardian\//],
 	},
 ];
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = ({ config, mode }) => {
 	//Get TypeScript working via babel preset
@@ -38,24 +39,13 @@ module.exports = ({ config, mode }) => {
 	).exclude = nodeModulesExclude;
 
 	config.resolve.extensions.push('.ts', '.tsx');
-	config.resolve.alias = {
-		'@guardian/src-foundations': path.resolve(
-			__dirname,
-			'../packages/@guardian/src-foundations/src',
-		),
-		'@guardian/src-label': path.resolve(
-			__dirname,
-			'../packages/@guardian/src-label',
-		),
-		'@guardian/src-user-feedback': path.resolve(
-			__dirname,
-			'../packages/@guardian/src-user-feedback',
-		),
-		'@guardian/src-helpers': path.resolve(
-			__dirname,
-			'../packages/@guardian/src-helpers',
-		),
-	};
+	config.resolve.plugins.push(
+		new TsconfigPathsPlugin({
+			configFile: path.resolve(__dirname, '..', 'tsconfig.json'),
+			extensions: config.resolve.extensions,
+			mainFields: config.resolve.mainFields,
+		}),
+	);
 
 	return config;
 };

--- a/lib/story-intents.ts
+++ b/lib/story-intents.ts
@@ -69,7 +69,6 @@ export const asChromaticStory = <Args>(story: Story<Args>) => {
 			},
 		},
 		docs: { disable: true },
-		controls: { disabled: true },
 		chromatic,
 	};
 };

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "stylelint-processor-styled-components": "^1.10.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^9.1.1",
+    "tsconfig-paths-webpack-plugin": "^3.5.2",
     "typescript": "^4.3.0",
     "webpack": "^5.57.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7342,7 +7342,7 @@ enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.8.3:
+enhanced-resolve@^5.7.0, enhanced-resolve@^5.8.3:
   version "5.8.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz#6d552d465cce0423f5b3d718511ea53826a7b2f0"
   integrity sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==
@@ -15445,6 +15445,15 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tsconfig-paths-webpack-plugin@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
+  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^3.9.0"
 
 tsconfig-paths@^3.9.0:
   version "3.11.0"


### PR DESCRIPTION
## What does this change?

-   `tsconfig-paths-webpack-plugin` means we dont have provide ts aliases anymore
-   disabling controls for chromatic stories triggers [a bug](https://github.com/storybookjs/storybook/issues/15503) that we dont need to, because they're canvases anyway. it seems to clear up the issue with selecting the wrong story type as you navigate around

## Why?

I tried to remove babel but no chance :(

so:

- i tried to update to latest to adopt the [tentative support for emotion 11](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#emotion11-quasi-compatibility) but got nowhere
  - they're enabling feature flags in 6 because many of the changes are breaking but they dont want to do a breaking release
  - it seemed to add complexity we didn't need to manage to me
- I tried to remove our extra webpack config and just set babel preset directly to use the `automatic` runtime/`importSource`, but the mdx webpack loader doesn't support the `automatic` runtime
- i tried to set the webpack `tsx` rule babel config only, but then it turns out `mdx` rules inherits from the `tsx` one

so gave up on all that.

_but_ i did find the things in this PR out along the way, so thought we could use them

it's Better Than Nothing™ 😜:pray: 
