### PR TITLE
Don't disable docs in Chromatic stories

### DIFF
--- a/lib/story-intents.ts
+++ b/lib/story-intents.ts
@@ -68,7 +68,6 @@ export const asChromaticStory = <T>(story: Story<T>): void => {
 				hidden: true,
 			},
 		},
-		docs: { disable: true },
 		chromatic,
 	};
 };


### PR DESCRIPTION
## What is the purpose of this change?

Oh boy.

Our Storybook is in a bit of state. For some components, the live component example in the docs tab doesn't appear. This is currently affecting the following components:

- Button
- Columns
- ChoiceCardGroup
- Footer
- Icons
- Inline
- RadioGroup
- Stack
- Select
- SvgGuardianLiveLogo
- SvgRoundelBrand
- SvgRoundelBrandInverse
- SvgRoundelDefault
- SvgRoundelInverse
- TextArea
- TextInput
- Tiles

What is special about these components, or their stories? I have no idea 🤷  In some cases, such as the Svg* components, the differences are completely trivial, yet the SvgGuardianLogo story appears and SvgGuardianLiveLogo doesn't.

The only way that I have have been able to fix these stories is by removing `{docs: { disable: true }}` from the Chromatic story parameters. I have tried many other things to varying degrees of success.

## What have you tried?

| What? | Success? | Notes |
| --- | --- | --- |
| Stop disabling docs from Chromatic stories | ✅ | The smallest possible change that fixes everything consistently, although it changes the behaviour of our docs pages |
| Delete Reader Revenue theme stories in Button stories | ✅ | This actually fixed the button doc story, although others remain broken. I couldn't determine why importing these themes was causing the Button doc story to break |
| Copy-pasting broken stories into a new file | ✅ | I copy-pasted the stories from TextArea.stories.tsx into a new file called TextArea2.stories.tsx. After doing this, both TextArea and TextArea2 doc stories started working again. This is perhaps the most baffling fix and I'm not sure how to turn it into a general solution. I'm not even happy that it might be a solution.  |
| Continue disabling docs in Chromatic stories but enable docs in Playground stories | ❌ | My reasoning here was that disabling docs in Chromatic stories is somehow disabling docs in Playground stories. Arguably this shouldn't work since Chromatic and Playground stories are all cloned from a Template using `Function.prototype.bind`. And alas it didn't work 😅  |
| Clear localStorage | ❌ | With all the apparent non-deterministic behaviour, this was worth a shot. No dice.  |
| Rename the stories file | ❌ | With the success of the copy-paste solution, I thought simply renaming the file might work. It did not. Nor did updating the title in the component parameters.  |

## What does this change?

-   Stop disabling docs in Chromatic stories

Note that this changes the behaviour of our Playgrounds. Rather than showing only the props table, the Playground now also shows each component story inlined.

Is this a bad thing? I'm not sure. It makes the Playground a bit noisier, although the noise appears below the props table, so is at lest out of the way. On the other hand, it might be useful for readers to scan every component variant on the same page to compare the presentational forms a component may take. 

This is the default behaviour of Storybook and is demonstrated in [Storybook's own design system documentation](https://storybook-design-system.netlify.app/). Disabling this behaviour involves toggling the `disabled` option, buried deep in the [docs addon documentation](https://github.com/storybookjs/storybook/blob/next/addons/docs/docs/recipes.md#disabling-docs-stories). Storybook suggests that it should be used "to exclude some of the stories", whereas we're taking it further. It does feel like we're deviating from how Storybook wants to behave, which leads me to my final point.

Storybook is a very important documentation framework built and maintained by many talented developers. But the codebase is currently in a fragile state. At time of writing it has nearly 1600 open issues and nearly as many issues that were [closed without explicit resolution](https://github.com/storybookjs/storybook/issues?q=is%3Aissue+is%3Aclosed+%22Hey+there%2C+it%27s+me+again%22). Documentation becomes [out of date quickly](https://github.com/storybookjs/storybook/issues/17413#issuecomment-1032180805) or is difficult to find. It seems that the cost of deviating from the standard Storybook behaviour is time spent debugging or logging bug reports against obscure behaviour, which in all likelihood won't get fixed.

In light of this, and where it doesn't compromise our core objective of providing clear, best-in-class component library documentation, I propose we stick close to Storybook's core behaviour.

Happy to discuss any of this, as well as alternative solutions 😊

## Screenshots

**Before**

<img width="1024" alt="Screenshot 2022-02-10 at 22 17 19" src="https://user-images.githubusercontent.com/5931528/153506068-3f2f9958-becf-475f-8367-d6e653f28b60.png">

**After**

<img width="1031" alt="Screenshot 2022-02-10 at 22 20 32" src="https://user-images.githubusercontent.com/5931528/153506471-15d49a2e-c59b-40c9-8e7f-a6033977b9a0.png">

<img width="1126" alt="Screenshot 2022-02-10 at 22 21 38" src="https://user-images.githubusercontent.com/5931528/153506580-27b69b4b-7e1d-48e7-b111-f809175e6ac2.png">
