### PR TITLE
Change unselected Checkbox border colour

### DIFF
--- a/.changeset/strange-brooms-talk.md
+++ b/.changeset/strange-brooms-talk.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': major
+---
+
+Improve accessibility of unselected state of checkbox

--- a/packages/@guardian/source-react-components/src/checkbox/theme.ts
+++ b/packages/@guardian/source-react-components/src/checkbox/theme.ts
@@ -7,7 +7,7 @@ import {
 
 export const checkboxThemeDefault = {
 	checkbox: {
-		border: palette.neutral[60],
+		border: palette.neutral[46],
 		borderHover: palette.brand[500],
 		borderChecked: palette.brand[500],
 		borderError: palette.error[400],

--- a/packages/@guardian/source-react-components/src/checkbox/theme.ts
+++ b/packages/@guardian/source-react-components/src/checkbox/theme.ts
@@ -1,11 +1,4 @@
-import {
-	background,
-	border,
-	brandBackground,
-	brandBorder,
-	brandText,
-	text,
-} from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { labelThemeBrand, labelThemeDefault } from '../label/theme';
 import {
 	userFeedbackThemeBrand,
@@ -14,14 +7,14 @@ import {
 
 export const checkboxThemeDefault = {
 	checkbox: {
-		border: border.input,
-		borderHover: border.inputHover,
-		borderChecked: border.inputChecked,
-		borderError: border.error,
-		backgroundChecked: background.inputChecked,
-		textLabel: text.inputLabel,
-		textLabelSupporting: text.inputLabelSupporting,
-		textIndeterminate: text.supporting,
+		border: palette.neutral[60],
+		borderHover: palette.brand[500],
+		borderChecked: palette.brand[500],
+		borderError: palette.error[400],
+		backgroundChecked: palette.brand[500],
+		textLabel: palette.neutral[7],
+		textLabelSupporting: palette.neutral[46],
+		textIndeterminate: palette.neutral[46],
 	},
 	...userFeedbackThemeDefault,
 	...labelThemeDefault,
@@ -29,14 +22,14 @@ export const checkboxThemeDefault = {
 
 export const checkboxThemeBrand = {
 	checkbox: {
-		border: brandBorder.input,
-		borderHover: brandBorder.inputHover,
-		borderChecked: brandBorder.inputChecked,
-		borderError: brandBorder.error,
-		backgroundChecked: brandBackground.inputChecked,
-		textLabel: brandText.inputLabel,
-		textLabelSupporting: brandText.inputLabelSupporting,
-		textIndeterminate: brandText.supporting,
+		border: palette.brand[800],
+		borderHover: palette.neutral[100],
+		borderChecked: palette.neutral[100],
+		borderError: palette.error[500],
+		backgroundChecked: palette.neutral[100],
+		textLabel: palette.neutral[100],
+		textLabelSupporting: palette.brand[800],
+		textIndeterminate: palette.brand[800],
 	},
 	...userFeedbackThemeBrand,
 	...labelThemeBrand,


### PR DESCRIPTION
## What is the purpose of this change?

The accessibility audit found that the Checkbox border colour (#999999 with a ratio of 2.84:1) did not meet the required ratio of 3:1 for AA standard.

## What does this change?

-   Changes the unselected Checkbox border colour to #707070 to meet the criteria for AA standard (contrast ratio of border to white background is now 4.95:1). 
-   Updates Checkbox theme to use `palette` colour tokens instead of deprecated ones.

## Screenshots

**Before**
<img width="214" alt="image" src="https://user-images.githubusercontent.com/15648334/168821091-ce081125-fe97-49a8-9b11-0fffda1dde7c.png">

**After**
<img width="212" alt="image" src="https://user-images.githubusercontent.com/15648334/168821259-e9795b2c-64d6-4088-95df-67a6c88a12a5.png">

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
