### PR TITLE
Create FooterWithContents and FooterLinks components in dev kitchen

### DIFF
--- a/.changeset/silent-rabbits-breathe.md
+++ b/.changeset/silent-rabbits-breathe.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': minor
+---
+
+add FooterWithContents and FooterLinks components

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 * @guardian/client-side-infra
 
 /packages/@guardian/source-react-components-development-kitchen/src/components/button @guardian/dotcom-platform
+/packages/@guardian/source-react-components-development-kitchen/src/components/footer-with-contents @guardian/conversions-developers
 /packages/@guardian/source-react-components-development-kitchen/src/components/lines @guardian/dotcom-platform
 /packages/@guardian/source-react-components-development-kitchen/src/components/logo @guardian/dotcom-platform
 /packages/@guardian/source-react-components-development-kitchen/src/components/quote-icon @guardian/dotcom-platform

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.stories.tsx
@@ -1,0 +1,51 @@
+import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
+import {
+	asChromaticStory,
+	asPlayground,
+} from '../../../../../lib/story-intents';
+import type { FooterLinksProps } from './FooterLinks';
+import { defaultGuardianLinks, FooterLinks } from './FooterLinks';
+
+export default {
+	title: 'Packages/source-react-components-development-kitchen/FooterLinks',
+	component: FooterLinks,
+	parameters: {
+		layout: 'fullscreen',
+	},
+};
+
+const Template: Story<FooterLinksProps> = (args: FooterLinksProps) => (
+	<FooterLinks {...args} />
+);
+
+// *****************************************************************************
+
+export const Playground = Template.bind({});
+Playground.args = {
+	links: [
+		{
+			href: '/',
+			text: 'Privacy policy',
+		},
+	],
+};
+asPlayground(Playground);
+
+// *****************************************************************************
+
+export const DefaultFooterLinks = Template.bind({});
+asChromaticStory(DefaultFooterLinks);
+
+// *****************************************************************************
+
+export const FooterLinksInColumns = Template.bind({});
+FooterLinksInColumns.args = {
+	links: [
+		...defaultGuardianLinks,
+		{
+			href: '/',
+			text: 'About us',
+		},
+	],
+};
+asChromaticStory(FooterLinksInColumns);

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterLinks.tsx
@@ -1,0 +1,115 @@
+import { ThemeProvider } from '@emotion/react';
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import {
+	Column,
+	Columns,
+	Hide,
+	Link,
+	linkThemeBrand,
+} from '@guardian/source-react-components';
+import type { AnchorHTMLAttributes } from 'react';
+import {
+	fullWidthContainer,
+	getItemStyles,
+	getListStyles,
+	linkElementStyles,
+} from './footerLinksStyles';
+
+type FooterLink = AnchorHTMLAttributes<HTMLAnchorElement> & {
+	/**
+	 * The URL of the link
+	 */
+	href: string;
+	/**
+	 * The visible text of the link
+	 */
+	text: string;
+	/**
+	 * A link marked as external will apply rel="noopener noreferrer"
+	 */
+	isExternal?: boolean;
+};
+
+export const defaultGuardianLinks: FooterLink[] = [
+	{
+		href: 'https://www.theguardian.com/info/privacy',
+		text: 'Privacy policy',
+		isExternal: true,
+	},
+	{
+		href: 'https://www.theguardian.com/help/contact-us',
+		text: 'Contact us',
+		isExternal: true,
+	},
+	{
+		href: 'https://www.theguardian.com/help',
+		text: 'Help centre',
+		isExternal: true,
+	},
+];
+
+export interface FooterLinksProps {
+	/**
+	 * An array of links, specifying the link text and href, if the link is external, and any other HTML attributes for an anchor tag
+	 */
+	links?: FooterLink[];
+	/**
+	 * Force the links into a column layout below desktop, regardless of the amount of links
+	 */
+	forceColumns?: boolean;
+}
+
+export const FooterLinks = ({
+	links = defaultGuardianLinks,
+	forceColumns = false,
+}: FooterLinksProps): EmotionJSX.Element => {
+	const useColumns = links.length > 3 || forceColumns;
+	return (
+		<div css={fullWidthContainer}>
+			<Hide from="tablet">
+				<ul css={getListStyles(useColumns)}>
+					{links.map(({ href, text, isExternal, ...linkAttrs }) => (
+						<li key={href} css={getItemStyles(useColumns)}>
+							<ThemeProvider theme={linkThemeBrand}>
+								<Link
+									cssOverrides={linkElementStyles}
+									href={href}
+									rel={
+										isExternal ? 'noopener noreferrer' : ''
+									}
+									{...linkAttrs}
+								>
+									{text}
+								</Link>
+							</ThemeProvider>
+						</li>
+					))}
+				</ul>
+			</Hide>
+			<Hide until="tablet">
+				<Columns cssOverrides={getListStyles(useColumns)}>
+					{links.map(({ href, text, isExternal, ...linkAttrs }) => (
+						<Column
+							key={href}
+							span={[0, 3, 2]}
+							cssOverrides={getItemStyles(useColumns)}
+						>
+							<ThemeProvider theme={linkThemeBrand}>
+								<Link
+									cssOverrides={linkElementStyles}
+									href={href}
+									rel={
+										isExternal ? 'noopener noreferrer' : ''
+									}
+									{...linkAttrs}
+								>
+									{text}
+								</Link>
+							</ThemeProvider>
+						</Column>
+					))}
+				</Columns>
+			</Hide>
+		</div>
+	);
+};

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.stories.tsx
@@ -1,0 +1,47 @@
+import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
+import {
+	asChromaticStory,
+	asPlayground,
+} from '../../../../../lib/story-intents';
+import {
+	DefaultFooterLinks,
+	FooterLinksInColumns,
+} from './FooterLinks.stories';
+import type { FooterWithContentsProps } from './FooterWithContents';
+import { FooterWithContents } from './FooterWithContents';
+
+export default {
+	title: 'Packages/source-react-components-development-kitchen/FooterWithContents',
+	component: FooterWithContents,
+	parameters: {
+		layout: 'fullscreen',
+	},
+};
+
+const Template: Story<FooterWithContentsProps> = (
+	args: FooterWithContentsProps,
+) => <FooterWithContents {...args} />;
+
+// *****************************************************************************
+
+export const Playground = Template.bind({});
+Playground.args = {
+	children: 'Content goes here',
+};
+asPlayground(Playground);
+
+// *****************************************************************************
+
+export const DefaultFooterWithContents = Template.bind({});
+DefaultFooterWithContents.args = {
+	children: <DefaultFooterLinks />,
+};
+asChromaticStory(DefaultFooterWithContents);
+
+// *****************************************************************************
+
+export const FooterWithColumnLinks = Template.bind({});
+FooterWithColumnLinks.args = {
+	children: <FooterLinksInColumns {...FooterLinksInColumns.args} />,
+};
+asChromaticStory(DefaultFooterWithContents);

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
@@ -1,0 +1,51 @@
+import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
+import { brand } from '@guardian/source-foundations';
+import { Container } from '@guardian/source-react-components';
+import { BackToTop } from '@guardian/source-react-components/src/footer/BackToTop';
+import type { ReactNode } from 'react';
+import {
+	backToTopStyles,
+	contentWrapperStyles,
+	copyrightStyles,
+	footer,
+} from './footerWithContentsStyles';
+
+export interface FooterWithContentsProps {
+	children: ReactNode;
+	/**
+	 * A container component that matches the type signature of the Source Container.
+	 * Use where different internal padding or other behaviour needs to be applied to match an existing layout.
+	 */
+	ContainerComponent?: typeof Container;
+}
+
+const footerContainerProps = {
+	sideBorders: true,
+	borderColor: brand[600],
+};
+
+export const FooterWithContents = ({
+	children,
+	ContainerComponent = Container,
+}: FooterWithContentsProps): EmotionJSX.Element => {
+	return (
+		<footer css={footer}>
+			<ContainerComponent {...footerContainerProps}>
+				<div css={contentWrapperStyles}>
+					{children}
+					<div css={backToTopStyles}>{BackToTop}</div>
+				</div>
+			</ContainerComponent>
+			<ContainerComponent
+				{...footerContainerProps}
+				topBorder={true}
+				sideBorders={false}
+			>
+				<small css={copyrightStyles}>
+					© {new Date().getFullYear()} Guardian News & Media Limited
+					or its affiliated companies. All rights reserved.
+				</small>
+			</ContainerComponent>
+		</footer>
+	);
+};

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/README.md
@@ -1,0 +1,25 @@
+# `Footer With Contents`
+
+A footer component that can have content added inside of it, and a footer links component to be used to display links within the footer.
+
+## Install
+
+```sh
+$ yarn add @guardian/source-react-components-development-kitchen
+```
+
+or
+
+```sh
+$ npm i @guardian/source-react-components-development-kitchen
+```
+
+## Use
+
+### API
+
+See [storybook](https://guardian.github.io/source/?path=/docs/packages-source-react-components-development-kitchen-divider--playground)
+
+### How to use
+
+For context and visual guides relating to usage see the [Source Design System website](https://theguardian.design).

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerLinksStyles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerLinksStyles.ts
@@ -1,0 +1,119 @@
+import { css } from '@emotion/react';
+import {
+	between,
+	brand,
+	brandAlt,
+	from,
+	space,
+	textSans,
+	until,
+} from '@guardian/source-foundations';
+
+export const fullWidthContainer = css`
+	width: 100%;
+`;
+
+export const linkListStyles = css`
+	background-color: ${brand[400]};
+	display: flex;
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	padding-bottom: 64px;
+	${from.tablet} {
+		padding-bottom: ${space[6]}px;
+	}
+`;
+
+export const linkColumnsStyles = css`
+	${until.desktop} {
+		position: relative;
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-auto-rows: min-content;
+		padding-bottom: 55px;
+		/* Centre divider */
+		:after {
+			position: absolute;
+			left: 50%;
+			bottom: 18px;
+			content: '';
+			width: 1px;
+			background-color: ${brand[600]};
+			height: calc(100% - 18px);
+		}
+
+		${from.tablet} {
+			grid-template-columns: 1fr 3fr;
+			padding-bottom: ${space[9]}px;
+			:after {
+				content: unset;
+			}
+		}
+	}
+`;
+
+export function getListStyles(useColumns: boolean) {
+	return useColumns ? [linkListStyles, linkColumnsStyles] : linkListStyles;
+}
+
+export const linkListItemStyles = css`
+	padding-top: ${space[3]}px;
+	${from.tablet} {
+		padding-top: 10px;
+	}
+	:not(:first-of-type) {
+		padding-left: ${space[2]}px;
+		border-left: 1px solid ${brand[600]};
+		${from.tablet} {
+			padding-left: 10px;
+		}
+	}
+	${until.tablet} {
+		:not(:last-of-type) {
+			padding-right: ${space[3]}px;
+			${from.mobileMedium} {
+				padding-right: ${space[6]}px;
+			}
+		}
+	}
+`;
+
+export const linkColumnItemStyles = css`
+	padding-top: ${space[3]}px;
+
+	:nth-child(even) {
+		padding-left: ${space[2]}px;
+		${from.tablet} {
+			padding-left: 10px;
+		}
+	}
+
+	${between.tablet.and.desktop} {
+		width: 100%;
+		:nth-child(odd) {
+			border-right: 1px solid ${brand[600]};
+		}
+	}
+
+	${from.desktop} {
+		${linkListItemStyles}
+	}
+`;
+
+export function getItemStyles(useColumns: boolean) {
+	return useColumns ? linkColumnItemStyles : linkListItemStyles;
+}
+
+export const linkElementStyles = css`
+	display: block;
+	text-decoration: none;
+	${textSans.small({ lineHeight: 'tight' })}
+	:hover {
+		text-decoration: underline;
+		color: ${brandAlt[400]};
+	}
+	${from.mobileMedium} {
+		${textSans.medium({ lineHeight: 'tight' })}
+	}
+`;

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerWithContentsStyles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/footerWithContentsStyles.ts
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import {
+	brand,
+	from,
+	neutral,
+	space,
+	textSans,
+} from '@guardian/source-foundations';
+
+export const footer = css`
+	background-color: ${brand[400]};
+	color: ${neutral[100]};
+	padding-bottom: ${space[1]}px;
+	${textSans.medium()};
+`;
+
+export const contentWrapperStyles = css`
+	display: flex;
+	position: relative;
+`;
+
+export const copyrightStyles = css`
+	display: block;
+	${textSans.xxsmall()};
+	padding-top: ${space[6]}px;
+	padding-bottom: 18px;
+	${from.tablet} {
+		padding-top: ${space[3]}px;
+	}
+`;
+
+export const backToTopStyles = css`
+	background-color: ${brand[400]};
+	padding: 0 ${space[2]}px;
+	position: absolute;
+	bottom: -21px;
+	right: ${space[3]}px;
+	${from.tablet} {
+		padding: 0 5px;
+		right: 0;
+	}
+`;

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.test.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.test.ts
@@ -5,6 +5,8 @@ import * as pkgExports from './index';
 export type {
 	EditorialButtonProps,
 	EditorialLinkButtonProps,
+	FooterLinksProps,
+	FooterWithContentsProps,
 	LineCount,
 	LinesProps,
 	LogoProps,
@@ -22,6 +24,8 @@ it('Should have exactly these exports', () => {
 		'EditorialButton',
 		'EditorialLinkButton',
 		'ErrorSummary',
+		'FooterLinks',
+		'FooterWithContents',
 		'InfoSummary',
 		'Lines',
 		'Logo',
@@ -31,5 +35,6 @@ it('Should have exactly these exports', () => {
 		'StraightLines',
 		'SuccessSummary',
 		'ToggleSwitch',
+		'defaultGuardianLinks',
 	]);
 });

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.ts
@@ -32,3 +32,11 @@ export type { InfoSummaryProps } from './summary/InfoSummary';
 
 export { ToggleSwitch } from './toggle-switch/ToggleSwitch';
 export type { ToggleSwitchProps } from './toggle-switch/ToggleSwitch';
+
+export { FooterWithContents } from './footer-with-contents/FooterWithContents';
+export {
+	FooterLinks,
+	defaultGuardianLinks,
+} from './footer-with-contents/FooterLinks';
+export type { FooterWithContentsProps } from './footer-with-contents/FooterWithContents';
+export type { FooterLinksProps } from './footer-with-contents/FooterLinks';


### PR DESCRIPTION
## What is the purpose of this change?

This adds a `FooterWithContents` component and a companion `FooterLinks` component to the dev kitchen, initially for use on the new Guardian supporter checkout but with potential future use on multiple other sites.

## What does this change?

-   Add `FooterWithContents` component with a copyright message and 'Back to Top' link, that renders children inside a container with side borders
-   Add `FooterLinks` component, intended for use with `FooterWithContents` to render a list of links in the footer. If passed more than three links they will be split over columns on mobile and tablet breakpoints (currently somewhat experimental).

## Screenshots

## Default - 3 links

**Mobile**
![Screenshot 2022-08-19 at 16 30 27](https://user-images.githubusercontent.com/29146931/185656111-0a5b7a03-829e-4c91-8035-caa891d3b226.png)

**Tablet**
![Screenshot 2022-08-19 at 16 30 18](https://user-images.githubusercontent.com/29146931/185656129-a42f9529-0f6b-4554-b256-dcad7726b65e.png)

**Wide**
![Screenshot 2022-08-19 at 16 29 58](https://user-images.githubusercontent.com/29146931/185656152-a904fc21-0538-42ac-b249-bbfb45d53594.png)

## > 3 links

**Mobile**
![Screenshot 2022-08-19 at 16 33 14](https://user-images.githubusercontent.com/29146931/185656321-62d79b66-e602-4039-b2ed-27b97f36a886.png)

**Tablet**
![Screenshot 2022-08-19 at 16 33 36](https://user-images.githubusercontent.com/29146931/185656336-7acc77fb-c970-445a-b791-a177c18be243.png)

**Wide**
![Screenshot 2022-08-19 at 16 35 37](https://user-images.githubusercontent.com/29146931/185656352-8570463d-6a64-44c7-bfd3-59bf606c022d.png)

## Checklist

### Accessibility

-   [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

-   [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

-   [x] Tested at all breakpoints
-   [x] Tested with with long text
-   [x] Stretched to fill a wide container

### Documentation

-   [ ] Full API surface area is documented in the README
-   [x] Examples in Storybook

<!--
If we need to make changes to the documentation website,
please specify them here
-->
