### PR TITLE
Update focus colour

### DIFF
--- a/.changeset/good-pillows-do.md
+++ b/.changeset/good-pillows-do.md
@@ -1,6 +1,6 @@
 ---
-'@guardian/source-foundations': minor
-'@guardian/source-react-components': minor
+'@guardian/source-foundations': major
+'@guardian/source-react-components': major
 ---
 
 Update focusHalo colour

--- a/.changeset/good-pillows-do.md
+++ b/.changeset/good-pillows-do.md
@@ -1,6 +1,0 @@
----
-'@guardian/source-foundations': major
-'@guardian/source-react-components': major
----
-
-Update focusHalo colour

--- a/.changeset/good-pillows-do.md
+++ b/.changeset/good-pillows-do.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-foundations': minor
+'@guardian/source-react-components': minor
+---
+
+Update focusHalo colour

--- a/.changeset/twelve-taxis-nail.md
+++ b/.changeset/twelve-taxis-nail.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': major
+---
+
+Update focusHalo colour

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -36,7 +36,6 @@ const colors = {
 		'#007ABC', //brand-500
 		'#506991', //brand-600
 		'#C1D8FC', //brand-800
-		'#0093E0',
 	],
 	browns: [
 		'#2B2625', //culture-50

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -26,7 +26,7 @@ const colors = {
 		'#003C60', //sport-100
 		'#004E7C', //sport-200
 		'#005689', //sport-300
-		'#0077B6', //sport-400
+		'#0077B6', //sport-400, focus-400
 		'#00B2FF', //sport-500
 		'#90DCFF', //sport-600
 		'#F1F8FC', //sport-800
@@ -36,7 +36,7 @@ const colors = {
 		'#007ABC', //brand-500
 		'#506991', //brand-600
 		'#C1D8FC', //brand-800
-		'#0093E0', //focus-400
+		'#0093E0',
 	],
 	browns: [
 		'#2B2625', //culture-50

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -201,7 +201,7 @@ export const palette = {
 		800: colors.grays[17],
 	},
 	focus: {
-		400: '#007CC4',
+		400: colors.blues[3],
 	},
 };
 


### PR DESCRIPTION
## What is the purpose of this change?

Updates the colour of the `focusHalo` from `#007CC4` (contrast ratio 4.48:1) to `#0077B6` (contrast ratio 4.86:1).

**Before**

![image](https://user-images.githubusercontent.com/15648334/169055666-53ceff40-426c-4421-8053-c90a56b634cb.png)

**After**

![image](https://user-images.githubusercontent.com/15648334/169055014-403b3c0e-f53a-47db-ad73-c084ffbc44b7.png)

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
