### PR TITLE
Remove fragment from ChoiceCardGroup story template

### DIFF
--- a/packages/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
+++ b/packages/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.stories.tsx
@@ -34,52 +34,48 @@ export default {
 
 const Template: Story<ChoiceCardGroupProps> = (args: ChoiceCardGroupProps) => (
 	<ChoiceCardGroup {...args}>
-		{
-			<>
-				<ChoiceCard
-					{...ChoiceCardStories.args}
-					id="abc1"
-					value="option-1"
-					label="Option 1"
-					key={1}
-				/>
-				<ChoiceCard
-					{...ChoiceCardStories.args}
-					id="abc2"
-					value="option-2"
-					label="Option 2"
-					key={2}
-				/>
-				<ChoiceCard
-					{...ChoiceCardStories.args}
-					id="abc3"
-					value="option-3"
-					label="Option 3"
-					key={3}
-				/>
-				<ChoiceCard
-					{...ChoiceCardStories.args}
-					id="abc4"
-					value="option-4"
-					label="Option 4"
-					key={4}
-				/>
-				<ChoiceCard
-					{...ChoiceCardStories.args}
-					id="abc5"
-					value="option-5"
-					label="Option 5"
-					key={5}
-				/>
-				<ChoiceCard
-					{...ChoiceCardStories.args}
-					id="abc6"
-					value="option-6"
-					label="Option 6"
-					key={6}
-				/>
-			</>
-		}
+		<ChoiceCard
+			{...ChoiceCardStories.args}
+			id="abc1"
+			value="option-1"
+			label="Option 1"
+			key={1}
+		/>
+		<ChoiceCard
+			{...ChoiceCardStories.args}
+			id="abc2"
+			value="option-2"
+			label="Option 2"
+			key={2}
+		/>
+		<ChoiceCard
+			{...ChoiceCardStories.args}
+			id="abc3"
+			value="option-3"
+			label="Option 3"
+			key={3}
+		/>
+		<ChoiceCard
+			{...ChoiceCardStories.args}
+			id="abc4"
+			value="option-4"
+			label="Option 4"
+			key={4}
+		/>
+		<ChoiceCard
+			{...ChoiceCardStories.args}
+			id="abc5"
+			value="option-5"
+			label="Option 5"
+			key={5}
+		/>
+		<ChoiceCard
+			{...ChoiceCardStories.args}
+			id="abc6"
+			value="option-6"
+			label="Option 6"
+			key={6}
+		/>
 	</ChoiceCardGroup>
 );
 


### PR DESCRIPTION
## What is the purpose of this change?

There is a redundant fragment in the ChoiceCardGroup story template. Not only is this cluttering the code, it is also causing a bug which means it's possible to select multiple choice cards even in single-select mode.

## What does this change?

-   Remove redundant fragment

