### PR TITLE
Publish packages as discrete modules

### DIFF
--- a/.changeset/silver-planets-try.md
+++ b/.changeset/silver-planets-try.md
@@ -1,0 +1,7 @@
+---
+'@guardian/source-foundations': patch
+'@guardian/source-react-components': patch
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Stop publishing packages as single files, so they can be properly tree-shaken.

--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -7,9 +7,9 @@
   },
   "license": "Apache-2.0",
   "sideEffects": false,
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/@guardian/source-foundations/rollup.config.js
+++ b/packages/@guardian/source-foundations/rollup.config.js
@@ -14,22 +14,25 @@ export default [
 		plugins: [ts({ tsconfig: '../../../tsconfig.json' })],
 		output: [
 			{
-				file: pkg.main,
+				dir: pkg.main.replace('/index.js', ''),
 				format: 'cjs',
 				sourcemap: true,
+				preserveModules: true,
 			},
 			{
-				file: pkg.module,
+				dir: pkg.module.replace('/index.js', ''),
 				format: 'es',
 				sourcemap: true,
+				preserveModules: true,
 			},
 		],
 	}),
 	bundle({
 		plugins: [dts()],
 		output: {
-			file: pkg.types,
+			dir: pkg.types.replace('/index.d.ts', ''),
 			format: 'es',
+			preserveModules: true,
 		},
 	}),
 ];

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.31",
   "license": "Apache-2.0",
   "sideEffects": false,
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/@guardian/source-react-components-development-kitchen/rollup.config.js
+++ b/packages/@guardian/source-react-components-development-kitchen/rollup.config.js
@@ -14,22 +14,25 @@ export default [
 		plugins: [ts({ tsconfig: '../../../tsconfig.json' })],
 		output: [
 			{
-				file: pkg.main,
+				dir: pkg.main.replace('/index.js', ''),
 				format: 'cjs',
 				sourcemap: true,
+				preserveModules: true,
 			},
 			{
-				file: pkg.module,
+				dir: pkg.module.replace('/index.js', ''),
 				format: 'es',
 				sourcemap: true,
+				preserveModules: true,
 			},
 		],
 	}),
 	bundle({
 		plugins: [dts()],
 		output: {
-			file: pkg.types,
+			dir: pkg.types.replace('/index.d.ts', ''),
 			format: 'es',
+			preserveModules: true,
 		},
 	}),
 ];

--- a/packages/@guardian/source-react-components/package.json
+++ b/packages/@guardian/source-react-components/package.json
@@ -7,9 +7,9 @@
   },
   "license": "Apache-2.0",
   "sideEffects": false,
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/@guardian/source-react-components/rollup.config.js
+++ b/packages/@guardian/source-react-components/rollup.config.js
@@ -11,14 +11,16 @@ export default [
 		input: 'src/index.ts',
 		output: [
 			{
-				file: pkg.main,
+				dir: pkg.main.replace('/index.js', ''),
 				format: 'cjs',
 				sourcemap: true,
+				preserveModules: true,
 			},
 			{
-				file: pkg.module,
+				dir: pkg.module.replace('/index.js', ''),
 				format: 'es',
 				sourcemap: true,
+				preserveModules: true,
 			},
 		],
 		external,
@@ -30,7 +32,8 @@ export default [
 	{
 		input: 'src/index.ts',
 		output: {
-			file: pkg.types,
+			dir: pkg.types.replace('/index.d.ts', ''),
+			preserveModules: true,
 			format: 'es',
 			sourcemap: true,
 		},


### PR DESCRIPTION
## What is the purpose of this change?

stop publishing packages as monolithic files, to make them tree-shakeable

I was 100% under the impression that tree-shaking ES modules marked as side effect free combined with minification/dead-code elimination at the application end would get rid of anything consumers didn't use from the single files we're currently publishing. this is not true!

Here is a hello-world preact app that renders a button from react-components:

### Before

![image (1)](https://user-images.githubusercontent.com/867233/151854364-8467f4b9-1d86-4a19-8bff-db03298f9f82.png)

### After
![image (2)](https://user-images.githubusercontent.com/867233/151854438-6d0405c5-c463-4103-aacf-da10a618f2d3.png)

