### PR TITLE
Change unselected ChoiceCard border colour

### DIFF
--- a/.changeset/perfect-rings-try.md
+++ b/.changeset/perfect-rings-try.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': major
+---
+
+Improve accessibility of unselected state of ChoiceCard

--- a/packages/@guardian/source-react-components/src/choice-card/theme.ts
+++ b/packages/@guardian/source-react-components/src/choice-card/theme.ts
@@ -7,7 +7,7 @@ export const choiceCardThemeDefault = {
 		textLabelSupporting: palette.neutral[46],
 		textGroupLabel: palette.neutral[7],
 		textGroupLabelSupporting: palette.neutral[46],
-		border: palette.neutral[60],
+		border: palette.neutral[46],
 		textChecked: palette.brand[400],
 		backgroundChecked: '#E3F6FF',
 		backgroundTick: palette.brand[500],

--- a/packages/@guardian/source-react-components/src/choice-card/theme.ts
+++ b/packages/@guardian/source-react-components/src/choice-card/theme.ts
@@ -1,21 +1,21 @@
-import { background, border, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { userFeedbackThemeDefault } from '../user-feedback/theme';
 
 export const choiceCardThemeDefault = {
 	choiceCard: {
-		textLabel: text.supporting,
-		textLabelSupporting: text.supporting,
-		textGroupLabel: text.groupLabel,
-		textGroupLabelSupporting: text.groupLabelSupporting,
-		border: border.input,
-		textChecked: text.inputChecked,
+		textLabel: palette.neutral[46],
+		textLabelSupporting: palette.neutral[46],
+		textGroupLabel: palette.neutral[7],
+		textGroupLabelSupporting: palette.neutral[46],
+		border: palette.neutral[60],
+		textChecked: palette.brand[400],
 		backgroundChecked: '#E3F6FF',
-		backgroundTick: background.inputChecked,
-		borderChecked: border.inputChecked,
-		textHover: text.inputHover,
-		borderHover: border.inputHover,
-		textError: text.error,
-		borderError: border.error,
+		backgroundTick: palette.brand[500],
+		borderChecked: palette.brand[500],
+		textHover: palette.brand[400],
+		borderHover: palette.brand[500],
+		textError: palette.error[400],
+		borderError: palette.error[400],
 	},
 	...userFeedbackThemeDefault,
 };


### PR DESCRIPTION
## What is the purpose of this change?

The accessibility audit found that "the colour of the grey button against the white background does not meet the required ratio of 3:1 for AA standard. This may be problematic for visually impaired users." The previous border colour was #999999 with a ratio of 2.84:1).

## What does this change?

-   Changes the unselected ChoiceCard border colour to #707070 to meet the criteria for AA standard (contrast ratio of border to white background is now 4.95:1). 
-   Updates ChoiceCard theme to use `palette` colour tokens instead of deprecated ones.


## Screenshots

**Before**
<img width="328" alt="image" src="https://user-images.githubusercontent.com/15648334/168795428-0fe4f32f-6b80-4c62-b570-83281d40db41.png">

**After**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/15648334/168795487-bf3a1b72-17cf-40fc-bcc1-10e6033666d7.png">

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
