### PR TITLE
Stop `valid-foundations-import-path` rule being logged to console

### DIFF
--- a/.changeset/big-comics-heal.md
+++ b/.changeset/big-comics-heal.md
@@ -1,0 +1,5 @@
+---
+'@guardian/eslint-plugin-source-foundations': patch
+---
+
+Remove `console.log` from `valid-foundations-import-path` rule

--- a/packages/@guardian/eslint-plugin-source-foundations/src/rules/valid-import-path.ts
+++ b/packages/@guardian/eslint-plugin-source-foundations/src/rules/valid-import-path.ts
@@ -1,4 +1,3 @@
-import { inspect } from 'node:util';
 import type { Rule } from 'eslint';
 import type {
 	ExportAllDeclaration,
@@ -341,7 +340,3 @@ export const validFoundationsImportPath: Rule.RuleModule = {
 		};
 	},
 };
-
-console.log(
-	inspect(validFoundationsImportPath, false, null, true /* enable colors */),
-);


### PR DESCRIPTION
## What is the purpose of this change?

Stops the `valid-foundations-import-path` rule from being logged to the console when running ESLint.

## What does this change?

-   Removes `console.log` and `inspect` import from this rule