### PR TITLE
Use nx to run `tsc`

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,7 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "test", "e2e"],
+        "cacheableOperations": ["build", "test", "e2e", "tsc"],
         "accessToken": "YjlhZjRmOWQtNWQwNy00YzUyLTk0YzItZWY1NTk3OGExMDQ4fHJlYWQtd3JpdGU="
       }
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "storybook": "start-storybook -p 6006",
     "test": "nx run-many --all --target=test",
     "test:coverage": "nx run-many --target=test --all --coverage",
-    "tsc": "tsc",
+    "tsc": "nx run-many --target=tsc --all",
     "validate": "npm-run-all tsc lint test build e2e",
     "e2e": "nx run-many --target=e2e --all"
   },

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "tsc": "tsc"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "5.21.0",

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "tsc": "tsc"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "5.21.0",

--- a/packages/@guardian/source-foundations/package.json
+++ b/packages/@guardian/source-foundations/package.json
@@ -16,7 +16,8 @@
     "build": "rollup -c",
     "clean": "rm -rf dist",
     "e2e": "jest src/index.test.ts --setupFilesAfterEnv=./jest.e2e.setup.js",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "tsc": "tsc"
   },
   "dependencies": {
     "mini-svg-data-uri": "^1.3.3"

--- a/packages/@guardian/source-foundations/tsconfig.json
+++ b/packages/@guardian/source-foundations/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "exclude": ["dist"],
+  "include": ["src"]
+}

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -12,7 +12,8 @@
     "build": "rollup -c",
     "clean": "rm -rf dist",
     "test": "jest --coverage",
-    "e2e": "jest src/index.test.ts --setupFilesAfterEnv=./jest.e2e.setup.js"
+    "e2e": "jest src/index.test.ts --setupFilesAfterEnv=./jest.e2e.setup.js",
+    "tsc": "tsc"
   },
   "devDependencies": {
     "mini-svg-data-uri": "^1.3.3",

--- a/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
+++ b/packages/@guardian/source-react-components-development-kitchen/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "exclude": ["dist"],
+  "include": ["src"]
+}

--- a/packages/@guardian/source-react-components/package.json
+++ b/packages/@guardian/source-react-components/package.json
@@ -17,7 +17,8 @@
     "clean": "rm -rf dist",
     "create-icons": "ts-node scripts/create-icons",
     "e2e": "jest src/index.test.ts --setupFilesAfterEnv=./jest.e2e.setup.js",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "tsc": "tsc"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",

--- a/packages/@guardian/source-react-components/tsconfig.json
+++ b/packages/@guardian/source-react-components/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.json",
+  "exclude": ["dist"],
+  "include": ["src"]
+}

--- a/scripts/get-usage/package.json
+++ b/scripts/get-usage/package.json
@@ -7,7 +7,8 @@
   "author": "",
   "main": "index.ts",
   "scripts": {
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "tsc": "tsc"
   },
   "dependencies": {
     "react-scanner": "^1.0.3",

--- a/scripts/get-usage/tsconfig.json
+++ b/scripts/get-usage/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "declaration": true,
-    "emitDeclarationOnly": true
-  },
   "include": ["."],
-  "exclude": ["node_modules", "tmp"]
+  "exclude": ["node_modules", "tmp", "dist"]
 }


### PR DESCRIPTION
## What is the purpose of this change?

speed up type checks, but using nX cache if possible

- use Nx to run `tsc`