### PR TITLE
Update chromatic.yml to use `CHROMATIC_PROJECT_TOKEN`

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_APP_CODE }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
           buildScriptName: 'build:storybook'
           exitOnceUploaded: true


### PR DESCRIPTION
## What is the purpose of this change?

Updates the `chromatic.yml` to use `CHROMATIC_PROJECT_TOKEN` rather than `CHROMATIC_APP_CODE`

Once this PR is merged the `CHROMATIC_APP_CODE` secret can be removed from the github secrets.

## Why?

The previous naming was unnecessarily confusing. 