### PR TITLE
Add default href to link component in stories

### DIFF
--- a/packages/@guardian/src-link/Link.stories.tsx
+++ b/packages/@guardian/src-link/Link.stories.tsx
@@ -13,6 +13,7 @@ export default {
 		subdued: false,
 		icon: <SvgExternal />,
 		iconSide: 'left',
+		href: '#',
 	},
 	argTypes: {
 		icon: {


### PR DESCRIPTION
## What is the purpose of this change?

Similar to #1221, it is necessary to add a default href arg for the component to receive focus.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Add a default href arg

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
