### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,17 @@ updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       day: 'monday'
       time: '06:00'
+    open-pull-requests-limit: 100
+    # Minimise the number of chromatic runs.
+    # We've enabled 'Require branches to be up to date before merging',
+    # so you won't be able to merge a dependabot PR unless you rebase manually anyway.
+    rebase-strategy: "disabled"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
       day: 'monday'
       time: '06:00'


### PR DESCRIPTION
- change frequency to monthly (we'll try to do manual updates weekly, this is a WCS)
- no limit on the number of PRs dependabot will create (nearly anyway – we want it to be shouty if we haven't done it)
- stop it rebasing dependabot PRs every time we merge to `main`


