### PR TITLE
Add documentation for `generateSourceId` function

### DIFF
--- a/packages/@guardian/source-foundations/src/accessibility/generate-source-id.stories.mdx
+++ b/packages/@guardian/source-foundations/src/accessibility/generate-source-id.stories.mdx
@@ -7,8 +7,17 @@ import { Meta } from '@storybook/addon-docs';
 
 # `generateSourceId`
 
-?
+A function that generates a unique ID for an element of the form `src-component-X` where `X` is a number.
 
-```
+```tsx
+import { generateSourceId } from '@guardian/source-foundations';
 
+const Form = () => {
+	const id = generateSourceId();
+	return (
+		<form>
+			<input id={id} type="text" />
+		</form>
+	);
+};
 ```


### PR DESCRIPTION
## What is the purpose of this change?

The `generateSourceId` function was not documented.

## What does this change?

This PR adds some documentation for the function.

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**
<img width="868" alt="image" src="https://user-images.githubusercontent.com/15648334/162227304-defc7911-b0a3-4153-b54d-5f2c9c134530.png">

**After**
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/15648334/162227006-8160f4b2-2293-4811-a2e9-5e1519ac17cc.png">
