### PR TITLE
Add `disabled` prop to `ToggleSwitch`

### DIFF
--- a/.changeset/itchy-monkeys-battle.md
+++ b/.changeset/itchy-monkeys-battle.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Adds a disabled prop which disables the ToggleSwitch and implements disabled specific styling

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/README.md
@@ -1,4 +1,4 @@
-# StarRating
+# ToggleSwitch
 
 Displays an on/off switch. See the accompanying stories for visual examples.
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -104,7 +104,11 @@ export const ToggleSwitch = ({
 	};
 
 	return (
-		<label id={labelId} css={[labelStyles(disabled), cssOverrides]} {...props}>
+		<label
+			id={labelId}
+			css={[labelStyles(disabled), cssOverrides]}
+			{...props}
+		>
 			{labelPosition === 'left' && label}
 			<button
 				id={buttonId}

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -46,6 +46,11 @@ export interface ToggleSwitchProps extends Props {
 	 */
 	platform?: Platform;
 	/**
+	 * Disables the toggle and implements disabled specific styling.
+	 * The default is false.
+	 */
+	disabled?: boolean;
+	/**
 	 * A callback function called when the component is checked or unchecked.
 	 * Receives the click event as an argument.
 	 */
@@ -82,12 +87,15 @@ export const ToggleSwitch = ({
 	defaultChecked,
 	cssOverrides,
 	platform = 'web',
+	disabled = false,
 	onClick = () => undefined,
 	...props
 }: ToggleSwitchProps): EmotionJSX.Element => {
 	const buttonId = id ?? generateSourceId();
 	const labelId = descriptionId(buttonId);
-	const isChecked = (): boolean => {
+	const isChecked = (disabled: boolean): boolean => {
+		if (disabled) return false;
+
 		if (checked != undefined) {
 			return checked;
 		}
@@ -102,9 +110,10 @@ export const ToggleSwitch = ({
 				id={buttonId}
 				css={[buttonStyles(labelPosition), getPlatformStyles(platform)]}
 				role="switch"
-				aria-checked={isChecked()}
+				aria-checked={isChecked(disabled)}
 				aria-labelledby={labelId}
 				onClick={onClick}
+				aria-disabled={disabled}
 			></button>
 			{labelPosition === 'right' && label}
 		</label>

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -90,6 +90,7 @@ export const ToggleSwitch = ({
 	platform = 'web',
 	disabled = false,
 	onClick = () => undefined,
+	...props
 }: ToggleSwitchProps): EmotionJSX.Element => {
 	const buttonId = id ?? generateSourceId();
 	const labelId = descriptionId(buttonId);
@@ -111,6 +112,7 @@ export const ToggleSwitch = ({
 				disabled ? disabledLabelStyles : '',
 				cssOverrides,
 			]}
+			{...props}
 		>
 			{labelPosition === 'left' && label}
 			<button

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -104,7 +104,7 @@ export const ToggleSwitch = ({
 	};
 
 	return (
-		<label id={labelId} css={[labelStyles, cssOverrides]} {...props}>
+		<label id={labelId} css={[labelStyles(disabled), cssOverrides]} {...props}>
 			{labelPosition === 'left' && label}
 			<button
 				id={buttonId}

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -5,6 +5,7 @@ import type { Props } from '@guardian/source-react-components';
 import {
 	androidStyles,
 	buttonStyles,
+	disabledLabelStyles,
 	iosStyles,
 	labelStyles,
 	webStyles,
@@ -89,11 +90,10 @@ export const ToggleSwitch = ({
 	platform = 'web',
 	disabled = false,
 	onClick = () => undefined,
-	...props
 }: ToggleSwitchProps): EmotionJSX.Element => {
 	const buttonId = id ?? generateSourceId();
 	const labelId = descriptionId(buttonId);
-	const isChecked = (disabled: boolean): boolean => {
+	const isChecked = (): boolean => {
 		if (disabled) return false;
 
 		if (checked != undefined) {
@@ -106,15 +106,18 @@ export const ToggleSwitch = ({
 	return (
 		<label
 			id={labelId}
-			css={[labelStyles(disabled), cssOverrides]}
-			{...props}
+			css={[
+				labelStyles,
+				disabled ? disabledLabelStyles : '',
+				cssOverrides,
+			]}
 		>
 			{labelPosition === 'left' && label}
 			<button
 				id={buttonId}
 				css={[buttonStyles(labelPosition), getPlatformStyles(platform)]}
 				role="switch"
-				aria-checked={isChecked(disabled)}
+				aria-checked={isChecked()}
 				aria-labelledby={labelId}
 				onClick={onClick}
 				aria-disabled={disabled}

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -149,10 +149,14 @@ export const webStyles = css`
 	}
 `;
 
-export const labelStyles = (disabled: boolean) => css`
+export const disabledLabelStyles = css`
+	color: ${neutral[86]};
+`;
+
+export const labelStyles = css`
 	${textSans.small()};
 	display: flex;
-	color: ${disabled ? neutral[86] : neutral[7]};
+	color: ${neutral[7]};
 	align-items: center;
 	cursor: pointer;
 	user-select: none;

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -152,9 +152,8 @@ export const webStyles = css`
 export const labelStyles = (disabled: boolean) => css`
 	${textSans.small()};
 	display: flex;
-	color: ${disabled? neutral[86] : neutral[7]};
+	color: ${disabled ? neutral[86] : neutral[7]};
 	align-items: center;
 	cursor: pointer;
 	user-select: none;
-
 `;

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -49,6 +49,10 @@ export const iosStyles = css`
 		left: 20px;
 		background: ${neutral[100]};
 	}
+
+	&[aria-disabled='true'] {
+		background: ${neutral[86]};
+	}
 `;
 
 export const androidStyles = css`
@@ -78,6 +82,10 @@ export const androidStyles = css`
 	&[aria-checked='true']:after {
 		left: 8px;
 		background: ${success[500]};
+	}
+
+	&[aria-disabled='true'] {
+		background: ${neutral[86]};
 	}
 `;
 
@@ -134,6 +142,10 @@ export const webStyles = css`
 	&[aria-checked='true']:after {
 		left: 1.375rem;
 		background: ${neutral[100]};
+	}
+
+	&[aria-disabled='true'] {
+		background: ${neutral[86]};
 	}
 `;
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -149,11 +149,12 @@ export const webStyles = css`
 	}
 `;
 
-export const labelStyles = css`
+export const labelStyles = (disabled: boolean) => css`
 	${textSans.small()};
 	display: flex;
-	color: ${neutral[7]};
+	color: ${disabled? neutral[86] : neutral[7]};
 	align-items: center;
 	cursor: pointer;
 	user-select: none;
+
 `;


### PR DESCRIPTION
## What is the purpose of this change?
As part of the ticket on creating a NoJS version of the key events toggle (https://trello.com/c/F710fnsR/187-hide-the-filter-key-events-when-js-is-off), this PR introduces a `disabled` prop which disables the `ToggleSwitch` and implements disabled specific styling. 

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://www.theguardian.design/2a1e5182b/p/77c9d9-contributing
-->

## What does this change?
1) A`disabled` prop is added to `ToggleSwitch`.
2) Disabled specific styling is added to `styles.ts`.

## Video

https://user-images.githubusercontent.com/55602675/168302872-4baaa753-ec56-444f-8a4b-18cd9a934deb.mov

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
