### PR TITLE
Remove aria-checked attributes

### DIFF
--- a/.changeset/gold-pianos-own.md
+++ b/.changeset/gold-pianos-own.md
@@ -1,0 +1,5 @@
+---
+"@guardian/source-react-components": patch
+---
+
+Remove aria-checked attributes from ChoiceCard, Checkbox and Radio components

--- a/packages/@guardian/source-react-components/src/checkbox/Checkbox.tsx
+++ b/packages/@guardian/source-react-components/src/checkbox/Checkbox.tsx
@@ -72,18 +72,6 @@ export const Checkbox = ({
 	cssOverrides,
 	...props
 }: CheckboxProps): EmotionJSX.Element => {
-	const ariaChecked = (): boolean | 'mixed' => {
-		// Note: the indeterminate prop takes precedence over the checked prop
-		if (indeterminate) {
-			return 'mixed';
-		}
-
-		if (checked != null) {
-			return checked;
-		}
-
-		return !!defaultChecked;
-	};
 	const isChecked = (): boolean => {
 		if (checked != null) {
 			return checked;
@@ -112,7 +100,6 @@ export const Checkbox = ({
 					cssOverrides,
 				]}
 				aria-invalid={!!error}
-				aria-checked={ariaChecked()}
 				ref={setIndeterminate}
 				defaultChecked={
 					defaultChecked != null ? defaultChecked : undefined

--- a/packages/@guardian/source-react-components/src/choice-card/ChoiceCard.tsx
+++ b/packages/@guardian/source-react-components/src/choice-card/ChoiceCard.tsx
@@ -85,7 +85,6 @@ export const ChoiceCard = ({
 
 	return (
 		<>
-			{/* eslint-disable-next-line jsx-a11y/role-supports-aria-props -- the `type` can only be 'radio' or 'checkbox' which both support `aria-checked` but eslint doesn't know about that */}
 			<input
 				css={(theme) => [
 					input(theme.choiceCard),
@@ -95,7 +94,6 @@ export const ChoiceCard = ({
 				id={id}
 				value={value}
 				aria-invalid={!!error}
-				aria-checked={isChecked()}
 				defaultChecked={
 					defaultChecked != null ? defaultChecked : undefined
 				}

--- a/packages/@guardian/source-react-components/src/radio/Radio.tsx
+++ b/packages/@guardian/source-react-components/src/radio/Radio.tsx
@@ -95,7 +95,6 @@ export const Radio = ({
 			type="radio"
 			css={(theme) => [radio(theme.radio), cssOverrides]}
 			value={value}
-			aria-checked={isChecked()}
 			defaultChecked={defaultChecked != null ? defaultChecked : undefined}
 			checked={checked != null ? isChecked() : undefined}
 			{...props}


### PR DESCRIPTION
## What is the purpose of this change?

`aria-checked` is often used to add assistive tech support to arbitrary elements (such as `<div>`s) that are being used as checkboxes or radios.

Since Source uses the semantically correct `<input>` elements as intended, there is no need to enhance them with `aria-checked` 

## What does this change?

-   Remove `aria-checked` attribute from Radio
-   Remove `aria-checked` attribute from Checkbox
-   Remove `aria-checked` attribute from ChoiceCard

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
