### PR TITLE
Add basic components package readme

### DIFF
--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -2,6 +2,29 @@
 
 [![npm](https://img.shields.io/npm/v/@guardian/source-react-components)](https://www.npmjs.com/package/@guardian/source-react-components)
 
-⚠️🚧 _UNDER CONSTRUCTION You probably want one of the [`@guardian/src-*`](https://www.npmjs.com/search?q=%40guardian%2Fsrc-) packages for the moment._ 🚧⚠️
+Components are individually installable as JavaScript packages via NPM or Yarn. Each component package exposes its React components, themes and TypeScript types.
 
-x
+## Install
+
+```sh
+$ yarn add @guardian/source-react-components
+```
+
+or
+
+```sh
+$ npm install @guardian/source-react-components
+```
+
+## Use
+
+```tsx
+import { TextInput, Button } from '@guardian/source-react-components';
+
+const Form = () => (
+    <form>
+        <TextInput label="First name" />
+        <Button>Submit</Button>
+    </>
+);
+```

--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -27,6 +27,6 @@ const Form = () => (
     <form>
         <TextInput label="First name" />
         <Button>Submit</Button>
-    </form >
+    </form>
 );
 ```

--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -18,7 +18,7 @@ or
 $ npm install @guardian/source-react-components
 ```
 
-## Use
+## Example
 
 ```tsx
 import { TextInput, Button } from '@guardian/source-react-components';

--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -2,7 +2,9 @@
 
 [![npm](https://img.shields.io/npm/v/@guardian/source-react-components)](https://www.npmjs.com/package/@guardian/source-react-components)
 
-Components are individually installable as JavaScript packages via NPM or Yarn. Each component package exposes its React components, themes and TypeScript types.
+A set of robust, accessible React components built using `@guardian/source-foundations`.
+
+See [the `@guardian/source-react-components` storybook](https://guardian.github.io/source/?path=/docs/Packages/source-react-components) for full info.
 
 ## Install
 

--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -27,6 +27,6 @@ const Form = () => (
     <form>
         <TextInput label="First name" />
         <Button>Submit</Button>
-    </>
+    </form >
 );
 ```


### PR DESCRIPTION
## What is the purpose of this change?

The components package readme needs some rudimentary introduction to the package.

## What does this change?

-   Adds a stripped-down readme

## Is this it?

It's likely that this will tie in to the work on Storybook documentation reorganisation. We could either leave this as a starter for 10, or implement this README as part of the wider docs work.