### PR TITLE
Line height storybook documentation

### DIFF
--- a/.changeset/smooth-goats-move.md
+++ b/.changeset/smooth-goats-move.md
@@ -1,7 +1,5 @@
 ---
-'@guardian/source-foundations': major
+'@guardian/source-foundations': patch
 ---
 
-Change the default line-height for text-sans to regular instead of loose.
-
-Please check that this doesn't break your existing layouts that use text-sans with the default line height.
+Extends the Typography story so that we better capture changes to the lineHeight of our fonts

--- a/.changeset/smooth-goats-move.md
+++ b/.changeset/smooth-goats-move.md
@@ -1,0 +1,7 @@
+---
+'@guardian/source-foundations': major
+---
+
+Change the default line-height for text-sans to regular instead of loose.
+
+Please check that this doesn't break your existing layouts that use text-sans with the default line height.

--- a/.storybook/typographyRenderers.tsx
+++ b/.storybook/typographyRenderers.tsx
@@ -4,24 +4,26 @@ import {
 	headlineObjectStyles,
 	textSansObjectStyles,
 } from '@guardian/source-foundations/src';
-import { fontWeightMapping, lineHeightMapping } from '@guardian/source-foundations/src/typography/data';
+import { fontWeightMapping } from '@guardian/source-foundations/src/typography/data';
 import type {
 	Category,
 	FontScaleFunction,
 	FontWeight,
-	LineHeight,
 } from '@guardian/source-foundations/src/typography/types';
 
 type FontFunctions = {
 	[key in Category]: FontScaleFunction;
 };
 
-interface Props {
+interface FontStylesRendererProps {
 	fontName: string;
 	fontStyles: FontFunctions;
 }
 
-export const FontStylesRenderer = ({ fontName, fontStyles }: Props) => {
+export const FontStylesRenderer: React.FC<FontStylesRendererProps> = ({
+	fontName,
+	fontStyles,
+}) => {
 	return (
 		<ul>
 			{Object.entries(fontStyles).map(([name, getFontStyles]) => {
@@ -37,23 +39,20 @@ export const FontStylesRenderer = ({ fontName, fontStyles }: Props) => {
 	);
 };
 
-export const LineHeightRenderer = () => (
-	<ul>
-		{Object.entries(lineHeightMapping).map(([lineHeight, value]) => (
-			<li
-				key={value}
-				style={{
-					...headlineObjectStyles.xxsmall({
-						lineHeight: lineHeight as LineHeight,
-					}),
-					margin: 0,
-				}}
-			>
-				{lineHeight} {'->'} {value}
-			</li>
-		))}
-	</ul>
-);
+interface LineHeightRendererProps {
+	getFontStyles: FontScaleFunction;
+}
+
+export const LineHeightRenderer: React.FC<LineHeightRendererProps> = ({
+	getFontStyles,
+}) => {
+	const fontStyles = getFontStyles({ unit: 'px' });
+	return (
+		<p style={{ ...fontStyles, width: '15ch' }}>
+			The quick brown fox jumps over the lazy dog
+		</p>
+	);
+};
 
 export const FontWeightRenderer = () => (
 	<ul>

--- a/.storybook/typographyRenderers.tsx
+++ b/.storybook/typographyRenderers.tsx
@@ -20,10 +20,10 @@ interface FontStylesRendererProps {
 	fontStyles: FontFunctions;
 }
 
-export const FontStylesRenderer: React.FC<FontStylesRendererProps> = ({
+export const FontStylesRenderer = ({
 	fontName,
 	fontStyles,
-}) => {
+}: FontStylesRendererProps) => {
 	return (
 		<ul>
 			{Object.entries(fontStyles).map(([name, getFontStyles]) => {
@@ -43,9 +43,9 @@ interface LineHeightRendererProps {
 	getFontStyles: FontScaleFunction;
 }
 
-export const LineHeightRenderer: React.FC<LineHeightRendererProps> = ({
+export const LineHeightRenderer = ({
 	getFontStyles,
-}) => {
+}: LineHeightRendererProps) => {
 	const fontStyles = getFontStyles({ unit: 'px' });
 	return (
 		<p style={{ ...fontStyles, width: '15ch' }}>

--- a/packages/@guardian/source-foundations/src/typography/api.ts
+++ b/packages/@guardian/source-foundations/src/typography/api.ts
@@ -83,7 +83,7 @@ type TextSansFunctions = {
 };
 
 const textSansDefaults = {
-	lineHeight: 'regular',
+	lineHeight: 'loose',
 	fontWeight: 'regular',
 	fontStyle: null,
 	unit: 'rem',

--- a/packages/@guardian/source-foundations/src/typography/api.ts
+++ b/packages/@guardian/source-foundations/src/typography/api.ts
@@ -83,7 +83,7 @@ type TextSansFunctions = {
 };
 
 const textSansDefaults = {
-	lineHeight: 'loose',
+	lineHeight: 'regular',
 	fontWeight: 'regular',
 	fontStyle: null,
 	unit: 'rem',

--- a/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -137,7 +137,7 @@ font-family: 'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetic
 
 #### Line height
 
-The default for body is `regular`. This maps to `1.35 (135%)`.
+The default for body is `loose`. This maps to `1.5 (150%)`.
 
 <Canvas>
 	<Story name="text-sans-lineheight">
@@ -207,8 +207,8 @@ The following is a table of the default line height for each font:
 	</tr>
 	<tr>
 		<td>Text Sans</td>
-		<td>135% (1.35)</td>
-		<td>regular</td>
+		<td>150% (1.50)</td>
+		<td>loose</td>
 	</tr>
 	<tr>
 		<td>Text Egyptian</td>

--- a/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -13,8 +13,8 @@ import {
 } from '/.storybook/typographyRenderers';
 
 <!--TODO: hide additional sidebar stories when functionality becomes available,
-    we need the <Story /> component to show examples of each font style in Chromatic
-    https://github.com/storybookjs/storybook/issues/9209 -->
+	we need the <Story /> component to show examples of each font style in Chromatic
+	https://github.com/storybookjs/storybook/issues/9209 -->
 
 <Meta
 	title="Packages/source-foundations/Typography"
@@ -173,6 +173,77 @@ The default for titlepiece is `tight`. This maps to `1.15 (115%)`.
 ### Options
 
 Each method may receive an `options` object. Missing options are merged with sensible defaults for each font family.
+
+#### Line height
+
+The available options for line height are documented in the table below.
+
+<table>
+	<tr>
+		<th>Alias in Source</th>
+		<th>Line height</th>
+	</tr>
+	<tr>
+		<td>loose</td>
+		<td>150% (1.5)</td>
+	</tr>
+	<tr>
+		<td>regular</td>
+		<td>135% (1.35)</td>
+	</tr>
+	<tr>
+		<td>tight</td>
+		<td>115% (1.15)</td>
+	</tr>
+</table>
+
+The following is a table of the default line height for each font:
+
+<table>
+	<tr>
+		<th>Font family</th>
+		<th>Line height</th>
+		<th>Alias in Source</th>
+	</tr>
+	<tr>
+		<td>Text Sans</td>
+		<td>135% (1.35)</td>
+		<td>regular</td>
+	</tr>
+	<tr>
+		<td>Text Egyptian</td>
+		<td>150% (1.5)</td>
+		<td>loose</td>
+	</tr>
+	<tr>
+		<td>Guardian Headline</td>
+		<td>115% (1.15)</td>
+		<td>tight</td>
+	</tr>
+	<tr>
+		<td>Guardian Titlepiece</td>
+		<td>115% (1.15)</td>
+		<td>tight</td>
+	</tr>
+</table>
+
+We calculate the final line height based on the font size using the following formula:
+
+```ts
+// line-height is defined as a unitless value, so we multiply
+// by the element's font-size in px to get the px value
+const finalLineHeight = `${lineHeight * fontSizeInPx}px`;
+```
+
+And a worked example:
+
+```ts
+const lineHeight =
+	1.15 * // line-height: tight (unitless)
+	30; // font-size: small (px)
+
+//  lineHeight === 34.5px
+```
 
 #### Font weight
 

--- a/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
+++ b/packages/@guardian/source-foundations/src/typography/typography.stories.mdx
@@ -3,22 +3,22 @@ import {
 	headlineObjectStyles,
 	bodyObjectStyles,
 	textSansObjectStyles,
-	titlepieceObjectStyles
+	titlepieceObjectStyles,
 } from '@guardian/source-foundations';
 import {
 	FontStylesRenderer,
 	LineHeightRenderer,
 	FontWeightRenderer,
-	ItalicsRenderer
+	ItalicsRenderer,
 } from '/.storybook/typographyRenderers';
 
 <!--TODO: hide additional sidebar stories when functionality becomes available,
-	we need the <Story /> component to show examples of each font style in Chromatic
-	https://github.com/storybookjs/storybook/issues/9209 -->
+    we need the <Story /> component to show examples of each font style in Chromatic
+    https://github.com/storybookjs/storybook/issues/9209 -->
 
 <Meta
 	title="Packages/source-foundations/Typography"
-	parameters={{ previewTabs: { canvas: { hidden: true }}, viewMode: 'docs' }}
+	parameters={{ previewTabs: { canvas: { hidden: true } }, viewMode: 'docs' }}
 />
 
 # Typography
@@ -79,7 +79,20 @@ font-family: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif';
 
 <Canvas>
 	<Story name="headline">
-		<FontStylesRenderer fontName="headline" fontStyles={headlineObjectStyles} />
+		<FontStylesRenderer
+			fontName="headline"
+			fontStyles={headlineObjectStyles}
+		/>
+	</Story>
+</Canvas>
+
+#### Line height
+
+The default for headline is `tight`. This maps to `1.15 (115%)`.
+
+<Canvas>
+	<Story name="headline-lineheight">
+		<LineHeightRenderer getFontStyles={headlineObjectStyles.large} />
 	</Story>
 </Canvas>
 
@@ -95,6 +108,18 @@ font-family: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif';
 	</Story>
 </Canvas>
 
+#### Line height
+
+The default for body is `loose`. This maps to `1.50 (150%)`.
+
+This meets the [WCAG 2.1 AAA success criterion for visual presentation](https://www.w3.org/TR/WCAG21/#visual-presentation).
+
+<Canvas>
+	<Story name="body-lineheight">
+		<LineHeightRenderer getFontStyles={bodyObjectStyles.small} />
+	</Story>
+</Canvas>
+
 ### Text sans
 
 ```css
@@ -103,7 +128,20 @@ font-family: 'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetic
 
 <Canvas>
 	<Story name="textSans">
-		<FontStylesRenderer fontName="textSans" fontStyles={textSansObjectStyles} />
+		<FontStylesRenderer
+			fontName="textSans"
+			fontStyles={textSansObjectStyles}
+		/>
+	</Story>
+</Canvas>
+
+#### Line height
+
+The default for body is `regular`. This maps to `1.35 (135%)`.
+
+<Canvas>
+	<Story name="text-sans-lineheight">
+		<LineHeightRenderer getFontStyles={textSansObjectStyles.medium} />
 	</Story>
 </Canvas>
 
@@ -115,29 +153,26 @@ font-family: 'GT Guardian Titlepiece, Georgia, serif';
 
 <Canvas>
 	<Story name="titlepiece">
-		<FontStylesRenderer fontName="titlepiece" fontStyles={titlepieceObjectStyles} />
+		<FontStylesRenderer
+			fontName="titlepiece"
+			fontStyles={titlepieceObjectStyles}
+		/>
+	</Story>
+</Canvas>
+
+#### Line height
+
+The default for titlepiece is `tight`. This maps to `1.15 (115%)`.
+
+<Canvas>
+	<Story name="titlepiece-lineheight">
+		<LineHeightRenderer getFontStyles={titlepieceObjectStyles.medium} />
 	</Story>
 </Canvas>
 
 ### Options
 
 Each method may receive an `options` object. Missing options are merged with sensible defaults for each font family.
-
-#### Line height
-
-```tsx
-headline.medium({ lineHeight: 'loose' });
-```
-
-<Canvas>
-	<Story name="line height">
-		<LineHeightRenderer />
-	</Story>
-</Canvas>
-
-The default for body and textSans is `loose`. This meets the [WCAG 2.1 AAA success criterion for visual presentation](https://www.w3.org/TR/WCAG21/#visual-presentation).
-
-The default for headline and titlepiece is `tight`.
 
 #### Font weight
 


### PR DESCRIPTION
## What is the purpose of this change?
In this PR we provide four extra stories for our typography documentation in Storybook so any future changes to default line height will be captured by our Chromatic visual regression testing.

## What does this change?

- Introduces four new stories to the Storybook Typography documentation improved by @joecowton1 in #1492 

## Screenshots

<table>
<tr>
	<th>Text Sans</th>
	<th>Text Egyptian</th>
	<th>Guardian Headline</th>
	<th>Guardian Titlepiece</th>
<tr>
<img width="466" alt="Screenshot 2022-08-25 at 09 45 33" src="https://user-images.githubusercontent.com/1771189/186620569-172f4eef-575a-4be2-938a-239cbf95f9c0.png">
	

<tr>
<img width="515" alt="Screenshot 2022-08-25 at 09 45 42" src="https://user-images.githubusercontent.com/1771189/186620373-dd7347ed-ba09-43da-8933-8085b18e0b10.png">


<tr>
<img width="488" alt="Screenshot 2022-08-25 at 09 45 46" src="https://user-images.githubusercontent.com/1771189/186620338-88eba0b8-6ce5-4eb2-9f55-498a5dfe09bf.png">


<tr>
<img width="502" alt="Screenshot 2022-08-25 at 09 45 38" src="https://user-images.githubusercontent.com/1771189/186619434-c3fd6407-6920-413d-ad01-2e50f66e5928.png">

</table>

A more general documentation section detailing the line height calculation and aliases was also added:
<img width="945" alt="Screenshot 2022-08-25 at 17 12 54" src="https://user-images.githubusercontent.com/1771189/186718851-268c1f76-16e0-42c8-8b3e-cc8885f7c4de.png">


