### PR TITLE
Expose spinner icon

### DIFF
--- a/.changeset/olive-experts-glow.md
+++ b/.changeset/olive-experts-glow.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': minor
+---
+
+expose spinner icon from components index

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -105,6 +105,7 @@ export { SvgPlus } from './icons/components/SvgPlus';
 export { SvgQuote } from './icons/components/SvgQuote';
 export { SvgSettings } from './icons/components/SvgSettings';
 export { SvgSpeechBubble } from './icons/components/SvgSpeechBubble';
+export { SvgSpinner } from './icons/components/SvgSpinner';
 export { SvgStar } from './icons/components/SvgStar';
 export { SvgTickRound } from './icons/components/SvgTickRound';
 export { SvgTwitter } from './icons/components/SvgTwitter';

--- a/scripts/validate-dist/source-package-exports.test.ts
+++ b/scripts/validate-dist/source-package-exports.test.ts
@@ -182,6 +182,7 @@ describe('No exports have changed in the ', () => {
 			'SvgRoundelInverse',
 			'SvgSettings',
 			'SvgSpeechBubble',
+			'SvgSpinner',
 			'SvgStar',
 			'SvgTickRound',
 			'SvgTwitter',


### PR DESCRIPTION
## What is the purpose of this change?

The Spinner icon was introduced in #1275 but it wasn't exposed externally.

This change exposes the icon so it may be consumed outside of the context of the loading button.

## What does this change?

-   Add SvgSpinner component to the list of exposed components