### PR TITLE
create `deprecated-exports` file

### DIFF
--- a/.changeset/tidy-fishes-argue.md
+++ b/.changeset/tidy-fishes-argue.md
@@ -1,0 +1,7 @@
+---
+"@guardian/source-react-components": patch
+---
+
+Move deprecated exports to their own files, and export them from there.
+
+This just keeps things cleaner internally.

--- a/.changeset/tidy-fishes-argue.md
+++ b/.changeset/tidy-fishes-argue.md
@@ -2,6 +2,6 @@
 "@guardian/source-react-components": patch
 ---
 
-Move deprecated exports to their own files, and export them from there.
+Move deprecated exports to their own file, and export them from there.
 
 This just keeps things cleaner internally.

--- a/packages/@guardian/source-react-components/src/deprecated-exports.ts
+++ b/packages/@guardian/source-react-components/src/deprecated-exports.ts
@@ -1,0 +1,14 @@
+/**
+ * DEPRECATED EXPORTS
+ *
+ * To be removed from the public interface in the next major version.
+ */
+
+import type { Props as InternalPropsType } from './@types/Props';
+
+/**
+ * @deprecated This is for internal use only.
+ * It was previously exported so the v3 `src-*` modules could use it
+ * but will be removed in the next major version.
+ */
+export type Props = InternalPropsType;

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -1,3 +1,5 @@
+export * from './deprecated-exports';
+
 export type { AccordionProps } from './accordion/Accordion';
 export { Accordion } from './accordion/Accordion';
 export { AccordionRow } from './accordion/AccordionRow';
@@ -186,9 +188,3 @@ export {
 	userFeedbackThemeBrand,
 	userFeedbackThemeDefault,
 } from './user-feedback/theme';
-
-/**
- * @deprecated This is for internal use only. It was previously exported so the v3 `src-*` modules could use it.
- * It will be removed from the public interface in v5.
- */
-export type Props = import('./@types/Props').Props; // eslint-disable-line @typescript-eslint/consistent-type-imports -- we want to apply the jsdoc @deprecated tag only the the public export, not the actual type itself


### PR DESCRIPTION
allows us to separate deprecated exports from the working api surface

