### PR TITLE
Use correct captialisation for editorial button stories

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialButton.stories.tsx
@@ -76,7 +76,7 @@ const Template: Story = (args: EditorialButtonProps) => {
 		props.cssOverrides = cssOverrides;
 	}
 
-	return <EditorialButton {...props}>Click Me</EditorialButton>;
+	return <EditorialButton {...props}>Click me</EditorialButton>;
 };
 
 export const Playground = Template.bind({});

--- a/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/EditorialLinkButton.stories.tsx
@@ -76,7 +76,7 @@ const Template: Story = (args: EditorialLinkButtonProps) => {
 		props.cssOverrides = cssOverrides;
 	}
 
-	return <EditorialLinkButton {...props}>Click Me</EditorialLinkButton>;
+	return <EditorialLinkButton {...props}>Click me</EditorialLinkButton>;
 };
 
 export const Playground = Template.bind({});


### PR DESCRIPTION
## What is the purpose of this change?

The Editorial Button stories have a label that says "Click Me". Ideally it would say "Click me" to match the Guardian style guide

## What does this change?

-   "Click Me" -> "Click me"

## Screenshots

**Before**
![Screenshot 2022-05-30 at 16 12 29](https://user-images.githubusercontent.com/5931528/171021170-76911035-b3be-4974-ae93-56987bdbbd43.png)

**After**
![Screenshot 2022-05-30 at 16 12 40](https://user-images.githubusercontent.com/5931528/171021186-02208c7b-98a5-4dff-a754-721d6fcd6d14.png)
