### PR TITLE
Remove toggle margin and make label display: flex

### DIFF
--- a/.changeset/twenty-jokes-poke.md
+++ b/.changeset/twenty-jokes-poke.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Remove margin from ToggleSwitch component

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -4,7 +4,7 @@ import { neutral, success, textSans } from '@guardian/source-foundations';
 export const buttonStyles = css`
 	flex: none;
 	border: none;
-	margin: 8px;
+	margin-right: 8px;
 	margin-left: 0;
 	padding: 0;
 	display: inline-block;
@@ -139,7 +139,7 @@ export const webStyles = css`
 
 export const labelStyles = css`
 	${textSans.small()};
-	display: inline-flex;
+	display: flex;
 	color: ${neutral[7]};
 	align-items: center;
 	cursor: pointer;


### PR DESCRIPTION
## What is the purpose of this change?

Removes an unnecessary margin from the ToggleSwitch component so we don't need to subsequently override it in DCR. 

## What does this change?

-   Removes margin
-   Switches label `display: inline-flex` to `display: flex` so we add full-width borders above it

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
