### PR TITLE
Change button focus style

### DIFF
--- a/.changeset/cool-bats-occur.md
+++ b/.changeset/cool-bats-occur.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-react-components': major
+'@guardian/source-foundations': minor
+---
+
+Add spaced focus halo and apply to buttons

--- a/packages/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
+++ b/packages/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
@@ -20,3 +20,17 @@ const customButtonStyles = css`
 	${focusHalo};
 `;
 ```
+
+# `focusHaloSpaced`
+
+The blue halo effect with a white border between the element and the halo for better visibility of halo on blue-coloured elements.
+
+Apply the `focusHaloSpaced` style to custom interactive elements:
+
+```tsx
+import { focusHalo } from '@guardian/source-foundations';
+
+const customButtonStyles = css`
+	${focusHaloSpaced};
+`;
+```

--- a/packages/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
+++ b/packages/@guardian/source-foundations/src/accessibility/focus-halo.stories.mdx
@@ -23,12 +23,12 @@ const customButtonStyles = css`
 
 # `focusHaloSpaced`
 
-The blue halo effect with a white border between the element and the halo for better visibility of halo on blue-coloured elements.
+The blue halo effect with additional spacing between the element and the halo for better visibility of halo on blue-coloured elements.
 
 Apply the `focusHaloSpaced` style to custom interactive elements:
 
 ```tsx
-import { focusHalo } from '@guardian/source-foundations';
+import { focusHaloSpaced } from '@guardian/source-foundations';
 
 const customButtonStyles = css`
 	${focusHaloSpaced};

--- a/packages/@guardian/source-foundations/src/accessibility/focus-halo.ts
+++ b/packages/@guardian/source-foundations/src/accessibility/focus-halo.ts
@@ -13,8 +13,9 @@ export const focusHalo = `
 `;
 
 export const focusHaloSpaced = `
- outline: 3px solid ${palette.neutral[100]};
+ outline: 0;
  html:not(.src-focus-disabled) & {
-	 box-shadow: 0 0 0 8px ${palette.focus[400]};
+	outline: 5px solid ${palette.focus[400]};
+	outline-offset: 3px;
  }
 `;

--- a/packages/@guardian/source-foundations/src/accessibility/focus-halo.ts
+++ b/packages/@guardian/source-foundations/src/accessibility/focus-halo.ts
@@ -11,3 +11,10 @@ export const focusHalo = `
 	 box-shadow: 0 0 0 5px ${palette.focus[400]};
  }
 `;
+
+export const focusHaloSpaced = `
+ outline: 3px solid ${palette.neutral[100]};
+ html:not(.src-focus-disabled) & {
+	 box-shadow: 0 0 0 8px ${palette.focus[400]};
+ }
+`;

--- a/packages/@guardian/source-foundations/src/accessibility/focus-halo.ts
+++ b/packages/@guardian/source-foundations/src/accessibility/focus-halo.ts
@@ -1,4 +1,4 @@
-import { border } from '../colour/palette';
+import { palette } from '../colour/palette';
 
 /**
  * [Storybook](https://guardian.github.io/source/?path=/docs/packages-source-foundations-focushalo--page)
@@ -8,6 +8,6 @@ import { border } from '../colour/palette';
 export const focusHalo = `
  outline: 0;
  html:not(.src-focus-disabled) & {
-	 box-shadow: 0 0 0 5px ${border.focusHalo};
+	 box-shadow: 0 0 0 5px ${palette.focus[400]};
  }
 `;

--- a/packages/@guardian/source-foundations/src/index.test.ts
+++ b/packages/@guardian/source-foundations/src/index.test.ts
@@ -49,6 +49,7 @@ it('Should have exactly these exports', () => {
 		'error',
 		'focus',
 		'focusHalo',
+		'focusHaloSpaced',
 		'fontWeights',
 		'fonts',
 		'from',

--- a/packages/@guardian/source-foundations/src/index.ts
+++ b/packages/@guardian/source-foundations/src/index.ts
@@ -2,7 +2,7 @@ import { palette } from './colour/palette';
 
 // accessibility
 export { descriptionId } from './accessibility/description-id';
-export { focusHalo } from './accessibility/focus-halo';
+export { focusHalo, focusHaloSpaced } from './accessibility/focus-halo';
 export { generateSourceId } from './accessibility/generate-source-id';
 export { visuallyHidden } from './accessibility/visually-hidden';
 

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -1,7 +1,7 @@
 import type { SerializedStyles, Theme } from '@emotion/react';
 import { css } from '@emotion/react';
 import {
-	focusHalo,
+	focusHaloSpaced,
 	height,
 	space,
 	textSans,
@@ -34,7 +34,7 @@ const button = css`
 	}
 
 	&:focus {
-		${focusHalo};
+		${focusHaloSpaced};
 	}
 `;
 


### PR DESCRIPTION
## What is the purpose of this change?

To improve accessibility of buttons and ensure button focus outline is visible on buttons of a similar blue colour, this PR adds 3px space between the button and the focus outline.

## What does this change?

-   Adds a new `focusHaloSpaced` component.
-   Implements `focusHaloSpaced` in `Button` component.
-   Updates `Button` style to use `palette` colour tokens.
-   Updates `focusHalo` story to include `focusHaloSpaced`.

## Screenshots
**Story**
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/15648334/169022686-61fe3a08-6c75-466f-9e6a-e988cbc3ba9b.png">

**Before**
<img width="201" alt="image" src="https://user-images.githubusercontent.com/15648334/169021292-09ca6ac6-aa79-423f-a379-66fad176d801.png">

<img width="199" alt="image" src="https://user-images.githubusercontent.com/15648334/169021745-6b95d6ac-d1e6-451c-9eb9-ef1bcd69e8ff.png">

<img width="184" alt="image" src="https://user-images.githubusercontent.com/15648334/169021626-50d445b5-da8e-4c3d-ae44-e2a669fb41ee.png">

<img width="186" alt="image" src="https://user-images.githubusercontent.com/15648334/169022298-4a3fa306-32a9-4c34-a096-f73b9f59b1b8.png">


**After**
<img width="197" alt="image" src="https://user-images.githubusercontent.com/15648334/169021354-62c44f68-d0b9-4d91-8c38-74f581474b0a.png">

<img width="191" alt="image" src="https://user-images.githubusercontent.com/15648334/169021791-af9679e1-4590-42e8-a541-350744d4c20b.png">

<img width="187" alt="image" src="https://user-images.githubusercontent.com/15648334/169021566-a1e6e9a0-5045-429b-94d0-84a8bd4e1023.png">

<img width="186" alt="image" src="https://user-images.githubusercontent.com/15648334/169022198-d345252e-a924-4156-b326-0f4fd26c5c75.png">


## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
### 