### PR TITLE
update palette.labs.200

### DIFF
--- a/.changeset/proud-mugs-sleep.md
+++ b/.changeset/proud-mugs-sleep.md
@@ -1,0 +1,5 @@
+---
+"@guardian/source-foundations": major
+---
+
+update palette.labs.200

--- a/packages/@guardian/source-foundations/src/colour/palette.ts
+++ b/packages/@guardian/source-foundations/src/colour/palette.ts
@@ -66,7 +66,7 @@ const colors = {
 		'#185E36', //green-300
 		'#22874D', //green-400, success-400
 		'#58D08B', //green-500, success-500
-		'#4B8878', //labs-200
+		'#0C7A73', //labs-200
 		'#65A897', //labs-300
 		'#69D1CA', //labs-400
 	],


### PR DESCRIPTION
## What is the purpose of this change?

We need a labs colour that has higher contrast against white and light grey backgrounds.

## What does this change?

-   Update `labs.200` from `#4B8878` to `#0C7A73`

## Screenshots

<img width="190" alt="Screenshot 2022-05-27 at 18 36 55" src="https://user-images.githubusercontent.com/5931528/170984552-b648c214-b0d9-4614-ba23-0cf9651bf345.png">

## Checklist

### Accessibility

-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)

