### PR TITLE
Add pinned SVG icon

### DIFF
--- a/.changeset/perfect-baboons-rush.md
+++ b/.changeset/perfect-baboons-rush.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': minor
+---
+
+Add pinned SVG icon

--- a/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
+++ b/packages/@guardian/source-react-components/src/icons/Icons.stories.tsx
@@ -46,6 +46,7 @@ import { SvgMinus } from './SvgMinus';
 import { SvgOfflineCloud } from './SvgOfflineCloud';
 import { SvgPayPal } from './SvgPayPal';
 import { SvgPerson } from './SvgPerson';
+import { SvgPinned } from './SvgPinned';
 import { SvgPinterest } from './SvgPinterest';
 import { SvgPlay } from './SvgPlay';
 import { SvgPlus } from './SvgPlus';
@@ -96,6 +97,7 @@ const uiIcons = {
 	SvgPlay,
 	SvgPlus,
 	SvgPerson,
+	SvgPinned,
 	SvgPinterest,
 	SvgQuote,
 	SvgIndent,

--- a/packages/@guardian/source-react-components/src/icons/SvgPinned.tsx
+++ b/packages/@guardian/source-react-components/src/icons/SvgPinned.tsx
@@ -1,0 +1,17 @@
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { iconSize } from '@guardian/source-foundations';
+import type { IconProps } from './types';
+
+export const SvgPinned = ({ size }: IconProps): EmotionJSX.Element => (
+	<svg
+		viewBox="-3 -3 30 30"
+		xmlns="http://www.w3.org/2000/svg"
+		width={size ? iconSize[size] : undefined}
+	>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18.3236 13.9904C17.5861 12.4521 16.3006 11.2088 14.7202 10.5345L14.1301 3.66475C15.1838 3.32759 16.111 2.75862 16.8907 2H14.0037H9.99985H7.11288C7.8715 2.75862 8.81978 3.32759 9.87342 3.66475L9.30445 10.5345C7.70292 11.2088 6.41748 12.4521 5.67993 13.9904H9.00943H11.0113V19.9962L12.0018 24L12.9922 19.9962V13.9904H14.9941H18.3236Z"
+		/>
+	</svg>
+);

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -98,6 +98,7 @@ export { SvgMinus } from './icons/SvgMinus';
 export { SvgOfflineCloud } from './icons/SvgOfflineCloud';
 export { SvgPayPal } from './icons/SvgPayPal';
 export { SvgPerson } from './icons/SvgPerson';
+export { SvgPinned } from './icons/SvgPinned';
 export { SvgPinterest } from './icons/SvgPinterest';
 export { SvgPlay } from './icons/SvgPlay';
 export { SvgPlus } from './icons/SvgPlus';

--- a/scripts/validate-dist/source-package-exports.test.ts
+++ b/scripts/validate-dist/source-package-exports.test.ts
@@ -166,6 +166,7 @@ describe('No exports have changed in the ', () => {
 			'SvgOfflineCloud',
 			'SvgPayPal',
 			'SvgPerson',
+			'SvgPinned',
 			'SvgPinterest',
 			'SvgPlay',
 			'SvgPlus',


### PR DESCRIPTION
## What is the purpose of this change?
There is a desire to import the pinned icon from Source as it is used in both dotcom rendering and apps rendering in several places in the liveblog. See here for its inclusion in the [Source icon figma file](https://www.figma.com/file/Ai7AELHC6KCz38qKZkvuHo/%E2%97%90-Icons?node-id=55%3A2). 

As the original SVG was designed to be 24x24, we are using a hack to make the viewbox 30x30 (thanks @mxdvl ) in keeping with the other icons in Source

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

## What does this change?
- Adds the pinned icon SVG to source-react-components
- Adds the icon to storybook
- Updates the changeset


## Screenshots

<img width="166" alt="Screenshot 2022-03-03 at 16 04 59" src="https://user-images.githubusercontent.com/20416599/156603403-228e8fbd-e103-4324-bb56-2a3a371a104f.png">

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
