### PR TITLE
Fix get-icons scripts

### DIFF
--- a/scripts/get-icons/components.ts
+++ b/scripts/get-icons/components.ts
@@ -51,7 +51,7 @@ export const writeComponentsIndex = (nodeNames: string[]): void => {
 	const typeExport = `export type { IconProps, IconSize } from '../types';`;
 	const componentExports = nodeNames.sort().map((name) => {
 		const iconName = `${kebabToTitle(name)}Icon`;
-		return `export { ${iconName} } from './icons/${iconName}';`;
+		return `export { ${iconName} } from './${iconName}';`;
 	});
 
 	writeFileSync(

--- a/scripts/get-icons/config.ts
+++ b/scripts/get-icons/config.ts
@@ -3,10 +3,10 @@ export const ICON_FILE = 'Ai7AELHC6KCz38qKZkvuHo';
 export const ICON_FRAMES = ['UI icons 24(w)x24(w)', 'Payment icons 24 x 24'];
 
 export const SVG_OUTPUT_DIR =
-	'../../packages/@guardian/source-react-components/icons/svgs';
+	'../../packages/@guardian/source-react-components/src/icons/svgs';
 
 export const REACT_COMPONENT_OUTPUT_DIR =
-	'../../packages/@guardian/source-react-components/icons/components';
+	'../../packages/@guardian/source-react-components/src/icons/components';
 
 export const FIGMA_OPTIONS = {
 	headers: {

--- a/scripts/get-icons/index.ts
+++ b/scripts/get-icons/index.ts
@@ -60,7 +60,7 @@ const getContentsAndWriteOutputForNode = (node: NodeWithUrl) => {
 			const titleCaseName = kebabToTitle(node.name);
 			writeFileSync(`${SVG_OUTPUT_DIR}/${node.name}.svg`, formattedSvg);
 			writeFileSync(
-				`${REACT_COMPONENT_OUTPUT_DIR}/icons/${titleCaseName}Icon.tsx`,
+				`${REACT_COMPONENT_OUTPUT_DIR}/${titleCaseName}Icon.tsx`,
 				generateReactComponent(titleCaseName, formattedSvg.trimEnd()),
 			);
 		})

--- a/scripts/get-icons/tsconfig.json
+++ b/scripts/get-icons/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
## What is the purpose of this change?

`get-icons` uses the root level `tsconfig.json`, which specifies `esnext` as the output module format. The ESModule format is not recognised by Node, and so `ts-node` fails.

Some of the output paths are erreneous, and perhaps add too much hierarchy. We should look to correct and flatten them

## What does this change?

-   add a tsconfig.json to the get-icons package that specified as output module format of `commonjs`
-   fix some erroneous paths
-  flatten the `icons/components` directory to remove the `icons` subdirectory

## Out of scope

Here, we do not check in the output of running this script. We'll address this in a subsequent PR.
