### PR TITLE
Add a loading state for buttons ⏳

### DIFF
--- a/.changeset/chilly-humans-report.md
+++ b/.changeset/chilly-humans-report.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': minor
+---
+
+Adds an `isLoading` prop to the Button component. This replaces any icon rendered on the button with a spinner (`SvgSpinner`). The spinner will have colours that match the background and text colours of the button. The Button `disabled` state is also extended to show a `not-allowed` cursor and set the opacity to 0.4 so that the disabled state is indicated visually"

--- a/.changeset/chilly-humans-report.md
+++ b/.changeset/chilly-humans-report.md
@@ -2,4 +2,4 @@
 '@guardian/source-react-components': minor
 ---
 
-Adds an `isLoading` prop to the Button component. This replaces any icon rendered on the button with a spinner (`SvgSpinner`). The spinner will have colours that match the background and text colours of the button. The Button `disabled` state is also extended to show a `not-allowed` cursor and set the opacity to 0.4 so that the disabled state is indicated visually"
+Adds an `isLoading` prop to the Button component. This replaces any icon rendered on the button with a spinner (`SvgSpinner`). The spinner will have colours that match the background and text colours of the button. The Button `disabled` state is also extended to show a `not-allowed` cursor so that the disabled state is indicated visually"

--- a/packages/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -278,7 +278,6 @@ asChromaticStory(IconOnlyXSmallSizeDefaultTheme);
 export const IsLoadingPrimary = Template.bind({});
 IsLoadingPrimary.args = {
 	isLoading: true,
-	iconSide: 'right',
 };
 asChromaticStory(IsLoadingPrimary);
 
@@ -296,8 +295,6 @@ asChromaticStory(IsLoadingSecondary);
 export const IsLoadingTertiary = Template.bind({});
 IsLoadingTertiary.args = {
 	isLoading: true,
-	icon: 'cross',
-	iconSide: 'right',
 	priority: 'tertiary',
 };
 asChromaticStory(IsLoadingTertiary);
@@ -307,21 +304,18 @@ asChromaticStory(IsLoadingTertiary);
 export const IsLoadingSubdued = Template.bind({});
 IsLoadingSubdued.args = {
 	isLoading: true,
-	icon: 'cross',
-	iconSide: 'right',
 	priority: 'subdued',
 };
 asChromaticStory(IsLoadingSubdued);
 
 // *****************************************************************************
 
-export const IsLoadingIconSideLeft = Template.bind({});
-IsLoadingIconSideLeft.args = {
+export const IsLoadingIconSideRight = Template.bind({});
+IsLoadingIconSideRight.args = {
 	isLoading: true,
-	iconSide: 'left',
-	priority: 'primary',
+	iconSide: 'right',
 };
-asChromaticStory(IsLoadingIconSideLeft);
+asChromaticStory(IsLoadingIconSideRight);
 
 // *****************************************************************************
 
@@ -329,7 +323,14 @@ export const IsLoadingDisabled = Template.bind({});
 IsLoadingDisabled.args = {
 	isLoading: true,
 	disabled: true,
-	iconSide: 'right',
-	priority: 'primary',
 };
 asChromaticStory(IsLoadingDisabled);
+
+// *****************************************************************************
+
+export const IsLoadingLabelHidden = Template.bind({});
+IsLoadingLabelHidden.args = {
+	isLoading: true,
+	hideLabel: true,
+};
+asChromaticStory(IsLoadingLabelHidden);

--- a/packages/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -275,37 +275,61 @@ asChromaticStory(IconOnlyXSmallSizeDefaultTheme);
 
 // *****************************************************************************
 
-export const IsLoadingButton = Template.bind({});
-IsLoadingButton.args = {
+export const IsLoadingPrimary = Template.bind({});
+IsLoadingPrimary.args = {
 	isLoading: true,
-	icon: 'cross',
 	iconSide: 'right',
 };
-asChromaticStory(IsLoadingButton);
+asChromaticStory(IsLoadingPrimary);
 
-export const IsLoadingButton1 = Template.bind({});
-IsLoadingButton1.args = {
+// *****************************************************************************
+
+export const IsLoadingSecondary = Template.bind({});
+IsLoadingSecondary.args = {
 	isLoading: true,
-	icon: 'cross',
-	iconSide: 'right',
 	priority: 'secondary',
 };
-asChromaticStory(IsLoadingButton1);
+asChromaticStory(IsLoadingSecondary);
 
-export const IsLoadingButton2 = Template.bind({});
-IsLoadingButton2.args = {
+// *****************************************************************************
+
+export const IsLoadingTertiary = Template.bind({});
+IsLoadingTertiary.args = {
 	isLoading: true,
 	icon: 'cross',
 	iconSide: 'right',
 	priority: 'tertiary',
 };
-asChromaticStory(IsLoadingButton2);
+asChromaticStory(IsLoadingTertiary);
 
-export const IsLoadingButton3 = Template.bind({});
-IsLoadingButton3.args = {
+// *****************************************************************************
+
+export const IsLoadingSubdued = Template.bind({});
+IsLoadingSubdued.args = {
 	isLoading: true,
 	icon: 'cross',
 	iconSide: 'right',
 	priority: 'subdued',
 };
-asChromaticStory(IsLoadingButton3);
+asChromaticStory(IsLoadingSubdued);
+
+// *****************************************************************************
+
+export const IsLoadingIconSideLeft = Template.bind({});
+IsLoadingIconSideLeft.args = {
+	isLoading: true,
+	iconSide: 'left',
+	priority: 'primary',
+};
+asChromaticStory(IsLoadingIconSideLeft);
+
+// *****************************************************************************
+
+export const IsLoadingDisabled = Template.bind({});
+IsLoadingDisabled.args = {
+	isLoading: true,
+	disabled: true,
+	iconSide: 'right',
+	priority: 'primary',
+};
+asChromaticStory(IsLoadingDisabled);

--- a/packages/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -272,3 +272,40 @@ IconOnlyXSmallSizeDefaultTheme.args = {
 	children: 'Close subscription banner',
 };
 asChromaticStory(IconOnlyXSmallSizeDefaultTheme);
+
+// *****************************************************************************
+
+export const IsLoadingButton = Template.bind({});
+IsLoadingButton.args = {
+	isLoading: true,
+	icon: 'cross',
+	iconSide: 'right',
+};
+asChromaticStory(IsLoadingButton);
+
+export const IsLoadingButton1 = Template.bind({});
+IsLoadingButton1.args = {
+	isLoading: true,
+	icon: 'cross',
+	iconSide: 'right',
+	priority: 'secondary',
+};
+asChromaticStory(IsLoadingButton1);
+
+export const IsLoadingButton2 = Template.bind({});
+IsLoadingButton2.args = {
+	isLoading: true,
+	icon: 'cross',
+	iconSide: 'right',
+	priority: 'tertiary',
+};
+asChromaticStory(IsLoadingButton2);
+
+export const IsLoadingButton3 = Template.bind({});
+IsLoadingButton3.args = {
+	isLoading: true,
+	icon: 'cross',
+	iconSide: 'right',
+	priority: 'subdued',
+};
+asChromaticStory(IsLoadingButton3);

--- a/packages/@guardian/source-react-components/src/button/Button.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.tsx
@@ -26,6 +26,7 @@ export const Button = ({
 	nudgeIcon,
 	type = 'button',
 	isLoading = false,
+	loadingAnnouncement = 'Loading',
 	cssOverrides,
 	children,
 	...props
@@ -43,7 +44,7 @@ export const Button = ({
 		})}
 		type={type}
 		aria-live="polite"
-		aria-label={isLoading ? 'Loading' : undefined}
+		aria-label={isLoading ? loadingAnnouncement : undefined}
 		{...props}
 	>
 		{buttonContents({

--- a/packages/@guardian/source-react-components/src/button/Button.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.tsx
@@ -42,8 +42,8 @@ export const Button = ({
 			isLoading,
 		})}
 		type={type}
-		aria-live={'polite'}
-		aria-busy={isLoading}
+		aria-live="polite"
+		aria-label={isLoading ? 'Loading' : undefined}
 		{...props}
 	>
 		{buttonContents({

--- a/packages/@guardian/source-react-components/src/button/Button.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.tsx
@@ -42,6 +42,8 @@ export const Button = ({
 			isLoading,
 		})}
 		type={type}
+		aria-live={'polite'}
+		aria-busy={isLoading}
 		{...props}
 	>
 		{buttonContents({

--- a/packages/@guardian/source-react-components/src/button/Button.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.tsx
@@ -25,6 +25,7 @@ export const Button = ({
 	hideLabel,
 	nudgeIcon,
 	type = 'button',
+	isLoading = false,
 	cssOverrides,
 	children,
 	...props
@@ -38,6 +39,7 @@ export const Button = ({
 			iconSide,
 			nudgeIcon,
 			cssOverrides,
+			isLoading,
 		})}
 		type={type}
 		{...props}
@@ -45,6 +47,7 @@ export const Button = ({
 		{buttonContents({
 			hideLabel,
 			iconSvg,
+			isLoading,
 			children,
 		})}
 	</button>

--- a/packages/@guardian/source-react-components/src/button/shared.tsx
+++ b/packages/@guardian/source-react-components/src/button/shared.tsx
@@ -3,19 +3,31 @@ import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { visuallyHidden } from '@guardian/source-foundations';
 import type { ReactElement, ReactNode } from 'react';
 import { cloneElement } from 'react';
+import { SvgSpinner } from '../icons/SvgSpinner';
 
 export const buttonContents = ({
 	hideLabel,
 	iconSvg,
+	isLoading,
 	children,
 }: {
 	hideLabel?: boolean;
 	iconSvg?: ReactElement;
+	isLoading?: boolean;
 	children: ReactNode;
 }): EmotionJSX.Element | ReactNode[] => {
 	const contents = [children];
 
-	if (iconSvg) {
+	if (isLoading) {
+		if (!hideLabel) {
+			contents.push(<div key="space" className="src-button-space" />);
+		}
+		contents.push(
+			cloneElement(<SvgSpinner />, {
+				key: 'svg',
+			}),
+		);
+	} else if (iconSvg) {
 		if (!hideLabel) {
 			contents.push(<div key="space" className="src-button-space" />);
 		}

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -29,6 +29,12 @@ const button = css`
 	text-decoration: none;
 	white-space: nowrap;
 
+	:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+		pointer-events: all !important;
+	}
+
 	&:focus {
 		${focusHalo};
 	}
@@ -47,6 +53,13 @@ const primary = (
 ): SerializedStyles => css`
 	background-color: ${button.backgroundPrimary};
 	color: ${button.textPrimary};
+
+	/* Fix for the light inner loading spinner colour bleeding through on dark backgrounds. */
+	${isLoading &&
+	button.backgroundSecondary &&
+	`path {
+		stroke-width: 65;
+	}`}
 
 	&:hover {
 		background-color: ${button.backgroundPrimaryHover};
@@ -67,8 +80,8 @@ const secondary = (
 	${isLoading &&
 	button.backgroundSecondary &&
 	`circle {
-			stroke: ${button.backgroundSecondary};
-		}`}
+		stroke: ${button.backgroundSecondary};
+	}`}
 
 	&:hover {
 		background-color: ${button.backgroundSecondaryHover};
@@ -90,8 +103,8 @@ const tertiary = (
 	${isLoading &&
 	button.backgroundTertiaryHover &&
 	`circle {
-			stroke: white;
-		}`}
+		stroke: white;
+	}`}
 
 	&:hover {
 		background-color: ${button.backgroundTertiaryHover};

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -30,9 +30,7 @@ const button = css`
 	white-space: nowrap;
 
 	:disabled {
-		opacity: 0.4;
 		cursor: not-allowed;
-		pointer-events: all !important;
 	}
 
 	&:focus {

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -229,10 +229,7 @@ const iconNudgeAnimation = css`
 `;
 
 const priorities: {
-	[key in ButtonPriority]: (
-		button?: ButtonTheme,
-		isLoading?: boolean,
-	) => SerializedStyles;
+	[key in ButtonPriority]: (button?: ButtonTheme) => SerializedStyles;
 } = {
 	primary,
 	secondary,
@@ -286,7 +283,7 @@ export const buttonStyles =
 		[
 			button,
 			sizes[size],
-			priorities[priority](theme.button, isLoading),
+			priorities[priority](theme.button),
 			iconSvg || isLoading ? iconSizes[size] : '',
 			(iconSvg || isLoading) && !hideLabel ? iconSides[iconSide] : '',
 			nudgeIcon ? iconNudgeAnimation : '',

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -34,36 +34,72 @@ const button = css`
 	}
 `;
 
+const transitionSpinnerBackground = css`
+	path,
+	circle {
+		transition: stroke ${transitions.medium};
+	}
+`;
+
 const primary = (
 	button: ButtonTheme = buttonThemeDefault.button,
+	isLoading = false,
 ): SerializedStyles => css`
 	background-color: ${button.backgroundPrimary};
 	color: ${button.textPrimary};
 
 	&:hover {
 		background-color: ${button.backgroundPrimaryHover};
+		${isLoading &&
+		`path {
+			stroke: ${button.backgroundPrimaryHover};
+		}`}
 	}
 `;
 
 const secondary = (
 	button: ButtonTheme = buttonThemeDefault.button,
+	isLoading = false,
 ): SerializedStyles => css`
 	background-color: ${button.backgroundSecondary};
 	color: ${button.textSecondary};
 
+	${isLoading &&
+	button.backgroundSecondary &&
+	`circle {
+			stroke: ${button.backgroundSecondary};
+		}`}
+
 	&:hover {
 		background-color: ${button.backgroundSecondaryHover};
+		${isLoading &&
+		button.backgroundSecondaryHover &&
+		`circle {
+			stroke: ${button.backgroundSecondaryHover};
+		}`}
 	}
 `;
 
 const tertiary = (
 	button: ButtonTheme = buttonThemeDefault.button,
+	isLoading = false,
 ): SerializedStyles => css`
 	color: ${button.textTertiary};
 	border: 1px solid ${button.borderTertiary};
 
+	${isLoading &&
+	button.backgroundTertiaryHover &&
+	`circle {
+			stroke: white;
+		}`}
+
 	&:hover {
 		background-color: ${button.backgroundTertiaryHover};
+		${isLoading &&
+		button.backgroundTertiaryHover &&
+		`circle {
+			stroke: ${button.backgroundTertiaryHover};
+		}`}
 	}
 `;
 
@@ -214,7 +250,10 @@ const iconNudgeAnimation = css`
 `;
 
 const priorities: {
-	[key in ButtonPriority]: (button?: ButtonTheme) => SerializedStyles;
+	[key in ButtonPriority]: (
+		button?: ButtonTheme,
+		isLoading?: boolean,
+	) => SerializedStyles;
 } = {
 	primary,
 	secondary,
@@ -260,6 +299,7 @@ export const buttonStyles =
 		iconSide = 'left',
 		nudgeIcon,
 		cssOverrides,
+		isLoading,
 	}: SharedButtonProps) =>
 	(
 		theme: Theme,
@@ -267,9 +307,10 @@ export const buttonStyles =
 		[
 			button,
 			sizes[size],
-			priorities[priority](theme.button),
-			iconSvg ? iconSizes[size] : '',
-			iconSvg && !hideLabel ? iconSides[iconSide] : '',
+			priorities[priority](theme.button, isLoading),
+			isLoading ? transitionSpinnerBackground : undefined,
+			iconSvg || isLoading ? iconSizes[size] : '',
+			(iconSvg || isLoading) && !hideLabel ? iconSides[iconSide] : '',
 			nudgeIcon ? iconNudgeAnimation : '',
 			hideLabel ? iconOnlySizes[size] : '',
 			cssOverrides,

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -54,17 +54,18 @@ const primary = (
 	background-color: ${button.backgroundPrimary};
 	color: ${button.textPrimary};
 
-	/* Fix for the light inner loading spinner colour bleeding through on dark backgrounds. */
 	${isLoading &&
-	button.backgroundSecondary &&
-	`path {
-		stroke-width: 65;
+	`circle {
+		stroke: ${button.backgroundPrimary};
+	}
+	path {
+		stroke: ${button.textPrimary}
 	}`}
 
 	&:hover {
 		background-color: ${button.backgroundPrimaryHover};
 		${isLoading &&
-		`path {
+		`circle {
 			stroke: ${button.backgroundPrimaryHover};
 		}`}
 	}
@@ -82,6 +83,13 @@ const secondary = (
 	`circle {
 		stroke: ${button.backgroundSecondary};
 	}`}
+
+	${isLoading &&
+	button.textSecondary &&
+	`path {
+		stroke: ${button.textSecondary};
+	}`}
+
 
 	&:hover {
 		background-color: ${button.backgroundSecondaryHover};
@@ -101,9 +109,14 @@ const tertiary = (
 	border: 1px solid ${button.borderTertiary};
 
 	${isLoading &&
-	button.backgroundTertiaryHover &&
 	`circle {
-		stroke: white;
+		stroke: transparent;
+	}`}
+
+	${isLoading &&
+	button.textTertiary &&
+	`path {
+		stroke: ${button.textTertiary};
 	}`}
 
 	&:hover {
@@ -118,10 +131,23 @@ const tertiary = (
 
 const subdued = (
 	button: ButtonTheme = buttonThemeDefault.button,
+	isLoading = false,
 ): SerializedStyles => css`
 	padding: 0;
 	background-color: transparent;
 	color: ${button.textSubdued};
+
+	${isLoading &&
+	`circle {
+		stroke: transparent;
+	}`}
+
+	${isLoading &&
+	button.textSubdued &&
+	`path {
+		stroke: ${button.textSubdued};
+	}`}
+
 
 	&:hover {
 		text-decoration: underline;

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -38,114 +38,56 @@ const button = css`
 	}
 `;
 
-const transitionSpinnerBackground = css`
+const applyButtonStylesToLoadingSpinner = css`
 	path,
 	circle {
 		transition: stroke ${transitions.medium};
+		stroke: transparent;
+	}
+	path {
+		stroke: currentColor;
 	}
 `;
 
 const primary = (
 	button: ButtonTheme = buttonThemeDefault.button,
-	isLoading = false,
 ): SerializedStyles => css`
 	background-color: ${button.backgroundPrimary};
 	color: ${button.textPrimary};
 
-	${isLoading &&
-	`circle {
-		stroke: ${button.backgroundPrimary};
-	}
-	path {
-		stroke: ${button.textPrimary}
-	}`}
-
 	&:hover {
 		background-color: ${button.backgroundPrimaryHover};
-		${isLoading &&
-		`circle {
-			stroke: ${button.backgroundPrimaryHover};
-		}`}
 	}
 `;
 
 const secondary = (
 	button: ButtonTheme = buttonThemeDefault.button,
-	isLoading = false,
 ): SerializedStyles => css`
 	background-color: ${button.backgroundSecondary};
 	color: ${button.textSecondary};
 
-	${isLoading &&
-	button.backgroundSecondary &&
-	`circle {
-		stroke: ${button.backgroundSecondary};
-	}`}
-
-	${isLoading &&
-	button.textSecondary &&
-	`path {
-		stroke: ${button.textSecondary};
-	}`}
-
-
 	&:hover {
 		background-color: ${button.backgroundSecondaryHover};
-		${isLoading &&
-		button.backgroundSecondaryHover &&
-		`circle {
-			stroke: ${button.backgroundSecondaryHover};
-		}`}
 	}
 `;
 
 const tertiary = (
 	button: ButtonTheme = buttonThemeDefault.button,
-	isLoading = false,
 ): SerializedStyles => css`
 	color: ${button.textTertiary};
 	border: 1px solid ${button.borderTertiary};
 
-	${isLoading &&
-	`circle {
-		stroke: transparent;
-	}`}
-
-	${isLoading &&
-	button.textTertiary &&
-	`path {
-		stroke: ${button.textTertiary};
-	}`}
-
 	&:hover {
 		background-color: ${button.backgroundTertiaryHover};
-		${isLoading &&
-		button.backgroundTertiaryHover &&
-		`circle {
-			stroke: ${button.backgroundTertiaryHover};
-		}`}
 	}
 `;
 
 const subdued = (
 	button: ButtonTheme = buttonThemeDefault.button,
-	isLoading = false,
 ): SerializedStyles => css`
 	padding: 0;
 	background-color: transparent;
 	color: ${button.textSubdued};
-
-	${isLoading &&
-	`circle {
-		stroke: transparent;
-	}`}
-
-	${isLoading &&
-	button.textSubdued &&
-	`path {
-		stroke: ${button.textSubdued};
-	}`}
-
 
 	&:hover {
 		text-decoration: underline;
@@ -345,10 +287,10 @@ export const buttonStyles =
 			button,
 			sizes[size],
 			priorities[priority](theme.button, isLoading),
-			isLoading ? transitionSpinnerBackground : undefined,
 			iconSvg || isLoading ? iconSizes[size] : '',
 			(iconSvg || isLoading) && !hideLabel ? iconSides[iconSide] : '',
 			nudgeIcon ? iconNudgeAnimation : '',
 			hideLabel ? iconOnlySizes[size] : '',
+			isLoading ? applyButtonStylesToLoadingSpinner : undefined,
 			cssOverrides,
 		];

--- a/packages/@guardian/source-react-components/src/button/types.ts
+++ b/packages/@guardian/source-react-components/src/button/types.ts
@@ -33,7 +33,7 @@ export interface SharedButtonProps extends Props {
 	 */
 	nudgeIcon?: boolean;
 	/**
-	 * When true, a loading spinner will appear to the right of the button content.
+	 * When true, a loading spinner will appear to the left of the button content.
 	 * Any icon present will be replaced by the spinner.
 	 */
 	isLoading?: boolean;

--- a/packages/@guardian/source-react-components/src/button/types.ts
+++ b/packages/@guardian/source-react-components/src/button/types.ts
@@ -34,8 +34,7 @@ export interface SharedButtonProps extends Props {
 	nudgeIcon?: boolean;
 	/**
 	 * When true, a loading spinner will appear to the right of the button content.
-	 * The button will be disabled, and any icon present will be replaced by the
-	 * spinner.
+	 * Any icon present will be replaced by the spinner.
 	 */
 	isLoading?: boolean;
 }

--- a/packages/@guardian/source-react-components/src/button/types.ts
+++ b/packages/@guardian/source-react-components/src/button/types.ts
@@ -37,4 +37,9 @@ export interface SharedButtonProps extends Props {
 	 * Any icon present will be replaced by the spinner.
 	 */
 	isLoading?: boolean;
+	/**
+	 * Adds the ability to provide a custom loading announcement for users who use a
+	 * screen reader. Defaults to "Loading".
+	 */
+	loadingAnnouncement?: string;
 }

--- a/packages/@guardian/source-react-components/src/button/types.ts
+++ b/packages/@guardian/source-react-components/src/button/types.ts
@@ -32,4 +32,10 @@ export interface SharedButtonProps extends Props {
 	 * When set, the icon (if visible) will move slightly to the right on hover.
 	 */
 	nudgeIcon?: boolean;
+	/**
+	 * When true, a loading spinner will appear to the right of the button content.
+	 * The button will be disabled, and any icon present will be replaced by the
+	 * spinner.
+	 */
+	isLoading?: boolean;
 }

--- a/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -102,13 +102,13 @@ const uiIcons = {
 	SvgInfo,
 	SvgSettings,
 	SvgSpeechBubble,
+	SvgSpinner,
 	SvgStar,
 	SvgTickRound,
 	SvgTwitter,
 	SvgAudio,
 	SvgVideo,
 	SvgWhatsApp,
-	SvgSpinner,
 };
 
 const paymentIcons = {

--- a/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -52,6 +52,7 @@ import { SvgPlus } from './SvgPlus';
 import { SvgQuote } from './SvgQuote';
 import { SvgSettings } from './SvgSettings';
 import { SvgSpeechBubble } from './SvgSpeechBubble';
+import { SvgSpinner } from './SvgSpinner';
 import { SvgStar } from './SvgStar';
 import { SvgTickRound } from './SvgTickRound';
 import { SvgTwitter } from './SvgTwitter';
@@ -107,6 +108,7 @@ const uiIcons = {
 	SvgAudio,
 	SvgVideo,
 	SvgWhatsApp,
+	SvgSpinner,
 };
 
 const paymentIcons = {

--- a/packages/@guardian/source-react-components/src/icons/SvgSpinner.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgSpinner.tsx
@@ -19,7 +19,7 @@ const darkblueStyles = css`
 	stroke: ${brand['400']};
 	stroke-dasharray: 820;
 	stroke-dashoffset: 820;
-	stroke-width: ${circleLineThickness + 4};
+	stroke-width: ${circleLineThickness};
 	fill: transparent;
 `;
 

--- a/packages/@guardian/source-react-components/src/icons/SvgSpinner.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgSpinner.tsx
@@ -1,0 +1,61 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css } from '@emotion/react';
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { brand, iconSize } from '@guardian/source-foundations';
+import type { IconProps } from './types';
+
+interface LoadingCircleIconProps extends IconProps {
+	additionalCss?: SerializedStyles;
+}
+
+const circleLineThickness = 50;
+
+const lightblueStyles = css`
+	stroke: #a5c0e8;
+	stroke-width: ${circleLineThickness};
+	fill: transparent;
+`;
+const darkblueStyles = css`
+	stroke: ${brand['400']};
+	stroke-dasharray: 820;
+	stroke-dashoffset: 820;
+	stroke-width: ${circleLineThickness + 4};
+	fill: transparent;
+`;
+
+export const SvgSpinner = ({
+	size,
+	additionalCss,
+}: LoadingCircleIconProps): EmotionJSX.Element => {
+	return (
+		<svg
+			width={size ? iconSize[size] : undefined}
+			viewBox="0 0 300 300"
+			css={additionalCss}
+		>
+			<g>
+				<animateTransform
+					attributeName="transform"
+					attributeType="XML"
+					type="rotate"
+					from="0 150 150"
+					to="360 150 150"
+					dur="2.5s"
+					repeatCount="indefinite"
+				/>
+				<circle cx="150" cy="150" r="126" css={lightblueStyles} />
+				<path
+					css={darkblueStyles}
+					d="M150,150 m0,-126 a 126,126 0 0,1 0,252 a 126,126 0 0,1 0,-252"
+				>
+					<animate
+						attributeName="stroke-dashoffset"
+						dur="3.5s"
+						to="-820"
+						repeatCount="indefinite"
+					/>
+				</path>
+			</g>
+		</svg>
+	);
+};

--- a/packages/@guardian/source-react-components/src/icons/SvgSpinner.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgSpinner.tsx
@@ -8,50 +8,46 @@ interface LoadingCircleIconProps extends IconProps {
 	additionalCss?: SerializedStyles;
 }
 
-const circleLineThickness = 50;
+const circleLineThickness = 5;
 
 const lightblueStyles = css`
 	stroke: #a5c0e8;
 	stroke-width: ${circleLineThickness};
 	fill: transparent;
 `;
+
 const darkblueStyles = css`
 	stroke: ${brand['400']};
-	stroke-dasharray: 820;
-	stroke-dashoffset: 820;
+	stroke-dasharray: 82;
+	stroke-dashoffset: 82;
 	stroke-width: ${circleLineThickness};
 	fill: transparent;
 `;
 
 export const SvgSpinner = ({
 	size,
-	additionalCss,
 }: LoadingCircleIconProps): EmotionJSX.Element => {
 	return (
-		<svg
-			width={size ? iconSize[size] : undefined}
-			viewBox="0 0 300 300"
-			css={additionalCss}
-		>
+		<svg width={size ? iconSize[size] : undefined} viewBox="0 0 30 30">
 			<g>
 				<animateTransform
 					attributeName="transform"
 					attributeType="XML"
 					type="rotate"
-					from="0 150 150"
-					to="360 150 150"
+					from="0 15 15"
+					to="360 15 15"
 					dur="2.5s"
 					repeatCount="indefinite"
 				/>
-				<circle cx="150" cy="150" r="126" css={lightblueStyles} />
+				<circle cx="15" cy="15" r="12.6" css={lightblueStyles} />
 				<path
 					css={darkblueStyles}
-					d="M150,150 m0,-126 a 126,126 0 0,1 0,252 a 126,126 0 0,1 0,-252"
+					d="M15,15 m0,-12.6 a 12.6,12.6 0 0,1 0,25.2 a 12.6,12.6 0 0,1 0,-25.2"
 				>
 					<animate
 						attributeName="stroke-dashoffset"
 						dur="3.5s"
-						to="-820"
+						to="-82"
 						repeatCount="indefinite"
 					/>
 				</path>


### PR DESCRIPTION
## What is the purpose of this change?
In Identity we are looking to indicate that our reset password page is in a loading state once the CTA button is clicked. This is so that users can't click the button more than once before the request has gone through — something that could potentially cause undesirable behaviour!

## What does this change?
This change brings the excellent work done by @jamesmockett and @rBangay  for `manage-frontend`, adding a loading indicator for their live chat initiation button, [^1] to Source 

-   The animated loading circle icon [^2] used in `manage-frontend` was added to Source as an available icon.
-   The existing Button component was modified to include an `isLoading` prop.
  - When `isLoading` is true any existing icon is overridden by the loading circle until `isLoading` is set to false again.
- The loading circle respects the colours of the button it is added to. The fill colour of the circle is set to the button variant text colour and the background colour is set to the button variant background colour.
  - The background colour of the spinner also changes on hover to respect the hover background colour.
- The button disabled state was improved to visually indicate that the button is disabled by setting the cursor to `not-allowed` when it is moused over.
  - `isLoading` does not apply the `disabled` state itself, instead this is left up to the person who is using the Button component as there may be cases where this is undesirable.
- Two aria attributes are added to make the button as accessible as possible:
  - `aria-live="polite"` will mean that the user is indicated when the button status changes
  - `aria-label={isLoading ? "loading" : undeifned}` means that the screen reader will announce when the button enters the loading state.

[^1]: https://github.com/guardian/manage-frontend/blob/main/app/client/components/liveChat/liveChat.tsx#L300
[^2]: https://github.com/guardian/manage-frontend/blob/main/app/client/components/svgs/loadingCircleIcon.tsx

## Screenshots

### Primary button loading state
https://user-images.githubusercontent.com/1771189/155011846-3768df3b-510f-460c-aabc-3b5675536922.mov

### Secondary button loading state

https://user-images.githubusercontent.com/1771189/155012151-d9c74090-84e9-4d91-a8c5-273391133b72.mov

### Tertiary button loading state
https://user-images.githubusercontent.com/1771189/155012177-085dc06a-b98c-4451-bac8-557d53ba5e19.mov


### No label loading state
https://user-images.githubusercontent.com/1771189/155012192-c5e3a747-ad4b-4dad-b476-e2e209f32fb9.mov

### Disabled loading state
https://user-images.githubusercontent.com/1771189/155012595-43108fd8-091b-4120-a6da-c93efba5c4dc.mov



## Checklist

### Accessibility

#### Demonstration of using Apple Voiceover with the button (sound on):

https://user-images.githubusercontent.com/1771189/155014206-4edc3efd-fea1-47ea-b422-f5d34b1aa207.mov



-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
