### PR TITLE
Change brand[500] colour token

### DIFF
--- a/.changeset/loud-cameras-hug.md
+++ b/.changeset/loud-cameras-hug.md
@@ -1,6 +1,6 @@
 ---
-'@guardian/source-foundations': minor
-'@guardian/source-react-components': minor
+'@guardian/source-foundations': major
+'@guardian/source-react-components': major
 ---
 
 Change brand[500] colour token

--- a/.changeset/loud-cameras-hug.md
+++ b/.changeset/loud-cameras-hug.md
@@ -1,6 +1,0 @@
----
-'@guardian/source-foundations': major
-'@guardian/source-react-components': major
----
-
-Change brand[500] colour token

--- a/.changeset/loud-cameras-hug.md
+++ b/.changeset/loud-cameras-hug.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-foundations': minor
+'@guardian/source-react-components': minor
+---
+
+Change brand[500] colour token

--- a/.changeset/perfect-wombats-fix.md
+++ b/.changeset/perfect-wombats-fix.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': major
+---
+
+Change brand[500] colour token

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -105,7 +105,7 @@ export const palette = {
 		100: colors.blues[7],
 		300: colors.blues[8],
 		400: colors.blues[9],
-		500: colors.blues[10],
+		500: colors.blues[3],
 		600: colors.blues[11],
 		800: colors.blues[12],
 	},

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -33,7 +33,6 @@ const colors = {
 		'#001536', //brand-100
 		'#041F4A', //brand-300
 		'#052962', //brand-400
-		'#007ABC',
 		'#506991', //brand-600
 		'#C1D8FC', //brand-800
 	],
@@ -106,8 +105,8 @@ export const palette = {
 		300: colors.blues[8],
 		400: colors.blues[9],
 		500: colors.blues[3],
-		600: colors.blues[11],
-		800: colors.blues[12],
+		600: colors.blues[10],
+		800: colors.blues[11],
 	},
 	brandAlt: {
 		200: colors.yellows[0],

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -26,14 +26,14 @@ const colors = {
 		'#003C60', //sport-100
 		'#004E7C', //sport-200
 		'#005689', //sport-300
-		'#0077B6', //sport-400, focus-400
+		'#0077B6', //sport-400, focus-400, brand-500
 		'#00B2FF', //sport-500
 		'#90DCFF', //sport-600
 		'#F1F8FC', //sport-800
 		'#001536', //brand-100
 		'#041F4A', //brand-300
 		'#052962', //brand-400
-		'#007ABC', //brand-500
+		'#007ABC',
 		'#506991', //brand-600
 		'#C1D8FC', //brand-800
 	],


### PR DESCRIPTION
## What is the purpose of this change?

Changes the `brand[500]` colour token from #007ABC (colour contrast 4.65:1) to #0077B6 (colour contrast 4.86:1).

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**
![image](https://user-images.githubusercontent.com/15648334/169066894-a2126e3b-3149-4f9f-92e8-ec4e6fac888a.png)

**After**
![image](https://user-images.githubusercontent.com/15648334/169066994-4dbef00c-2150-41a3-8866-e9a1069f3fe0.png)

## Checklist

### Accessibility

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [ ] Tested at all breakpoints
-   [ ] Tested with with long text
-   [ ] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [ ] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
