### PR TITLE
Add 14px to Body font

### DIFF
--- a/.changeset/curvy-owls-train.md
+++ b/.changeset/curvy-owls-train.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': minor
+---
+
+Add 14px "xsmall" font size to body

--- a/.changeset/ninety-bobcats-press.md
+++ b/.changeset/ninety-bobcats-press.md
@@ -1,5 +1,0 @@
----
-'@guardian/source-foundations': patch
----
-
-Adds xsmall to body font

--- a/.changeset/ninety-bobcats-press.md
+++ b/.changeset/ninety-bobcats-press.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': patch
+---
+
+Adds xsmall to body font

--- a/packages/@guardian/source-foundations/src/typography/api.ts
+++ b/packages/@guardian/source-foundations/src/typography/api.ts
@@ -70,6 +70,8 @@ const bodyDefaults = {
 const bodyFs = fs('body');
 
 export const body: BodyFunctions = {
+	xsmall: (options?: FontScaleArgs) =>
+		bodyFs('xsmall', Object.assign({}, bodyDefaults, options)),
 	small: (options?: FontScaleArgs) =>
 		bodyFs('small', Object.assign({}, bodyDefaults, options)),
 	medium: (options?: FontScaleArgs) =>

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -34,6 +34,7 @@ const headlineSizes = {
 } as const;
 
 const bodySizes = {
+	xsmall: fontSizes[1], //14px
 	small: fontSizes[2], //15px
 	medium: fontSizes[3], //17px
 } as const;
@@ -75,6 +76,7 @@ const remHeadlineSizes = {
 } as const;
 
 const remBodySizes = {
+	xsmall: remFontSizes[1], //14px
 	small: remFontSizes[2], //15px
 	medium: remFontSizes[3], //17px
 } as const;

--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -88,6 +88,8 @@ const headline: TypographyApi<HeadlineSizes> = {
  * ```
  */
 const body: TypographyApi<BodySizes> = {
+	xsmall: (options?: FontScaleArgs) =>
+		objectStylesToString(bodyAsObj.small(options)),
 	small: (options?: FontScaleArgs) =>
 		objectStylesToString(bodyAsObj.small(options)),
 	medium: (options?: FontScaleArgs) =>

--- a/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -75,6 +75,7 @@ font-family: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif';
 font-family: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif';
 ```
 
+-   `body.xsmall()` -> 14px
 -   `body.small()` -> 15px
 -   `body.medium()` -> 17px
 


### PR DESCRIPTION
## What is the purpose of this change?

Adds `xsmall` (14px) to the `body` font.

This font style is used for standfirsts on cards on Dotcom fronts.

## Screenshots
<img width="1043" alt="Screenshot 2022-07-11 at 14 44 11" src="https://user-images.githubusercontent.com/77005274/178278434-d68b8b0b-cc91-49ce-bed8-2eefc75c5770.png">



