### PR TITLE
list kitchen package stories under `Packages` heading

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,7 +15,7 @@ export const parameters = {
 	},
 	options: {
 		storySort: {
-			order: ['Docs', 'Source', 'Editorial'],
+			order: ['Docs', 'Packages'],
 			method: 'alphabetical',
 		},
 	},

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/divider/Divider.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/divider/Divider.stories.tsx
@@ -7,7 +7,7 @@ import type { DividerProps } from './index';
 import { Divider } from './index';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Divider',
+	title: 'Packages/source-react-components-development-kitchen/Divider',
 	component: Divider,
 };
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialButton.stories.tsx
@@ -20,7 +20,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/EditorialButton',
+	title: 'Packages/source-react-components-development-kitchen/EditorialButton',
 	component: EditorialButton,
 	argTypes: {
 		format: {

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialLinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/editorial-button/EditorialLinkButton.stories.tsx
@@ -20,7 +20,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/EditorialLinkButton',
+	title: 'Packages/source-react-components-development-kitchen/EditorialLinkButton',
 	component: EditorialLinkButton,
 	argTypes: {
 		format: {

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/lines/Lines.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/lines/Lines.stories.tsx
@@ -7,7 +7,7 @@ import type { LinesProps } from './index';
 import { Lines } from './index';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Lines',
+	title: 'Packages/source-react-components-development-kitchen/Lines',
 	component: Lines,
 	args: {
 		effect: 'straight',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/logo/Logo.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/logo/Logo.stories.tsx
@@ -7,7 +7,7 @@ import type { LogoProps } from './Logo';
 import { Logo } from './Logo';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Logo',
+	title: 'Packages/source-react-components-development-kitchen/Logo',
 	component: Logo,
 	args: {
 		logoType: 'standard',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/quote-icon/QuoteIcon.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/quote-icon/QuoteIcon.stories.tsx
@@ -18,7 +18,7 @@ const defaultFormat = {
 };
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/QuoteIcon',
+	title: 'Packages/source-react-components-development-kitchen/QuoteIcon',
 	component: QuoteIcon,
 	argTypes: {
 		format: {

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/star-rating/StarRating.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/star-rating/StarRating.stories.tsx
@@ -7,7 +7,7 @@ import type { StarRatingProps } from './StarRating';
 import { StarRating } from './StarRating';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Star Rating',
+	title: 'Packages/source-react-components-development-kitchen/Star Rating',
 	component: StarRating,
 	args: {
 		size: 'medium',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/ErrorSummary.stories.tsx
@@ -7,7 +7,7 @@ import type { ErrorSummaryProps } from './ErrorSummary';
 import { ErrorSummary } from './ErrorSummary';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Error Summary',
+	title: 'Packages/source-react-components-development-kitchen/Error Summary',
 	component: ErrorSummary,
 	args: {
 		message: 'There has been a problem',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/InfoSummary.stories.tsx
@@ -7,7 +7,7 @@ import type { InfoSummaryProps } from './InfoSummary';
 import { InfoSummary } from './InfoSummary';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Info Summary',
+	title: 'Packages/source-react-components-development-kitchen/Info Summary',
 	component: InfoSummary,
 	args: {
 		message: 'Here is some information',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/summary/SuccessSummary.stories.tsx
@@ -7,7 +7,7 @@ import type { SuccessSummaryProps } from './SuccessSummary';
 import { SuccessSummary } from './SuccessSummary';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/Success Summary',
+	title: 'Packages/source-react-components-development-kitchen/Success Summary',
 	component: SuccessSummary,
 	args: {
 		message: 'Your request was successful',

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.stories.tsx
@@ -8,7 +8,7 @@ import { ToggleSwitch } from './ToggleSwitch';
 import type { ToggleSwitchProps } from './ToggleSwitch';
 
 export default {
-	title: 'Kitchen/source-react-components-development-kitchen/ToggleSwitch',
+	title: 'Packages/source-react-components-development-kitchen/ToggleSwitch',
 	component: ToggleSwitch,
 	args: {},
 };


### PR DESCRIPTION
## What is the purpose of this change?

start grouping stories as top-level `docs` or `packages` in prep for no v3 stories

![image](https://user-images.githubusercontent.com/867233/145031235-1a528c0c-8d9c-41de-a474-ca6b5f591b48.png)
