### PR TITLE
feat(icon): Add `SvgArrowCircleClockwise` (reload icon)

### DIFF
--- a/.changeset/proud-impalas-happen.md
+++ b/.changeset/proud-impalas-happen.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': minor
+---
+
+Add SVG Arrow Circle Clockwise

--- a/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -10,6 +10,7 @@ import { SvgAlert } from './SvgAlert';
 import { SvgAlertRound } from './SvgAlertRound';
 import { SvgAlertTriangle } from './SvgAlertTriangle';
 import { SvgAppleBrand } from './SvgAppleBrand';
+import { SvgArrowCircleClockwise } from './SvgArrowCircleClockwise';
 import { SvgArrowDownStraight } from './SvgArrowDownStraight';
 import { SvgArrowLeftStraight } from './SvgArrowLeftStraight';
 import { SvgArrowRightStraight } from './SvgArrowRightStraight';
@@ -64,6 +65,7 @@ const uiIcons = {
 	SvgAlertRound,
 	SvgAlertTriangle,
 	SvgAppleBrand,
+	SvgArrowCircleClockwise,
 	SvgArrowDownStraight,
 	SvgArrowLeftStraight,
 	SvgArrowRightStraight,

--- a/packages/@guardian/source-react-components/src/icons/SvgArrowCircleClockwise.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgArrowCircleClockwise.tsx
@@ -6,7 +6,8 @@ export const SvgArrowCircleClockwise = ({
 	size,
 }: IconProps): EmotionJSX.Element => (
 	<svg
-		viewBox="0 0 24 24"
+		// Really this is 24×24, hence the offset
+		viewBox="-3 -3 30 30"
 		width={size ? iconSize[size] : '24'}
 		height={size ? iconSize[size] : '24'}
 	>

--- a/packages/@guardian/source-react-components/src/icons/SvgArrowCircleClockwise.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgArrowCircleClockwise.tsx
@@ -1,0 +1,15 @@
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { iconSize } from '@guardian/source-foundations';
+import type { IconProps } from './types';
+
+export const SvgArrowCircleClockwise = ({
+	size,
+}: IconProps): EmotionJSX.Element => (
+	<svg
+		viewBox="0 0 24 24"
+		width={size ? iconSize[size] : '24'}
+		height={size ? iconSize[size] : '24'}
+	>
+		<path d="M11.588 1a10.928 10.928 0 0 0-9.046 4.786l.126.676.877.527.676-.176C5.85 4.508 8.506 2.98 11.588 2.98c4.936 0 8.995 4.059 8.995 9.045 0 4.961-4.059 8.995-8.995 8.995-2.832 0-5.262-1.252-6.94-3.257l3.632-.601v-1.253H1.866l-.476.476V23h1.227l.627-3.784C5.248 21.546 8.205 23 11.588 23c6.089 0 11.025-4.911 11.025-10.975A11.01 11.01 0 0 0 11.588 1Z" />
+	</svg>
+);

--- a/packages/@guardian/source-react-components/src/icons/SvgArrowCircleClockwise.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgArrowCircleClockwise.tsx
@@ -6,10 +6,9 @@ export const SvgArrowCircleClockwise = ({
 	size,
 }: IconProps): EmotionJSX.Element => (
 	<svg
-		// Really this is 24×24, hence the offset
+		// Icon authored as 24×24, hence the -3 offset on the viewBox to make it 30×30
 		viewBox="-3 -3 30 30"
-		width={size ? iconSize[size] : '24'}
-		height={size ? iconSize[size] : '24'}
+		width={size ? iconSize[size] : undefined}
 	>
 		<path d="M11.588 1a10.928 10.928 0 0 0-9.046 4.786l.126.676.877.527.676-.176C5.85 4.508 8.506 2.98 11.588 2.98c4.936 0 8.995 4.059 8.995 9.045 0 4.961-4.059 8.995-8.995 8.995-2.832 0-5.262-1.252-6.94-3.257l3.632-.601v-1.253H1.866l-.476.476V23h1.227l.627-3.784C5.248 21.546 8.205 23 11.588 23c6.089 0 11.025-4.911 11.025-10.975A11.01 11.01 0 0 0 11.588 1Z" />
 	</svg>

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -62,6 +62,7 @@ export { SvgAlert } from './icons/SvgAlert';
 export { SvgAlertRound } from './icons/SvgAlertRound';
 export { SvgAlertTriangle } from './icons/SvgAlertTriangle';
 export { SvgAppleBrand } from './icons/SvgAppleBrand';
+export { SvgArrowCircleClockwise } from './icons/SvgArrowCircleClockwise';
 export { SvgArrowDownStraight } from './icons/SvgArrowDownStraight';
 export { SvgArrowLeftStraight } from './icons/SvgArrowLeftStraight';
 export { SvgArrowRightStraight } from './icons/SvgArrowRightStraight';

--- a/scripts/validate-dist/source-package-exports.test.ts
+++ b/scripts/validate-dist/source-package-exports.test.ts
@@ -128,6 +128,7 @@ describe('No exports have changed in the ', () => {
 			'SvgAlertRound',
 			'SvgAlertTriangle',
 			'SvgAppleBrand',
+			'SvgArrowCircleClockwise',
 			'SvgArrowDownStraight',
 			'SvgArrowLeftStraight',
 			'SvgArrowRightStraight',


### PR DESCRIPTION
## What is the purpose of this change?

Add a new icon to the react components for use in DCR.

Named closely to the Unicode name of `U+21bb`: Clockwise Open Circle Arrow	↻

## Screenshots

<img width="64" alt="screenshot of circle arrow SVG" src="https://user-images.githubusercontent.com/76776/154104173-ab2a867a-80dc-47b8-8a7d-36644949a860.png">


## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Documentation

-   [ ] Full API surface area is documented in the README
-   [X] Examples in Storybook

### Known issues

N/A