### PR TITLE
Update styled-components VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
-    "jpoissonnier.vscode-styled-components",
+	"styled-components.vscode-styled-components",
     "stylelint.vscode-stylelint",
     "stkb.rewrap",
     "naumovs.color-highlight"


### PR DESCRIPTION
## What is the purpose of this change?

According to the [Visual Studio marketplace website](https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components):

> Styled Components has moved! Make sure you're downloading it from here: https://marketplace.visualstudio.com/items?itemName=styled-components.vscode-styled-components. The `jpoissonnier.vscode-styled-components` version will recieve no more updates.

## What does this change?

-   Replace `jpoissonnier.vscode-styled-components` with `styled-components.vscode-styled-components`

