### PR TITLE
Add box-styles: border box to toggle :before

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -106,13 +106,12 @@ export const webStyles = css`
 		content: '';
 		position: absolute;
 		top: 0.375rem;
-		height: 0.5rem;
-		width: 0.25rem;
+		height: 0.7rem;
+		width: 0.4rem;
 		opacity: 0;
 		border-bottom: 2px solid ${success[400]};
 		border-right: 2px solid ${success[400]};
 		transition: opacity 0.1s ease-in;
-		box-sizing: content-box;
 	}
 
 	&:after {

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -96,6 +96,12 @@ export const webStyles = css`
 	height: 1.5rem;
 	border-radius: 15.5px;
 
+	// this will go away when resets have been standardised
+	&:before,
+	&:after {
+		box-sizing: border-box;
+	}
+
 	&:before {
 		content: '';
 		position: absolute;
@@ -106,6 +112,7 @@ export const webStyles = css`
 		border-bottom: 2px solid ${success[400]};
 		border-right: 2px solid ${success[400]};
 		transition: opacity 0.1s ease-in;
+		box-sizing: content-box;
 	}
 
 	&:after {


### PR DESCRIPTION
## What is the purpose of this change?

When implemented in projects using a CSS reset, the positioning of the tick on the web toggle was broken.

## What does this change?

This PR adds the specific section of the CSS reset to the parent div of the toggle component, and then adds the fix for this to the `:before` element that was being broken.

-   add CSS reset styles specific to this component
-   updates `:before` styling `width` and `height` to fix toggle tick

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before (with CSS reset)**
<img width="281" alt="Screenshot 2022-01-20 at 14 58 30" src="https://user-images.githubusercontent.com/77005274/150363686-d77bae11-ac75-4afd-b8f4-1862906521a8.png">

**After (with CSS reset)**
<img width="281" alt="Screenshot 2022-01-20 at 14 58 40" src="https://user-images.githubusercontent.com/77005274/150363716-fb8cd72a-c87b-4cc5-861b-ce3a9ca829eb.png">

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
