### PR TITLE
Fix typo in max length arg name

### DIFF
--- a/packages/@guardian/src-text-area/TextArea.stories.tsx
+++ b/packages/@guardian/src-text-area/TextArea.stories.tsx
@@ -86,7 +86,7 @@ asChromaticStory(ErrorWithMessageDefaultTheme);
 
 export const WithMaxLengthDefaultTheme = Template.bind({});
 WithMaxLengthDefaultTheme.args = {
-	maxLengh: 10,
+	maxLength: 10,
 };
 asChromaticStory(WithMaxLengthDefaultTheme);
 


### PR DESCRIPTION
## What is the purpose of this change?

The max length story for TextArea is broken because the arg name has a typo. 

## What does this change?

-   Fix typo in arg name

