### PR TITLE
Add success message to text area

### DIFF
--- a/packages/@guardian/src-text-area/TextArea.stories.tsx
+++ b/packages/@guardian/src-text-area/TextArea.stories.tsx
@@ -14,6 +14,14 @@ export default {
 			},
 			control: { type: 'radio' },
 		},
+		success: {
+			options: ['undefined', 'success'],
+			mapping: {
+				undefined: undefined,
+				success: 'Thanks for telling us your views',
+			},
+			control: { type: 'radio' },
+		},
 	},
 	args: {
 		label: 'Comments',
@@ -21,6 +29,7 @@ export default {
 		hideLabel: false,
 		supporting: '',
 		error: undefined,
+		success: undefined,
 	},
 };
 
@@ -81,6 +90,14 @@ ErrorWithMessageDefaultTheme.args = {
 	error: 'Please tell us your views',
 };
 asChromaticStory(ErrorWithMessageDefaultTheme);
+
+// *****************************************************************************
+
+export const SuccessWithMessageDefaultTheme = Template.bind({});
+SuccessWithMessageDefaultTheme.args = {
+	success: 'Thanks for telling us your views',
+};
+asChromaticStory(SuccessWithMessageDefaultTheme);
 
 // *****************************************************************************
 

--- a/packages/@guardian/src-text-area/TextArea.tsx
+++ b/packages/@guardian/src-text-area/TextArea.tsx
@@ -1,10 +1,11 @@
 import { InputHTMLAttributes } from 'react';
-import { InlineError } from '@guardian/src-user-feedback';
+import { InlineError, InlineSuccess } from '@guardian/src-user-feedback';
 import { Label } from '@guardian/src-label';
 import {
 	widthFluid,
 	textArea,
 	errorInput,
+	successInput,
 	labelMargin,
 	supportingTextMargin,
 	inlineMessageMargin,
@@ -47,6 +48,11 @@ export interface TextAreaProps
 	 */
 	error?: string;
 	/**
+	 * Appears as an inline success message.
+	 * This prop should not have a value set at the same time as the error prop. In the event that both are set, errors take precedence.
+	 */
+	success?: string;
+	/**
 	 * Specify the number of rows the component should display by default.
 	 */
 	rows?: number;
@@ -67,6 +73,7 @@ export const TextArea = ({
 	hideLabel = false,
 	supporting,
 	error,
+	success,
 	cssOverrides,
 	rows = 3,
 	className,
@@ -102,18 +109,28 @@ export const TextArea = ({
 					</InlineError>
 				</div>
 			)}
+			{!error && success && (
+				<div css={inlineMessageMargin}>
+					<InlineSuccess id={descriptionId(textAreaId)}>
+						{success}
+					</InlineSuccess>
+				</div>
+			)}
 			<textarea
 				css={[
 					widthFluid,
 					textArea,
 					supporting ? supportingTextMargin : labelMargin,
 					error ? errorInput : '',
+					!error && success ? successInput : '',
 					cssOverrides,
 				]}
 				id={textAreaId}
 				aria-required={!optional}
 				aria-invalid={!!error}
-				aria-describedby={error ? descriptionId(textAreaId) : ''}
+				aria-describedby={
+					error || success ? descriptionId(textAreaId) : ''
+				}
 				required={!optional}
 				rows={rows}
 				className={getClassName()}

--- a/packages/@guardian/src-text-area/styles.ts
+++ b/packages/@guardian/src-text-area/styles.ts
@@ -14,6 +14,15 @@ export const errorInput = css`
 		border: 4px solid ${border.error};
 	}
 `;
+export const successInput = css`
+	border: 4px solid ${border.success};
+	color: ${text.success};
+	margin-top: 0;
+	/* When input is active and in a success state, we want the border to remain the same. */
+	&:active {
+		border: 4px solid ${border.success};
+	}
+`;
 
 export const textArea = css`
 	${resets.input};


### PR DESCRIPTION
## What is the purpose of this change?
There is a [desire to support success messages in the TextArea component](https://github.com/guardian/source/issues/898). This PR adds a `success` prop to the TextArea component to enable a success message to be displayed when successful validation has occurred.

## What does this change?
- Add the success prop.
- Add support so error message takes precedent if both error and success prop are set at the same time.
- Add a new Storybook story to test it.
- Add a description of the new prop to the README

## Screenshots
![Screenshot 2022-01-11 at 18 09 03](https://user-images.githubusercontent.com/20416599/148997879-1b096aa7-45c2-4d91-bf6b-9dedcdb69399.png)

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
