### PR TITLE
Change `TextInput` and `TextArea` default border colours

### DIFF
--- a/.changeset/calm-llamas-talk.md
+++ b/.changeset/calm-llamas-talk.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': major
+---
+
+Update default border colour for TextInput and TextArea

--- a/packages/@guardian/source-react-components/src/text-area/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-area/styles.ts
@@ -16,6 +16,7 @@ export const errorInput = css`
 		border: 4px solid ${palette.error[400]};
 	}
 `;
+
 export const successInput = css`
 	border: 4px solid ${palette.success[400]};
 	color: ${palette.success[400]};
@@ -32,7 +33,7 @@ export const textArea = css`
 	${textSans.medium({ lineHeight: 'regular' })};
 	color: ${palette.neutral[7]};
 	background-color: ${palette.neutral[100]};
-	border: 2px solid ${palette.neutral[60]};
+	border: 2px solid ${palette.neutral[46]};
 	padding: ${space[2]}px ${space[2]}px 0 ${space[2]}px;
 
 	&:active {

--- a/packages/@guardian/source-react-components/src/text-input/theme.ts
+++ b/packages/@guardian/source-react-components/src/text-input/theme.ts
@@ -10,7 +10,7 @@ export const textInputThemeDefault = {
 		textError: palette.neutral[7],
 		textSuccess: palette.success[400],
 		backgroundInput: palette.neutral[100],
-		border: palette.neutral[60],
+		border: palette.neutral[46],
 		borderActive: palette.focus[400],
 		borderError: palette.error[400],
 		borderSuccess: palette.success[400],


### PR DESCRIPTION
## What is the purpose of this change?

The current border colour of the text input and text area is neutral.60. It doesn't pass the AA contrast ratio.

Please change it to neutral.46

## What does this change?

<!--
Give an overview of the changes you have made.
-->

-   Update default border on `TextArea`
-   Update default border on `TextInput`

## Screenshots



<!--
If you are not making changes to the design, please delete this section.
-->

**Before**

<img width="991" alt="Screenshot 2022-07-07 at 15 57 42" src="https://user-images.githubusercontent.com/77005274/177805534-405e4c47-2b84-4f92-98be-9b8d90b965f5.png">
<img width="991" alt="Screenshot 2022-07-07 at 15 56 33" src="https://user-images.githubusercontent.com/77005274/177805605-0301bc3d-29e6-4b1c-9ec3-765cb42a8f05.png">

**After**

<img width="991" alt="Screenshot 2022-07-07 at 15 57 19" src="https://user-images.githubusercontent.com/77005274/177805736-88f547d1-280b-473e-aad9-73957c200aa8.png">
<img width="991" alt="Screenshot 2022-07-07 at 15 55 54" src="https://user-images.githubusercontent.com/77005274/177805709-5dad440b-a119-4b2b-99b5-a6225ebf94a4.png">


## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [x] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->

### Known issues

<!--
If there are known issues, please specify them here
-->
