### PR TITLE
move legacy icon exports to `dprectaed-exports`

### DIFF
--- a/.changeset/four-monkeys-teach.md
+++ b/.changeset/four-monkeys-teach.md
@@ -1,0 +1,5 @@
+---
+"@guardian/source-react-components": patch
+---
+
+move legacy icon exports to `deprecated-exports`

--- a/packages/@guardian/source-react-components/src/deprecated-exports.ts
+++ b/packages/@guardian/source-react-components/src/deprecated-exports.ts
@@ -5,6 +5,11 @@
  */
 
 import type { Props as InternalPropsType } from './@types/Props';
+import { SvgCrossedOutCloud } from './icons/components/SvgCrossedOutCloud';
+import { SvgExclamation } from './icons/components/SvgExclamation';
+import { SvgFacebookMessenger } from './icons/components/SvgFacebookMessenger';
+import { SvgInfoRound } from './icons/components/SvgInfoRound';
+import { SvgMediaControlsPlay } from './icons/components/SvgMediaControlsPlay';
 
 /**
  * @deprecated This is for internal use only.
@@ -12,3 +17,18 @@ import type { Props as InternalPropsType } from './@types/Props';
  * but will be removed in the next major version.
  */
 export type Props = InternalPropsType;
+
+/** @deprecated Use `SvgCrossedOutCloud` instead. */
+export const SvgOfflineCloud = SvgCrossedOutCloud;
+
+/** @deprecated Use `SvgExclamation` instead. */
+export const SvgAlert = SvgExclamation;
+
+/** @deprecated Use `SvgFacebookMessenger` instead. */
+export const SvgMessenger = SvgFacebookMessenger;
+
+/** @deprecated Use `SvgInfoRound` instead. */
+export const SvgInfo = SvgInfoRound;
+
+/** @deprecated Use `SvgMediaControlsPlay` instead. */
+export const SvgPlay = SvgMediaControlsPlay;

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -114,13 +114,6 @@ export { SvgTwitter } from './icons/components/SvgTwitter';
 export { SvgVideo } from './icons/components/SvgVideo';
 export { SvgWhatsApp } from './icons/components/SvgWhatsApp';
 
-// Legacy icon API. Remove these aliases in a future major version bump
-export { SvgExclamation as SvgAlert } from './icons/components/SvgExclamation';
-export { SvgInfoRound as SvgInfo } from './icons/components/SvgInfoRound';
-export { SvgFacebookMessenger as SvgMessenger } from './icons/components/SvgFacebookMessenger';
-export { SvgCrossedOutCloud as SvgOfflineCloud } from './icons/components/SvgCrossedOutCloud';
-export { SvgMediaControlsPlay as SvgPlay } from './icons/components/SvgMediaControlsPlay';
-
 export type { IconProps, IconSize } from './icons/types';
 
 export { labelThemeDefault, labelThemeBrand } from './label/theme';


### PR DESCRIPTION
i got very confused between #1307, #1326 and #1318