### PR TITLE
Add platform prop and 'web' design to ToggleSwitch

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.stories.tsx
@@ -33,34 +33,51 @@ asPlayground(Playground);
 
 // *****************************************************************************
 
-export const SlimNoLabel = Template.bind({});
-SlimNoLabel.args = {
-	size: 'slim',
+export const AndroidNoLabel = Template.bind({});
+AndroidNoLabel.args = {
+	platform: 'android',
 };
-asChromaticStory(SlimNoLabel);
+asChromaticStory(AndroidNoLabel);
 
 // *****************************************************************************
 
 export const MediumNoLabel = Template.bind({});
 MediumNoLabel.args = {
-	size: 'medium',
+	platform: 'ios',
 };
 asChromaticStory(MediumNoLabel);
 
 // *****************************************************************************
 
-export const SlimWithLabel = Template.bind({});
-SlimWithLabel.args = {
-	label: 'Get alerts on this story',
-	size: 'slim',
+export const WebNoLabel = Template.bind({});
+WebNoLabel.args = {
+	platform: 'web',
 };
-asChromaticStory(SlimWithLabel);
+asChromaticStory(WebNoLabel);
+
+// *****************************************************************************
+
+export const AndroidWithLabel = Template.bind({});
+AndroidWithLabel.args = {
+	label: 'Get alerts on this story',
+	platform: 'android',
+};
+asChromaticStory(AndroidWithLabel);
 
 // *****************************************************************************
 
 export const MediumWithLabel = Template.bind({});
 MediumWithLabel.args = {
 	label: 'Get alerts on this story',
-	size: 'medium',
+	platform: 'ios',
 };
 asChromaticStory(MediumWithLabel);
+
+// *****************************************************************************
+
+export const WebWithLabel = Template.bind({});
+WebWithLabel.args = {
+	label: 'Get alerts on this story',
+	platform: 'web',
+};
+asChromaticStory(WebWithLabel);

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.stories.tsx
@@ -41,11 +41,11 @@ asChromaticStory(AndroidNoLabel);
 
 // *****************************************************************************
 
-export const MediumNoLabel = Template.bind({});
-MediumNoLabel.args = {
+export const IosNoLabel = Template.bind({});
+IosNoLabel.args = {
 	platform: 'ios',
 };
-asChromaticStory(MediumNoLabel);
+asChromaticStory(IosNoLabel);
 
 // *****************************************************************************
 
@@ -66,12 +66,12 @@ asChromaticStory(AndroidWithLabel);
 
 // *****************************************************************************
 
-export const MediumWithLabel = Template.bind({});
-MediumWithLabel.args = {
+export const IosWithLabel = Template.bind({});
+IosWithLabel.args = {
 	label: 'Get alerts on this story',
 	platform: 'ios',
 };
-asChromaticStory(MediumWithLabel);
+asChromaticStory(IosWithLabel);
 
 // *****************************************************************************
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.tsx
@@ -34,6 +34,7 @@ export interface ToggleSwitchProps extends Props {
 	label?: string;
 	/**
 	 * Sets the toggle styling appropriate for each platform.
+	 * The default platform is 'web'.
 	 */
 	platform?: Platform;
 	/**
@@ -60,7 +61,7 @@ const getPlatformStyles = (platform: Platform): SerializedStyles => {
 			return androidStyles;
 		case 'ios':
 			return iosStyles;
-		default:
+		case 'web':
 			return webStyles;
 	}
 };

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/ToggleSwitch.tsx
@@ -1,14 +1,16 @@
+import type { SerializedStyles } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import type { Props } from '@guardian/src-helpers';
 import {
+	androidStyles,
 	buttonStyles,
+	iosStyles,
 	labelStyles,
-	mediumStyles,
-	slimStyles,
 	toggleSwitchStyles,
+	webStyles,
 } from './styles';
 
-export type Size = 'medium' | 'slim';
+export type Platform = 'android' | 'ios' | 'web';
 
 export interface ToggleSwitchProps extends Props {
 	/**
@@ -31,12 +33,9 @@ export interface ToggleSwitchProps extends Props {
 	 */
 	label?: string;
 	/**
-	 * slim or medium toggle would be different in size and colors.
-	 * slim has the size and look of an android toggle switch and
-	 * medium has the ios switch look and feel.
-	 *
+	 * Sets the toggle styling appropriate for each platform.
 	 */
-	size?: Size;
+	platform?: Platform;
 	/**
 	 * A callback function called when the component is checked or unchecked.
 	 * Receives the click event as an argument.
@@ -50,17 +49,28 @@ export interface ToggleSwitchProps extends Props {
  * [GitHub](https://github.com/guardian/source/tree/main/packages/@guardian/source-react-components-development-kitchen/components/toggle-switch) •
  * [NPM](https://www.npmjs.com/package/@guardian/source-react-components-development-kitchen)
  *
- * Displays an on/off toggle switch. This toggle has default styling and can be used in andriod or ios.
+ * Displays an on/off toggle switch. This toggle has default styling and can be used on andriod, ios or web.
+ * These styles are driven by the 'platform' prop.
  * To give it more custome styling cssOverride may be used.
  *
  */
+const getPlatformStyles = (platform: Platform): SerializedStyles => {
+	switch (platform) {
+		case 'android':
+			return androidStyles;
+		case 'ios':
+			return iosStyles;
+		default:
+			return webStyles;
+	}
+};
 
 export const ToggleSwitch = ({
 	checked,
 	label,
 	defaultChecked,
 	cssOverrides,
-	size = 'medium',
+	platform = 'web',
 	onClick = () => undefined,
 	...props
 }: ToggleSwitchProps): EmotionJSX.Element => {
@@ -72,12 +82,10 @@ export const ToggleSwitch = ({
 		return !!defaultChecked;
 	};
 
-	const isSlim = size === 'slim';
-
 	return (
 		<div css={[toggleSwitchStyles, cssOverrides]} {...props}>
 			<button
-				css={[buttonStyles, isSlim ? slimStyles : mediumStyles]}
+				css={[buttonStyles, getPlatformStyles(platform)]}
 				role="switch"
 				aria-checked={isChecked()}
 				aria-labelledby="notify"

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
@@ -87,6 +87,11 @@ export const androidStyles = css`
 	}
 `;
 
+/**
+ * These 'webStyles' are shared with Frontend and will potentially also need updating there if updated here.
+	https://github.com/guardian/frontend/blob/c2b3103e1796b9b2fc3326e792323dd919d4b85a/static/src/stylesheets/module/content-garnett/_live-blog.scss#L257
+ */
+
 export const webStyles = css`
 	width: 2.75rem;
 	height: 1.5rem;

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
@@ -95,9 +95,9 @@ export const webStyles = css`
 	&:before {
 		content: '';
 		position: absolute;
-		top: 6px;
-		height: 8px;
-		width: 4px;
+		top: 0.375rem;
+		height: 0.5rem;
+		width: 0.25rem;
 		opacity: 0;
 		border-bottom: 2px solid ${success[400]};
 		border-right: 2px solid ${success[400]};
@@ -107,8 +107,8 @@ export const webStyles = css`
 	&:after {
 		height: 1.125rem;
 		width: 1.125rem;
-		top: 2.5px;
-		left: 4px;
+		top: 0.15625rem;
+		left: 0.25rem;
 	}
 
 	&[aria-checked='false'] {
@@ -126,7 +126,7 @@ export const webStyles = css`
 	}
 
 	&[aria-checked='true']:after {
-		left: 22px;
+		left: 1.375rem;
 		background: ${neutral[100]};
 	}
 `;

--- a/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/components/toggle-switch/styles.ts
@@ -29,7 +29,7 @@ export const buttonStyles = css`
 	}
 `;
 
-export const mediumStyles = css`
+export const iosStyles = css`
 	width: 3.188rem;
 	height: 1.938rem;
 	border-radius: 15.5px;
@@ -56,7 +56,8 @@ export const mediumStyles = css`
 		background: ${neutral[100]};
 	}
 `;
-export const slimStyles = css`
+
+export const androidStyles = css`
 	width: 1.625rem;
 	height: 0.75rem;
 	border-radius: 6px;
@@ -83,6 +84,50 @@ export const slimStyles = css`
 	&[aria-checked='true']:after {
 		left: 8px;
 		background: ${success[500]};
+	}
+`;
+
+export const webStyles = css`
+	width: 2.75rem;
+	height: 1.5rem;
+	border-radius: 15.5px;
+
+	&:before {
+		content: '';
+		position: absolute;
+		top: 6px;
+		height: 8px;
+		width: 4px;
+		opacity: 0;
+		border-bottom: 2px solid ${success[400]};
+		border-right: 2px solid ${success[400]};
+		transition: opacity 0.1s ease-in;
+	}
+
+	&:after {
+		height: 1.125rem;
+		width: 1.125rem;
+		top: 2.5px;
+		left: 4px;
+	}
+
+	&[aria-checked='false'] {
+		background-color: rgba(153, 153, 153, 0.5);
+	}
+
+	&[aria-checked='true'] {
+		background: ${success[500]};
+	}
+
+	&[aria-checked='true']:before {
+		opacity: 1;
+		z-index: 1;
+		transform: translateX(6px) rotate(45deg);
+	}
+
+	&[aria-checked='true']:after {
+		left: 22px;
+		background: ${neutral[100]};
 	}
 `;
 


### PR DESCRIPTION
## What is the purpose of this change?

When adding the Filter Key Events toggle to DCR we realised that the existing `ToggleSwitch` component in Source was specific to iOS and Android, and did not contain the web variant of the toggle which currently exists in [Frontend](https://github.com/guardian/frontend/blob/c2318985237baad1dbd68c1f9f99651f67db78af/article/app/views/liveblog/filterButton.scala.html). 

## What does this change?

-  Removes the `size` prop and replaces it with a new `platform` prop
-  Swaps `slimStyles` for `androidStyles` and `mediumStyles` for `iosStyles` in the styles
-  Adds `webStyles` CSS including a `:before` pseudo element for the tick 
-  Updates the stories to reflect the above changes

## Screenshots

**Before**
![Screenshot 2022-01-05 at 14 15 07](https://user-images.githubusercontent.com/77005274/148231993-3746c1b2-23c0-46dd-983f-46aaa891b4b3.png)
![Screenshot 2022-01-05 at 14 20 42](https://user-images.githubusercontent.com/77005274/148232975-a3a1b4f7-5602-4656-a91f-76d9a3483c15.png)

**After**
![Screenshot 2022-01-05 at 14 23 31](https://user-images.githubusercontent.com/77005274/148233263-feea52a5-139f-4ef3-bc51-6f0b558ac27b.png)
![Screenshot 2022-01-05 at 14 14 57](https://user-images.githubusercontent.com/77005274/148232012-a64e6474-6321-4630-8152-484ceb676da6.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

We will need to update the MetaData component on Apps-Rendering to reflect the change from `size` to `platform`
