### PR TITLE
Add default href to linkbutton in stories

### DIFF
--- a/packages/@guardian/src-button/LinkButton.stories.tsx
+++ b/packages/@guardian/src-button/LinkButton.stories.tsx
@@ -28,6 +28,7 @@ export default {
 		priority: 'primary',
 		iconSide: 'left',
 		nudgeIcon: false,
+		href: '#',
 	},
 };
 


### PR DESCRIPTION
## What is the purpose of this change?

Currently in LinkButton stories, the LinkButton does not receive a `href` prop. This means the `<a>` element that gets generated cannot receive focus.

In order to demonstrate the focus state, we should add a default `href` arg to the LinkButton component in stories.

## What does this change?

-   add a default `href` arg to the LinkButton component in stories.


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)