### PR TITLE
Only run chromatic tests when review is requested...

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,10 @@
 name: Chromatic
 on:
   push:
-    branches-ignore:
-      - 'gh-pages'
-      - '[0-9]+.[0-9]+'
+    branches:
+      - main
+  pull_request:
+    types: ['review_requested']
 jobs:
   upload-storybook:
     runs-on: ubuntu-latest


### PR DESCRIPTION
...and when somethign happens in `main` (since you can commit directly to `main` so we want to know that hasn't broken)

thanks to @coldlink for the suggestion

