### PR TITLE
Import the Guardian’s eslint/prettier config packages

### DIFF
--- a/packages/@guardian/eslint-config-typescript/README.md
+++ b/packages/@guardian/eslint-config-typescript/README.md
@@ -1,0 +1,24 @@
+# `@guardian/eslint-config-typescript`
+
+> ESLint config for Guardian TypeScript projects.
+
+## Installation
+
+```bash
+yarn add -D @guardian/eslint-config-typescript
+```
+
+or
+
+```bash
+npm install --save-dev @guardian/eslint-config-typescript
+```
+
+## Usage
+
+```js
+// ESLint configuration file
+{
+    "extends": "@guardian/eslint-config-typescript"
+}
+```

--- a/packages/@guardian/eslint-config-typescript/index.js
+++ b/packages/@guardian/eslint-config-typescript/index.js
@@ -1,0 +1,125 @@
+module.exports = {
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		ecmaVersion: 'es2020',
+		project: './tsconfig.json',
+		sourceType: 'module',
+	},
+	plugins: ['@typescript-eslint'],
+	extends: [
+		'@guardian/eslint-config',
+		'plugin:@typescript-eslint/eslint-recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-requiring-type-checking',
+		'plugin:import/typescript',
+	],
+	settings: {
+		'import/extensions': ['.ts', '.tsx'],
+		'import/parsers': {
+			'@typescript-eslint/parser': ['.ts', '.tsx'],
+		},
+		'import/resolver': {
+			typescript: {
+				// always try to resolve types under `<root>@types` directory even it doesn't contain any source code
+				alwaysTryTypes: true,
+			},
+		},
+	},
+	rules: {
+		/*
+		FIXABLE STYLISTIC CHOICES THAT DIFFER FROM THE DEFAULT
+		The intention is to maximise clarity and consistency,
+		not direct or inhibit what can be done with code.
+		*/
+
+		// use `string[]` for simple arrays, `Array<string>` for complex ones
+		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md#array-simple
+		'@typescript-eslint/array-type': [
+			2,
+			{
+				default: 'array-simple',
+			},
+		],
+
+		// use `Record<string, unknown>` instead of `{ [key: string]: unknown }`
+		'@typescript-eslint/consistent-indexed-object-style': [2, 'record'],
+
+		// be explicit when you only want to import a type:
+		// `import type { Foo } from 'Foo';`
+		'@typescript-eslint/consistent-type-imports': [
+			2,
+			{
+				prefer: 'type-imports',
+			},
+		],
+
+		// delimit members with semi-colons and require
+		// one at the end to keep diffs simpler
+		'@typescript-eslint/member-delimiter-style': [
+			2,
+			{
+				multiline: {
+					delimiter: 'semi',
+					requireLast: true,
+				},
+				singleline: {
+					delimiter: 'semi',
+					requireLast: false,
+				},
+			},
+		],
+
+		// use `(1 + foo.num!) == 2` instead of `1 + foo.num! == 2`
+		'@typescript-eslint/no-confusing-non-null-assertion': 2,
+
+		'@typescript-eslint/no-unnecessary-boolean-literal-compare': 2,
+		'@typescript-eslint/no-unnecessary-condition': 2,
+		'@typescript-eslint/no-unnecessary-qualifier': 2,
+		'@typescript-eslint/no-unnecessary-type-arguments': 2,
+
+		// use `str.includes(value)` instead of `str.indexOf(value) !== -1`
+		'@typescript-eslint/prefer-includes': 2,
+
+		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
+		'@typescript-eslint/prefer-reduce-type-parameter': 2,
+
+		// use String#startsWith or String#endsWith instead of String#indexOf et al
+		'@typescript-eslint/prefer-string-starts-ends-with': 2,
+
+		// use `@ts-expect-error` instead of `@ts-ignore`
+		'@typescript-eslint/prefer-ts-expect-error': 2,
+
+		/*
+		NOT FIXABLE BUT USEFUL
+		*/
+
+		// Enforce TypeScript naming conventions
+		// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
+		'@typescript-eslint/naming-convention': [
+			2,
+
+			// types are 'PascalCase'
+			{
+				selector: ['typeLike', 'enumMember'],
+				format: ['PascalCase'],
+			},
+
+			// booleans are descriptive
+			// {
+			// 	selector: 'variable',
+			// 	types: ['boolean'],
+			// 	format: ['PascalCase'],
+			// 	prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+			// },
+		],
+
+		// use `foo ?? 'a string'` instead of `foo !== null && foo !== undefined ? foo : 'a string'`
+		'@typescript-eslint/prefer-nullish-coalescing': 2,
+
+		// use `a?.b` instead of `a && a.b`
+		'@typescript-eslint/prefer-optional-chain': 2,
+
+		// requires any function or method that returns a Promise to be marked async
+		// '@typescript-eslint/promise-function-async': 2,
+	},
+};

--- a/packages/@guardian/eslint-config-typescript/package.json
+++ b/packages/@guardian/eslint-config-typescript/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@guardian/eslint-config-typescript",
+  "version": "1.0.1",
+  "description": "ESLint config for Guardian TypeScript projects",
+  "homepage": "https://github.com/guardian/source#readme",
+  "bugs": {
+    "url": "https://github.com/guardian/source/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/source.git"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "dependencies": {
+    "@guardian/eslint-config": "^1.0.0",
+    "@typescript-eslint/eslint-plugin": "5.6.0",
+    "@typescript-eslint/parser": "5.6.0",
+    "eslint-import-resolver-typescript": "2.5.0",
+    "eslint-plugin-import": "2.25.3"
+  },
+  "peerDependencies": {
+    "eslint": "^8.0.0",
+    "typescript": "^4.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@guardian/eslint-config/DECISION_RECORD.md
+++ b/packages/@guardian/eslint-config/DECISION_RECORD.md
@@ -1,0 +1,15 @@
+# Decision Records
+
+## Keep `eslint-config` and `eslint-config-typescript` distinct
+
+In https://github.com/guardian/configs/pull/144 we proposed merging our current eslint configs into one, so that we can use the same config for both typescript and javascript.
+
+After discussion offline, https://github.com/sndrs and https://github.com/tjsilver concluded that approach was not sustainable.
+
+### Why?
+
+Initially it would mean JS codebases that use the plugin still have to pay the cost of eslint making checks for TS and then skipping them.
+
+As we add, for example, framework configs too (e.g. react for dotcom, angular for ed tools), you will need to pay the cost of each config regardless of whether it is needed or not. 
+
+Keeping them separate means you only pay the cost of the additional linting overhead where you get the benefit.

--- a/packages/@guardian/eslint-config/README.md
+++ b/packages/@guardian/eslint-config/README.md
@@ -1,0 +1,24 @@
+# `@guardian/eslint-config`
+
+> ESLint config for Guardian JavaScript projects.
+
+## Installation
+
+```bash
+yarn add -D @guardian/eslint-config
+```
+
+or
+
+```bash
+npm install --save-dev @guardian/eslint-config
+```
+
+## Usage
+
+```js
+// ESLint configuration file
+{
+    "extends": "@guardian/eslint-config"
+}
+```

--- a/packages/@guardian/eslint-config/index.js
+++ b/packages/@guardian/eslint-config/index.js
@@ -1,0 +1,86 @@
+module.exports = {
+	env: {
+		browser: true,
+		es6: true,
+		node: true,
+	},
+	extends: [
+		'eslint:recommended',
+		'plugin:import/errors',
+		'plugin:import/warnings',
+
+		// this works for all possible configs in v8
+		// https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
+		'plugin:prettier/recommended',
+	],
+	plugins: ['eslint-comments'],
+	rules: {
+		// prevent dangling returns without braces
+		curly: ['error', 'multi-line'],
+
+		// require a `eslint-enable` comment for every `eslint-disable` comment
+		'eslint-comments/disable-enable-pair': [2, { allowWholeFile: true }],
+
+		// disallow duplicate `eslint-disable` comments
+		'eslint-comments/no-duplicate-disable': 2,
+
+		// disallow unused eslint-en/disable comments
+		// (make sure they're not left in after a fix)
+		'eslint-comments/no-unused-disable': 2,
+		'eslint-comments/no-unused-enable': 2,
+
+		// require an explanation if you disable eslint
+		'eslint-comments/require-description': [
+			2,
+			{ ignore: ['eslint-enable'] },
+		],
+
+		// this doesn't catch bugs or make things more readable
+		// and sometimes tools or 3rd parties require it
+		'no-underscore-dangle': 0,
+
+		// encourages consistent token use across code bases
+		// (you have to deliberately rename an import) and
+		// makes the location of errors easier to discover:
+		// https://twitter.com/addyosmani/status/1411233253948747777
+		'import/no-default-export': 2,
+		'import/prefer-default-export': 0,
+
+		// less diff noise (they're hoisted anyway)
+		'import/first': 2,
+
+		// fixable import formatting, designed to minimise diff noise
+		'sort-imports': [
+			'error',
+			{
+				ignoreCase: true,
+				ignoreDeclarationSort: true,
+				ignoreMemberSort: false,
+			},
+		],
+		'import/newline-after-import': 2,
+		'import/order': [
+			'error',
+			{
+				groups: [
+					'builtin',
+					'external',
+					'internal',
+					'parent',
+					'sibling',
+					'index',
+					'object',
+					'unknown',
+				],
+				'newlines-between': 'never',
+				alphabetize: {
+					order: 'asc',
+					caseInsensitive: true,
+				},
+			},
+		],
+
+		// prevent circular dependencies
+		'import/no-cycle': 2,
+	},
+};

--- a/packages/@guardian/eslint-config/package.json
+++ b/packages/@guardian/eslint-config/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@guardian/eslint-config",
+  "version": "1.0.0",
+  "description": "ESLint config for Guardian JavaScript projects",
+  "homepage": "https://github.com/guardian/source#readme",
+  "bugs": {
+    "url": "https://github.com/guardian/source/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/source.git"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "dependencies": {
+    "eslint-config-prettier": "8.3.0",
+    "eslint-plugin-eslint-comments": "3.2.0",
+    "eslint-plugin-import": "2.25.3",
+    "eslint-plugin-prettier": "4.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "^8.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@guardian/prettier/README.md
+++ b/packages/@guardian/prettier/README.md
@@ -1,0 +1,22 @@
+# `@guardian/prettier`
+
+> Prettier config for Guardian JavaScript projects.
+
+## Installation
+
+```bash
+yarn add -D @guardian/prettier
+```
+
+or
+
+```bash
+npm install --save-dev @guardian/prettier
+```
+
+## Usage
+
+```yaml
+# Prettier configuration file
+'@guardian/prettier'
+```

--- a/packages/@guardian/prettier/index.js
+++ b/packages/@guardian/prettier/index.js
@@ -1,0 +1,30 @@
+module.exports = {
+	arrowParens: 'always',
+	bracketSpacing: true,
+	bracketSameLine: false,
+	jsxSingleQuote: false,
+	printWidth: 80,
+	quoteProps: 'as-needed',
+	semi: true,
+	singleQuote: true,
+	trailingComma: 'all',
+	useTabs: true,
+	overrides: [
+		{
+			// align with .editorconfig
+			files: '*.md',
+			options: {
+				tabWidth: 4,
+				useTabs: false,
+			},
+		},
+		{
+			// align with .editorconfig
+			files: '*.json',
+			options: {
+				tabWidth: 2,
+				useTabs: false,
+			},
+		},
+	],
+};

--- a/packages/@guardian/prettier/package.json
+++ b/packages/@guardian/prettier/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@guardian/prettier",
+  "version": "1.0.0",
+  "description": "Prettier config for Guardian JavaScript projects",
+  "homepage": "https://github.com/guardian/source#readme",
+  "bugs": {
+    "url": "https://github.com/guardian/source/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guardian/source.git"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "peerDependencies": {
+    "prettier": "^2.4.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,36 +1557,10 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@guardian/eslint-config-typescript@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-1.0.1.tgz#4411d107a514b6eee486ba18402faf238cddbae1"
-  integrity sha512-DuGJsGg5xU7E8VA9/5gX+qF29SfHS8gbTQO2UMnnqwhVjuhF25Pnt04KkNCVnS2o/H+TqA6Y918A4yfNi3Uk1A==
-  dependencies:
-    "@guardian/eslint-config" "^1.0.0"
-    "@typescript-eslint/eslint-plugin" "5.6.0"
-    "@typescript-eslint/parser" "5.6.0"
-    eslint-import-resolver-typescript "2.5.0"
-    eslint-plugin-import "2.25.3"
-
-"@guardian/eslint-config@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-1.0.0.tgz#40289ff5a383e178984c9a6b817e1a222df30c68"
-  integrity sha512-D4bCS3Nos9HrJ2FeZgmMKkmNoMuBQrzIlEWuKCqDIfzOom0oE4H8JerYpAC3J3/kvXJya8kjwoYrxOFuatZSsQ==
-  dependencies:
-    eslint-config-prettier "8.3.0"
-    eslint-plugin-eslint-comments "3.2.0"
-    eslint-plugin-import "2.25.3"
-    eslint-plugin-prettier "4.0.0"
-
 "@guardian/libs@3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@guardian/libs/-/libs-3.0.0.tgz#d54813f12f77cede9ee681033f251383ea379acd"
   integrity sha512-s2NEuE+rX2IyQohFWjKA0OV2GT7HPmh/2QO7cXaZirvMAhrgmEDXu7MSfHfqaLJybpDskUCyik6Yo73qgfnJdg==
-
-"@guardian/prettier@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@guardian/prettier/-/prettier-1.0.0.tgz#a5dd832e2ce31c6f723f0af77fe116b32b4695ff"
-  integrity sha512-srnhPn3hcSv14mDotFQN0CfN3k8MaGsXdK8BXAG95QQxM69Ybi16o4/Xqe361fwDEp7m+9jf03sETcMi8WsDlA==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"


### PR DESCRIPTION
## What is the purpose of this change?

move our eslint/prettier config packages to the source Nx monorepo

part of a wider test at seeing how Nx performs. 

if it goes well, we'll look at moving pkgu and libs too, and if _that_ goes well then who knows where we go...

## What does this change?

- import `@guardian/eslint-config` package
- import `@guardian/eslint-config-typescript` package
- import `@guardian/prettier` package

if we merge i'll archive https://github.com/guardian/configs

cc @akash1810 