### PR TITLE
Prevent layout jumps during page rendering

### DIFF
--- a/.changeset/five-games-ring.md
+++ b/.changeset/five-games-ring.md
@@ -1,0 +1,5 @@
+---
+"@guardian/source-foundations": patch
+---
+
+Prevent layout jumps when navigating between pages where one has content shorter than the viewport

--- a/packages/@guardian/source-foundations/src/utils/resets.ts
+++ b/packages/@guardian/source-foundations/src/utils/resets.ts
@@ -35,6 +35,7 @@ const defaults = `
     html {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+        overflow-y: scroll;
     }
     html, body {
         text-rendering: optimizeLegibility;

--- a/packages/@guardian/source-foundations/src/utils/resets.ts
+++ b/packages/@guardian/source-foundations/src/utils/resets.ts
@@ -35,6 +35,9 @@ const defaults = `
     html {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+        // always show the vertical scroll bar to stop the page
+        // jumping about when navigating between pages where 
+        // one has content shorter than the viewport
         overflow-y: scroll;
     }
     html, body {


### PR DESCRIPTION
>If you move from one page of a site without a scrollbar to another with a scrollbar, you’ll see a slight layout shift as things squeeze inward a bit to make room for the scrollbar. -- https://css-tricks.com/elegant-fix-jumping-scrollbar-issue/

There are [other possible fixes](https://aykevl.nl/2014/09/fix-jumping-scrollbar) for this performance issue, but I went for the same as the one used in guardian/frontend:

https://github.com/guardian/frontend/blob/2cb01d2b326603de6354db9d9b6fe856a8b7cb2c/static/src/stylesheets/base/_base.scss#L1-L2