### PR TITLE
Replace deprecated colour tokens with palette

### DIFF
--- a/.changeset/clean-berries-cough.md
+++ b/.changeset/clean-berries-cough.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-foundations': major
+'@guardian/source-react-components': major
+---
+
+Replace deprecated colour tokens with palette

--- a/.storybook/preview/backgrounds.ts
+++ b/.storybook/preview/backgrounds.ts
@@ -1,31 +1,27 @@
-import {
-	background,
-	brandBackground,
-	brandAltBackground,
-} from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export const backgrounds = {
 	default: 'background.primary',
 	values: [
 		{
 			name: 'background.primary',
-			value: background.primary,
+			value: palette.neutral[100],
 		},
 		{
 			name: 'background.secondary',
-			value: background.secondary,
+			value: palette.neutral[97],
 		},
 		{
 			name: 'background.inverse',
-			value: background.inverse,
+			value: palette.neutral[10],
 		},
 		{
 			name: 'brandBackground.primary',
-			value: brandBackground.primary,
+			value: palette.brand[400],
 		},
 		{
 			name: 'brandAltBackground.primary',
-			value: brandAltBackground.primary,
+			value: palette.brandAlt[400],
 		},
 	],
 };

--- a/packages/@guardian/source-foundations/src/utils/resets.ts
+++ b/packages/@guardian/source-foundations/src/utils/resets.ts
@@ -1,4 +1,4 @@
-import { background, text } from '../colour/palette';
+import { palette } from '../colour/palette';
 
 ////////////////////////////
 // Element specific resets
@@ -43,8 +43,8 @@ const defaults = `
         font-variant-ligatures: common-ligatures;
     }
     body {
-        background-color: ${background.primary};
-        color: ${text.primary};
+        background-color: ${palette.neutral[100]};
+        color: ${palette.neutral[7]};
     }
     em {
         font-style: italic;

--- a/packages/@guardian/source-react-components/README.md
+++ b/packages/@guardian/source-react-components/README.md
@@ -78,11 +78,11 @@ To extend or override the styles of Source components, pass `SerializedStyles` g
 import { css } from '@emotion/react';
 
 const dangerStyles = css`
-    background-colour: ${error[500]};
-    color: ${text.ctaPrimary};
+    background-colour: ${palette.error[500]};
+    color: ${palette.neutral[100]};
 
     &:hover {
-        background-colour: ${error[400]};
+        background-colour: ${palette.error[400]};
     }
 `;
 

--- a/packages/@guardian/source-react-components/src/accordion/theme.ts
+++ b/packages/@guardian/source-react-components/src/accordion/theme.ts
@@ -1,8 +1,8 @@
-import { border, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export const accordionThemeDefault = {
 	accordion: {
-		textPrimary: text.primary,
-		borderPrimary: border.primary,
+		textPrimary: palette.neutral[7],
+		borderPrimary: palette.neutral[60],
 	},
 };

--- a/packages/@guardian/source-react-components/src/button/theme.ts
+++ b/packages/@guardian/source-react-components/src/button/theme.ts
@@ -1,14 +1,4 @@
-import {
-	background,
-	border,
-	brandAltBackground,
-	brandAltBorder,
-	brandAltText,
-	brandBackground,
-	brandBorder,
-	brandText,
-	text,
-} from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export type ButtonTheme = {
 	textPrimary: string;
@@ -25,45 +15,44 @@ export type ButtonTheme = {
 
 export const buttonThemeDefault: { button: ButtonTheme } = {
 	button: {
-		textPrimary: text.ctaPrimary,
-		backgroundPrimary: background.ctaPrimary,
-		backgroundPrimaryHover: background.ctaPrimaryHover,
-		textSecondary: text.ctaSecondary,
-		backgroundSecondary: background.ctaSecondary,
-		backgroundSecondaryHover: background.ctaSecondaryHover,
-		textTertiary: text.ctaTertiary,
-		backgroundTertiaryHover: background.ctaTertiaryHover,
-		borderTertiary: border.ctaTertiary,
-		textSubdued: text.ctaSecondary,
+		textPrimary: palette.neutral[100],
+		backgroundPrimary: palette.brand[400],
+		backgroundPrimaryHover: '#234B8A', // One-off colour variant generated from palette.brand[400]
+		textSecondary: palette.brand[400],
+		backgroundSecondary: palette.brand[800],
+		backgroundSecondaryHover: '#ACC9F7', // One-off colour variant generated from palette.brand[800]
+		textTertiary: palette.brand[400],
+		backgroundTertiaryHover: '#E5E5E5', // One-off colour variant
+		borderTertiary: palette.brand[400],
+		textSubdued: palette.brand[400],
 	},
 };
 
 export const buttonThemeBrand: { button: ButtonTheme } = {
 	button: {
-		textPrimary: brandText.ctaPrimary,
-		backgroundPrimary: brandBackground.ctaPrimary,
-		backgroundPrimaryHover: brandBackground.ctaPrimaryHover,
-		textSecondary: brandText.ctaSecondary,
-		backgroundSecondary: brandBackground.ctaSecondary,
-		backgroundSecondaryHover: brandBackground.ctaSecondaryHover,
-		textTertiary: brandText.ctaTertiary,
-		backgroundTertiaryHover: brandBackground.ctaTertiaryHover,
-		borderTertiary: brandBorder.ctaTertiary,
-		textSubdued: brandText.ctaSecondary,
+		textPrimary: palette.brand[400],
+		backgroundPrimary: palette.neutral[100],
+		backgroundPrimaryHover: '#E0E0E0', // One-off colour variant generated from palette.neutral[100]
+		textSecondary: palette.neutral[100],
+		backgroundSecondary: palette.brand[600],
+		backgroundSecondaryHover: '#234B8A', // One-off colour variant generated from palette.brand[600]
+		textTertiary: palette.neutral[100],
+		backgroundTertiaryHover: palette.brand[300],
+		borderTertiary: palette.neutral[100],
+		textSubdued: palette.neutral[100],
 	},
 };
 
 export const buttonThemeBrandAlt: { button: ButtonTheme } = {
 	button: {
-		textPrimary: brandAltText.ctaPrimary,
-		backgroundPrimary: brandAltBackground.ctaPrimary,
-		backgroundPrimaryHover: brandAltBackground.ctaPrimaryHover,
-		textSecondary: brandAltText.ctaSecondary,
-		backgroundSecondary: brandAltBackground.ctaSecondary,
-		backgroundSecondaryHover: brandAltBackground.ctaSecondaryHover,
-		textTertiary: brandAltText.ctaTertiary,
-		backgroundTertiaryHover: brandAltBackground.ctaTertiaryHover,
-		borderTertiary: brandAltBorder.ctaTertiary,
-		textSubdued: brandAltText.ctaSecondary,
+		textPrimary: palette.neutral[100],
+		backgroundPrimary: palette.neutral[7],
+		backgroundPrimaryHover: '#454545', // One-off colour variant generated from palette.neutral[7]
+		textSecondary: palette.neutral[7],
+		backgroundSecondary: palette.brandAlt[200],
+		backgroundSecondaryHover: '#F2AE00', // One-off colour variant generated from palette.brandAlt[200]
+		backgroundTertiaryHover: '#FFD213', // One-off colour variant
+		borderTertiary: palette.neutral[7],
+		textSubdued: palette.neutral[7],
 	},
 };

--- a/packages/@guardian/source-react-components/src/container/styles.ts
+++ b/packages/@guardian/source-react-components/src/container/styles.ts
@@ -1,6 +1,11 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
-import { border, breakpoints, from, space } from '@guardian/source-foundations';
+import {
+	breakpoints,
+	from,
+	palette,
+	space,
+} from '@guardian/source-foundations';
 
 export const container = css`
 	margin: 0 auto;
@@ -22,7 +27,7 @@ export const container = css`
 	${from.wide} {
 		width: ${breakpoints.wide}px;
 	}
-	border-color: ${border.secondary};
+	border-color: ${palette.neutral[86]};
 `;
 
 export const containerSideBorders = css`

--- a/packages/@guardian/source-react-components/src/footer/theme.ts
+++ b/packages/@guardian/source-react-components/src/footer/theme.ts
@@ -1,15 +1,11 @@
-import {
-	brandBackground,
-	brandBorder,
-	brandText,
-} from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export const footerThemeBrand = {
 	footer: {
-		border: brandBorder.primary,
-		background: brandBackground.primary,
-		text: brandText.primary,
-		anchor: brandText.anchorPrimary,
-		anchorHover: brandText.anchorPrimaryHover,
+		border: palette.brand[600],
+		background: palette.brand[400],
+		text: palette.neutral[100],
+		anchor: palette.neutral[100],
+		anchorHover: palette.brandAlt[400],
 	},
 };

--- a/packages/@guardian/source-react-components/src/label/theme.ts
+++ b/packages/@guardian/source-react-components/src/label/theme.ts
@@ -1,21 +1,21 @@
-import { brandText, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export const labelThemeDefault = {
 	label: {
-		textLabel: text.inputLabel,
-		textOptional: text.supporting,
-		textSupporting: text.supporting,
-		textError: text.error,
-		textSuccess: text.success,
+		textLabel: palette.neutral[7],
+		textOptional: palette.neutral[46],
+		textSupporting: palette.neutral[46],
+		textError: palette.error[400],
+		textSuccess: palette.success[400],
 	},
 };
 
 export const labelThemeBrand = {
 	label: {
-		textLabel: brandText.inputLabel,
-		textOptional: brandText.supporting,
-		textSupporting: brandText.supporting,
-		textError: brandText.error,
-		textSuccess: brandText.success,
+		textLabel: palette.neutral[100],
+		textOptional: palette.brand[800],
+		textSupporting: palette.brand[800],
+		textError: palette.error[500],
+		textSuccess: palette.success[500],
 	},
 };

--- a/packages/@guardian/source-react-components/src/link/theme.ts
+++ b/packages/@guardian/source-react-components/src/link/theme.ts
@@ -1,4 +1,4 @@
-import { brandAltText, brandText, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export type LinkTheme = {
 	textPrimary: string;
@@ -9,23 +9,23 @@ export type LinkTheme = {
 
 export const linkThemeDefault: { link: LinkTheme } = {
 	link: {
-		textPrimary: text.anchorPrimary,
-		textPrimaryHover: text.anchorPrimary,
-		textSecondary: text.anchorSecondary,
-		textSecondaryHover: text.anchorSecondary,
+		textPrimary: palette.brand[500],
+		textPrimaryHover: palette.brand[500],
+		textSecondary: palette.neutral[7],
+		textSecondaryHover: palette.neutral[7],
 	},
 };
 
 export const linkThemeBrand: { link: LinkTheme } = {
 	link: {
-		textPrimary: brandText.anchorPrimary,
-		textPrimaryHover: brandText.anchorPrimary,
+		textPrimary: palette.neutral[100],
+		textPrimaryHover: palette.neutral[100],
 	},
 };
 
 export const linkThemeBrandAlt: { link: LinkTheme } = {
 	link: {
-		textPrimary: brandAltText.anchorPrimary,
-		textPrimaryHover: brandAltText.anchorPrimary,
+		textPrimary: palette.neutral[7],
+		textPrimaryHover: palette.neutral[7],
 	},
 };

--- a/packages/@guardian/source-react-components/src/radio/theme.ts
+++ b/packages/@guardian/source-react-components/src/radio/theme.ts
@@ -1,11 +1,4 @@
-import {
-	background,
-	border,
-	brandBackground,
-	brandBorder,
-	brandText,
-	text,
-} from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { labelThemeBrand, labelThemeDefault } from '../label/theme';
 import {
 	userFeedbackThemeBrand,
@@ -14,12 +7,12 @@ import {
 
 export const radioThemeDefault = {
 	radio: {
-		borderHover: border.inputHover,
-		border: border.input,
-		backgroundChecked: background.inputChecked,
-		textLabel: text.inputLabel,
-		textLabelSupporting: text.inputLabelSupporting,
-		borderError: border.error,
+		borderHover: palette.focus[400],
+		border: palette.neutral[60],
+		backgroundChecked: palette.focus[400],
+		textLabel: palette.neutral[7],
+		textLabelSupporting: palette.neutral[46],
+		borderError: palette.error[400],
 	},
 	...labelThemeDefault,
 	...userFeedbackThemeDefault,
@@ -27,12 +20,12 @@ export const radioThemeDefault = {
 
 export const radioThemeBrand = {
 	radio: {
-		borderHover: brandBorder.inputHover,
-		border: brandBorder.input,
-		backgroundChecked: brandBackground.inputChecked,
-		textLabel: brandText.inputLabel,
-		textLabelSupporting: brandText.supporting,
-		borderError: brandBorder.error,
+		borderHover: palette.neutral[100],
+		border: palette.brand[800],
+		backgroundChecked: palette.neutral[100],
+		textLabel: palette.neutral[100],
+		textLabelSupporting: palette.brand[800],
+		borderError: palette.error[500],
 	},
 	...labelThemeBrand,
 	...userFeedbackThemeBrand,

--- a/packages/@guardian/source-react-components/src/select/theme.ts
+++ b/packages/@guardian/source-react-components/src/select/theme.ts
@@ -1,19 +1,19 @@
-import { background, border, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { userFeedbackThemeDefault } from '../user-feedback/theme';
 
 export const selectThemeDefault = {
 	select: {
-		textUserInput: text.userInput,
-		textLabel: text.inputLabel,
-		textLabelOptional: text.supporting,
-		textLabelSupporting: text.supporting,
-		textError: text.inputError,
-		textSuccess: text.success,
-		backgroundInput: background.input,
-		border: border.input,
-		borderActive: border.inputActive,
-		borderError: border.error,
-		borderSuccess: border.success,
+		textUserInput: palette.neutral[7],
+		textLabel: palette.neutral[7],
+		textLabelOptional: palette.neutral[46],
+		textLabelSupporting: palette.neutral[46],
+		textError: palette.neutral[7],
+		textSuccess: palette.success[400],
+		backgroundInput: palette.neutral[100],
+		border: palette.neutral[60],
+		borderActive: palette.focus[400],
+		borderError: palette.error[400],
+		borderSuccess: palette.success[400],
 	},
 	...userFeedbackThemeDefault,
 };

--- a/packages/@guardian/source-react-components/src/text-area/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-area/styles.ts
@@ -1,30 +1,28 @@
 import { css } from '@emotion/react';
 import {
-	background,
-	border,
 	focusHalo,
+	palette,
 	resets,
 	space,
-	text,
 	textSans,
 } from '@guardian/source-foundations';
 
 export const errorInput = css`
-	border: 4px solid ${border.error};
-	color: ${text.inputError};
+	border: 4px solid ${palette.error[400]};
+	color: ${palette.neutral[7]};
 	margin-top: 0;
 	/* When input is active and in an error state, we want the border to remain the same. */
 	&:active {
-		border: 4px solid ${border.error};
+		border: 4px solid ${palette.error[400]};
 	}
 `;
 export const successInput = css`
-	border: 4px solid ${border.success};
-	color: ${text.success};
+	border: 4px solid ${palette.success[400]};
+	color: ${palette.success[400]};
 	margin-top: 0;
 	/* When input is active and in a success state, we want the border to remain the same. */
 	&:active {
-		border: 4px solid ${border.success};
+		border: 4px solid ${palette.success[400]};
 	}
 `;
 
@@ -32,13 +30,13 @@ export const textArea = css`
 	${resets.input};
 	box-sizing: border-box;
 	${textSans.medium({ lineHeight: 'regular' })};
-	color: ${text.userInput};
-	background-color: ${background.input};
-	border: 2px solid ${border.input};
+	color: ${palette.neutral[7]};
+	background-color: ${palette.neutral[100]};
+	border: 2px solid ${palette.neutral[60]};
 	padding: ${space[2]}px ${space[2]}px 0 ${space[2]}px;
 
 	&:active {
-		border: 2px solid ${border.inputActive};
+		border: 2px solid ${palette.brand[500]};
 	}
 
 	&:focus {

--- a/packages/@guardian/source-react-components/src/text-input/theme.ts
+++ b/packages/@guardian/source-react-components/src/text-input/theme.ts
@@ -1,19 +1,19 @@
-import { background, border, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 import { userFeedbackThemeDefault } from '../user-feedback/theme';
 
 export const textInputThemeDefault = {
 	textInput: {
-		textUserInput: text.userInput,
-		textLabel: text.inputLabel,
-		textLabelOptional: text.supporting,
-		textLabelSupporting: text.supporting,
-		textError: text.inputError,
-		textSuccess: text.success,
-		backgroundInput: background.input,
-		border: border.input,
-		borderActive: border.inputActive,
-		borderError: border.error,
-		borderSuccess: border.success,
+		textUserInput: palette.neutral[7],
+		textLabel: palette.neutral[7],
+		textLabelOptional: palette.neutral[46],
+		textLabelSupporting: palette.neutral[46],
+		textError: palette.neutral[7],
+		textSuccess: palette.success[400],
+		backgroundInput: palette.neutral[100],
+		border: palette.neutral[60],
+		borderActive: palette.focus[400],
+		borderError: palette.error[400],
+		borderSuccess: palette.success[400],
 	},
 	...userFeedbackThemeDefault,
 };

--- a/packages/@guardian/source-react-components/src/user-feedback/theme.ts
+++ b/packages/@guardian/source-react-components/src/user-feedback/theme.ts
@@ -1,15 +1,15 @@
-import { brandText, text } from '@guardian/source-foundations';
+import { palette } from '@guardian/source-foundations';
 
 export const userFeedbackThemeDefault = {
 	userFeedback: {
-		textSuccess: text.success,
-		textError: text.error,
+		textSuccess: palette.success[400],
+		textError: palette.error[400],
 	},
 };
 
 export const userFeedbackThemeBrand = {
 	userFeedback: {
-		textSuccess: brandText.success,
-		textError: brandText.error,
+		textSuccess: palette.success[500],
+		textError: palette.error[500],
 	},
 };


### PR DESCRIPTION
## What is the purpose of this change?

This PR replaces uses of the deprecated colour tokens with the newer `palette` tokens for consistency.

## What does this change?

There should be no perceptible changes apart from the updated example in the Components README.
