### PR TITLE
Increase spacing between choice cards and label

### DIFF
--- a/.changeset/nasty-chicken-divide.md
+++ b/.changeset/nasty-chicken-divide.md
@@ -1,0 +1,5 @@
+---
+"@guardian/source-react-components": major
+---
+
+Increase spacing between choice cards and label

--- a/packages/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.tsx
+++ b/packages/@guardian/source-react-components/src/choice-card/ChoiceCardGroup.tsx
@@ -5,7 +5,13 @@ import { Children, cloneElement } from 'react';
 import type { Props } from '../@types/Props';
 import { Legend } from '../label/Legend';
 import { InlineError } from '../user-feedback/InlineError';
-import { fieldset, flexContainer, gridColumns, gridContainer } from './styles';
+import {
+	containerTopMargin,
+	fieldset,
+	flexContainer,
+	gridColumns,
+	gridContainer,
+} from './styles';
 
 export type ChoiceCardColumns = 2 | 3 | 4 | 5;
 
@@ -68,6 +74,9 @@ export const ChoiceCardGroup = ({
 	...props
 }: ChoiceCardGroupProps): EmotionJSX.Element => {
 	const groupId = id ?? generateSourceId();
+	const topMargin =
+		(label && !hideLabel) || supporting || error ? containerTopMargin : '';
+
 	return (
 		<fieldset css={[fieldset, cssOverrides]} id={groupId} {...props}>
 			{label ? (
@@ -83,11 +92,12 @@ export const ChoiceCardGroup = ({
 				<InlineError id={descriptionId(groupId)}>{error}</InlineError>
 			)}
 			<div
-				css={
+				css={[
 					columns
 						? [gridContainer, gridColumns[columns]]
-						: flexContainer
-				}
+						: flexContainer,
+					topMargin,
+				]}
 			>
 				{Children.map(children, (child) => {
 					return cloneElement(

--- a/packages/@guardian/source-react-components/src/choice-card/styles.ts
+++ b/packages/@guardian/source-react-components/src/choice-card/styles.ts
@@ -31,6 +31,10 @@ export const flexContainer = css`
 	}
 `;
 
+export const containerTopMargin = css`
+	margin-top: ${space[2]}px;
+`;
+
 export const gridContainer = css`
 	width: 100%;
 	${from.mobileLandscape} {


### PR DESCRIPTION
## What is the purpose of this change?

The choice card designs have 8px of space between the label and the choice cards. We should update the code implementation to match.

**Note:** There is more complexity here. Label, supporting text and an error message are all optional, but the spacing should be applied if any one of these is present.

## What does this change?

-   apply 8px top margin to choice card container if label, supporting text or error message is shown

## Screenshots

**Before**

![Screenshot 2022-05-30 at 16 07 37](https://user-images.githubusercontent.com/5931528/171020079-e8428321-d239-42d0-84e2-e520c42b0f64.png)
![Screenshot 2022-05-30 at 16 07 27](https://user-images.githubusercontent.com/5931528/171020076-3127ce97-aea3-4592-b8a2-aca45ece2d36.png)
![Screenshot 2022-05-30 at 16 07 18](https://user-images.githubusercontent.com/5931528/171020073-cdc06977-cb2b-4d48-8e19-fa6d935c9055.png)


**After**

![Screenshot 2022-05-30 at 16 06 41](https://user-images.githubusercontent.com/5931528/171020124-35a8e75d-5b11-4b7b-a183-4320895968e4.png)
![Screenshot 2022-05-30 at 16 06 50](https://user-images.githubusercontent.com/5931528/171020128-3815f3c5-e20a-4ba5-ac1d-5d80d7093153.png)
![Screenshot 2022-05-30 at 16 07 01](https://user-images.githubusercontent.com/5931528/171020129-bc73883e-3673-43f9-b137-91e423babe61.png)
