### PR TITLE
Improve the accessibility of stories

### DIFF
--- a/packages/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -185,6 +185,7 @@ asChromaticStory(XSmallSizeDefaultTheme);
 export const TextAndIconLeftDefaultSizeDefaultTheme = Template.bind({});
 TextAndIconLeftDefaultSizeDefaultTheme.args = {
 	icon: 'cross',
+	children: 'Close',
 };
 asChromaticStory(TextAndIconLeftDefaultSizeDefaultTheme);
 
@@ -194,6 +195,7 @@ export const TextAndIconRightDefaultSizeDefaultTheme = Template.bind({});
 TextAndIconRightDefaultSizeDefaultTheme.args = {
 	icon: 'cross',
 	iconSide: 'right',
+	children: 'Close',
 };
 asChromaticStory(TextAndIconRightDefaultSizeDefaultTheme);
 
@@ -203,6 +205,7 @@ export const TextAndIconLeftSmallSizeDefaultTheme = Template.bind({});
 TextAndIconLeftSmallSizeDefaultTheme.args = {
 	icon: 'cross',
 	size: 'small',
+	children: 'Close',
 };
 asChromaticStory(TextAndIconLeftSmallSizeDefaultTheme);
 
@@ -213,6 +216,7 @@ TextAndIconRightSmallSizeDefaultTheme.args = {
 	icon: 'cross',
 	iconSide: 'right',
 	size: 'small',
+	children: 'Close',
 };
 asChromaticStory(TextAndIconRightSmallSizeDefaultTheme);
 
@@ -222,6 +226,7 @@ export const TextAndIconLeftXSmallSizeDefaultTheme = Template.bind({});
 TextAndIconLeftXSmallSizeDefaultTheme.args = {
 	icon: 'cross',
 	size: 'xsmall',
+	children: 'Close',
 };
 asChromaticStory(TextAndIconLeftXSmallSizeDefaultTheme);
 
@@ -232,6 +237,7 @@ TextAndIconRightXSmallSizeDefaultTheme.args = {
 	icon: 'cross',
 	iconSide: 'right',
 	size: 'xsmall',
+	children: 'Close',
 };
 asChromaticStory(TextAndIconRightXSmallSizeDefaultTheme);
 
@@ -241,6 +247,7 @@ export const IconOnlyDefaultSizeDefaultTheme = Template.bind({});
 IconOnlyDefaultSizeDefaultTheme.args = {
 	icon: 'cross',
 	hideLabel: true,
+	children: 'Close subscription banner',
 };
 asChromaticStory(IconOnlyDefaultSizeDefaultTheme);
 
@@ -251,6 +258,7 @@ IconOnlySmallSizeDefaultTheme.args = {
 	icon: 'cross',
 	hideLabel: true,
 	size: 'small',
+	children: 'Close subscription banner',
 };
 asChromaticStory(IconOnlySmallSizeDefaultTheme);
 
@@ -261,5 +269,6 @@ IconOnlyXSmallSizeDefaultTheme.args = {
 	icon: 'cross',
 	hideLabel: true,
 	size: 'xsmall',
+	children: 'Close subscription banner',
 };
 asChromaticStory(IconOnlyXSmallSizeDefaultTheme);

--- a/packages/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -80,7 +80,7 @@ export default {
 		},
 	},
 	args: {
-		children: 'Button',
+		children: 'Subscribe now',
 		size: 'default',
 		hideLabel: false,
 		icon: 'undefined',

--- a/packages/@guardian/source-react-components/src/button/LinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/LinkButton.stories.tsx
@@ -25,7 +25,7 @@ export default {
 		},
 	},
 	args: {
-		children: 'Link Button',
+		children: 'Subscribe now',
 		size: 'default',
 		hideLabel: false,
 		icon: 'undefined',

--- a/packages/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
+++ b/packages/@guardian/source-react-components/src/checkbox/Checkbox.stories.tsx
@@ -15,7 +15,7 @@ export default {
 	component: Checkbox,
 	argTypes: {},
 	args: {
-		label: 'Checkbox',
+		label: 'The Guardian Today',
 		checked: true,
 		supporting: '',
 	},

--- a/packages/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/checkbox/CheckboxGroup.stories.tsx
@@ -16,8 +16,8 @@ export default {
 	subcomponents: { Checkbox },
 	argTypes: {},
 	args: {
-		name: 'checkbox-group',
-		label: 'Checkbox group',
+		name: 'your-newsletters',
+		label: 'Your newsletters',
 		supporting: '',
 		hideLabel: false,
 		error: undefined,
@@ -85,7 +85,7 @@ asChromaticStory(VisuallyHideLegendBrandTheme);
 
 export const SupportingTextDefaultTheme = Template.bind({});
 SupportingTextDefaultTheme.args = {
-	supporting: 'Supporting text',
+	supporting: 'Pick the issues and topics that interest you',
 };
 asChromaticStory(SupportingTextDefaultTheme);
 
@@ -99,7 +99,7 @@ SupportingTextBrandTheme.parameters = {
 	theme: checkboxThemeBrand,
 };
 SupportingTextBrandTheme.args = {
-	supporting: 'Supporting text',
+	supporting: 'Pick the issues and topics that interest you',
 };
 asChromaticStory(SupportingTextBrandTheme);
 
@@ -107,7 +107,7 @@ asChromaticStory(SupportingTextBrandTheme);
 
 export const ErrorDefaultTheme = Template.bind({});
 ErrorDefaultTheme.args = {
-	error: 'Error message',
+	error: 'This newsletter is not available in your region',
 };
 asChromaticStory(ErrorDefaultTheme);
 
@@ -121,6 +121,6 @@ ErrorBrandTheme.parameters = {
 	theme: checkboxThemeBrand,
 };
 ErrorBrandTheme.args = {
-	error: 'Error message',
+	error: 'This newsletter is not available in your region',
 };
 asChromaticStory(ErrorBrandTheme);

--- a/packages/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
+++ b/packages/@guardian/source-react-components/src/link/ButtonLink.stories.tsx
@@ -29,7 +29,7 @@ export default {
 };
 
 const Template: Story = (args: ButtonLinkProps) => (
-	<ButtonLink {...args}>Click Me</ButtonLink>
+	<ButtonLink {...args}>Return to home page</ButtonLink>
 );
 
 // *****************************************************************************

--- a/packages/@guardian/source-react-components/src/link/Link.stories.tsx
+++ b/packages/@guardian/source-react-components/src/link/Link.stories.tsx
@@ -30,7 +30,9 @@ export default {
 	},
 };
 
-const Template: Story = (args: LinkProps) => <Link {...args}>Click Me</Link>;
+const Template: Story = (args: LinkProps) => (
+	<Link {...args}>Return to home page</Link>
+);
 
 // *****************************************************************************
 

--- a/packages/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/packages/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -63,7 +63,7 @@ asChromaticStory(DefaultBrandTheme);
 
 export const SupportingTextDefaultTheme = Template.bind({});
 SupportingTextDefaultTheme.args = {
-	supporting: '#ff0000',
+	supporting: 'Hex colour code: #ff0000',
 };
 asChromaticStory(SupportingTextDefaultTheme);
 
@@ -77,7 +77,7 @@ SupportingTextBrandTheme.parameters = {
 	theme: radioThemeBrand,
 };
 SupportingTextBrandTheme.args = {
-	supporting: '#ff0000',
+	supporting: 'Hex colour code: #ff0000',
 };
 asChromaticStory(SupportingTextBrandTheme);
 
@@ -85,7 +85,7 @@ asChromaticStory(SupportingTextBrandTheme);
 
 export const SupportingTextOnlyDefaultTheme = Template.bind({});
 SupportingTextOnlyDefaultTheme.args = {
-	supporting: '#ff0000',
+	supporting: 'Hex colour code: #ff0000',
 	label: null,
 };
 asChromaticStory(SupportingTextOnlyDefaultTheme);
@@ -100,7 +100,7 @@ SupportingTextOnlyBrandTheme.parameters = {
 	theme: radioThemeBrand,
 };
 SupportingTextOnlyBrandTheme.args = {
-	supporting: '#ff0000',
+	supporting: 'Hex colour code: #ff0000',
 	label: null,
 };
 asChromaticStory(SupportingTextOnlyBrandTheme);

--- a/packages/@guardian/source-react-components/src/radio/Radio.stories.tsx
+++ b/packages/@guardian/source-react-components/src/radio/Radio.stories.tsx
@@ -32,7 +32,7 @@ export default {
 		label: 'Red',
 		value: 'red',
 		supporting: '',
-		checked: true,
+		defaultChecked: true,
 	},
 };
 

--- a/packages/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/radio/RadioGroup.stories.tsx
@@ -37,17 +37,17 @@ export default {
 };
 
 const Image = () => (
-	<div style={{ padding: `8px 0` }}>
-		<img
-			alt="test"
-			src="https://i.guim.co.uk/img/media/9bd896505173dcf4adadd02e5f40a03414c50bdc/172_201_2329_1397/master/2329.jpg?width=620&quality=85&auto=format&fit=max&s=133b7c6ce78a0780e99e605bb3ae7479"
-		/>
-	</div>
+	<img
+		style={{ padding: `8px 0` }}
+		alt="test"
+		src="https://i.guim.co.uk/img/media/9bd896505173dcf4adadd02e5f40a03414c50bdc/172_201_2329_1397/master/2329.jpg?width=620&quality=85&auto=format&fit=max&s=133b7c6ce78a0780e99e605bb3ae7479"
+	/>
 );
 
 const Template: Story = (args: RadioGroupProps) => (
 	<RadioGroup {...args}>
 		<Radio {...RadioStories.args} key="radio-1" />
+		<Radio label="Blue" value="blue" key="radio-2" />
 	</RadioGroup>
 );
 
@@ -122,7 +122,7 @@ asChromaticStory(SupportingMediaDefaultTheme);
 
 export const ErrorDefaultTheme = Template.bind({});
 ErrorDefaultTheme.args = {
-	error: 'Please select a colour',
+	error: 'The selected colour is out of stock',
 };
 asChromaticStory(ErrorDefaultTheme);
 
@@ -130,7 +130,7 @@ asChromaticStory(ErrorDefaultTheme);
 
 export const ErrorBrandTheme = Template.bind({});
 ErrorBrandTheme.args = {
-	error: 'Please select a colour',
+	error: 'The selected colour is out of stock',
 };
 ErrorBrandTheme.parameters = {
 	backgrounds: {

--- a/packages/@guardian/source-react-components/src/select/Select.stories.tsx
+++ b/packages/@guardian/source-react-components/src/select/Select.stories.tsx
@@ -51,7 +51,7 @@ const Template: Story<SelectProps> = (args: SelectProps) => (
 
 export const Playground = Template.bind({});
 Playground.args = {
-	supporting: 'Leave blank if you are not within the US',
+	supporting: 'This helps us to provide accurate shipping costs',
 };
 asPlayground(Playground);
 


### PR DESCRIPTION
## What is the purpose of this change?

The accessibility audit by DAC identified confusing or non-representative stories. It was difficult for auditors to separate problems with the components from problems with the stories. Addressing issues with the stories will make it easier to identify issues with the components themselves.

## What does this change?

- improved the text descriptions in various component stories
- use `defaultChecked` instead of `checked` prop in Radio stories, as these elements are uncontrolled
- removed wrapper div from label image in radio group stories (`<div>` is invalid inside a `<p>`)
- added a second radio element to radio group stories to better demonstrate the behaviour of these components
