### PR TITLE
Use `@deprecated` jsdoc tag

### DIFF
--- a/.changeset/ten-coins-scream.md
+++ b/.changeset/ten-coins-scream.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-foundations': patch
+'@guardian/source-react-components': patch
+---
+
+Add `@deprecated` jsdoc hints so that VS Code will let you know if you use deprecated features.

--- a/packages/@guardian/source-foundations/src/colour/palette.stories.mdx
+++ b/packages/@guardian/source-foundations/src/colour/palette.stories.mdx
@@ -6,7 +6,7 @@ import { palette } from './palette';
 	parameters={{ previewTabs: { canvas: { hidden: true } } }}
 />
 
-# palette
+# `palette`
 
 The colour palette is organised by type e.g. `error`, or pillar e.g. `opinion`.
 

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -213,6 +213,8 @@ export const palette = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/9280ee)
  *
  * Default theme background colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const background = {
 	primary: palette.neutral[100],
@@ -232,6 +234,8 @@ export const background = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/63cc10)
  *
  * Brand theme background colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandBackground = {
 	primary: palette.brand[400],
@@ -248,6 +252,8 @@ export const brandBackground = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/743232)
  *
  * Alternative brand theme background colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandAltBackground = {
 	primary: palette.brandAlt[400],
@@ -263,6 +269,8 @@ export const brandAltBackground = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/69c92f)
  *
  * Default theme border colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const border = {
 	primary: palette.neutral[60],
@@ -282,6 +290,8 @@ export const border = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/04883b)
  *
  * Brand theme border colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandBorder = {
 	primary: palette.brand[600],
@@ -299,6 +309,8 @@ export const brandBorder = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/b/21c6cc)
  *
  * Alternative brand theme border colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandAltBorder = {
 	ctaTertiary: palette.neutral[7],
@@ -309,6 +321,8 @@ export const brandAltBorder = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/593cc9)
  *
  * Default theme line colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const line = {
 	primary: palette.neutral[86],
@@ -319,6 +333,8 @@ export const line = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/66455d)
  *
  * Brand theme line colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandLine = {
 	primary: palette.brand[600],
@@ -329,6 +345,8 @@ export const brandLine = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/89955e)
  *
  * Alternative brand theme line colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandAltLine = {
 	primary: palette.neutral[7],
@@ -339,6 +357,8 @@ export const brandAltLine = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/85d3b0)
  *
  * Default theme text colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const text = {
 	primary: palette.neutral[7],
@@ -366,6 +386,8 @@ export const text = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/244480)
  *
  * Brand theme text colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandText = {
 	primary: palette.neutral[100],
@@ -387,6 +409,8 @@ export const brandText = {
  * [Design System](https://theguardian.design/2a1e5182b/p/1377a6-tokens/t/11d5fd)
  *
  * Alternative brand theme text colours
+ *
+ * @deprecated Use the `palette` export instead
  */
 export const brandAltText = {
 	primary: palette.neutral[7],

--- a/packages/@guardian/source-react-components/src/columns/Columns.tsx
+++ b/packages/@guardian/source-react-components/src/columns/Columns.tsx
@@ -52,6 +52,8 @@ export interface ColumnsProps extends HTMLAttributes<HTMLDivElement>, Props {
 	 * **Deprecated**
 	 *
 	 * Use `collapseUntil` instead.
+	 *
+	 * @deprecated Use `collapseUntil` instead.
 	 */
 	collapseBelow?: CollapseBreakpoint;
 	/**

--- a/packages/@guardian/source-react-components/src/container/Container.tsx
+++ b/packages/@guardian/source-react-components/src/container/Container.tsx
@@ -14,6 +14,8 @@ export interface ContainerProps extends HTMLAttributes<HTMLElement>, Props {
 	 * **Deprecated**
 	 *
 	 * Use `sideBorders` instead.
+	 *
+	 * @deprecated Use `sideBorders` instead.
 	 */
 	border?: boolean;
 	/**

--- a/packages/@guardian/source-react-components/src/hide/Hide.tsx
+++ b/packages/@guardian/source-react-components/src/hide/Hide.tsx
@@ -18,12 +18,16 @@ export interface HideProps extends HTMLAttributes<HTMLDivElement>, Props {
 	 * **Deprecated**
 	 *
 	 * Use `from` instead.
+	 *
+	 * @deprecated Use `from` instead.
 	 */
 	above?: Breakpoint;
 	/**
 	 * **Deprecated**
 	 *
 	 * Use `until` instead.
+	 *
+	 * @deprecated Use `until` instead.
 	 */
 	below?: Breakpoint;
 }

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -186,4 +186,8 @@ export {
 	userFeedbackThemeDefault,
 } from './user-feedback/theme';
 
-export type { Props } from './@types/Props';
+/**
+ * @deprecated This is for internal use only. It was previously exported so the v3 `src-*` modules could use it.
+ * It will be removed from the public interface in v5.
+ */
+export type Props = import('./@types/Props').Props; // eslint-disable-line @typescript-eslint/consistent-type-imports -- we want to apply the jsdoc @deprecated tag only the the public export, not the actual type itself

--- a/packages/@guardian/source-react-components/src/tiles/Tiles.tsx
+++ b/packages/@guardian/source-react-components/src/tiles/Tiles.tsx
@@ -57,6 +57,8 @@ export interface TilesProps extends HTMLAttributes<HTMLDivElement>, Props {
 	 * **Deprecated**
 	 *
 	 * Use `collapseUntil` instead.
+	 *
+	 * @deprecated Use `collapseUntil` instead.
 	 */
 	collapseBelow?: CollapseBreakpoint;
 }


### PR DESCRIPTION
- adds the jsdoc `@deprected` flag, so that VS code can let you know if you use a deprecated feature
- deprecates the `Props` export (cc @oliverlloyd)


## Screenshot
<img width="643" alt="image" src="https://user-images.githubusercontent.com/867233/158823660-7f053daa-9be6-41f1-8bf3-de97fa293f9f.png">
