### PR TITLE
Typography refactor | Simplify theme token data structure

### DIFF
--- a/.changeset/twenty-onions-fetch.md
+++ b/.changeset/twenty-onions-fetch.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': patch
+---
+
+refactoring of internal typography definitions to directly map to a concrete value instead of pulling from an array of values; a general simplification of the typography data file, and of its exports

--- a/.storybook/typographyRenderers.tsx
+++ b/.storybook/typographyRenderers.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {
 	bodyObjectStyles,
+	fontWeights,
 	headlineObjectStyles,
 	textSansObjectStyles,
 } from '@guardian/source-foundations/src';
-import { fontWeightMapping } from '@guardian/source-foundations/src/typography/data';
 import type {
 	Category,
 	FontScaleFunction,
@@ -56,7 +56,7 @@ export const LineHeightRenderer = ({
 
 export const FontWeightRenderer = () => (
 	<ul>
-		{Object.entries(fontWeightMapping).map(([fontWeight, value]) => (
+		{Object.entries(fontWeights).map(([fontWeight, value]) => (
 			<li
 				key={value}
 				style={{

--- a/packages/@guardian/source-foundations/src/index.ts
+++ b/packages/@guardian/source-foundations/src/index.ts
@@ -79,10 +79,11 @@ export {
 	remHeadlineSizes,
 	remBodySizes,
 	remTextSansSizes,
-	fontMapping as fonts,
-	fontWeightMapping as fontWeights,
-	lineHeightMapping as lineHeights,
+	fonts,
+	fontWeights,
+	lineHeights,
 } from './typography';
+
 export {
 	body as bodyObjectStyles,
 	headline as headlineObjectStyles,

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -6,8 +6,8 @@ import { pxToRem } from '../utils/px-to-rem';
  * These fit the following px size scale:
  * [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70]
  */
-const pxTextSizes = {
-	textSansSizes: {
+export const pxTextSizes = {
+	textSans: {
 		xxsmall: 12,
 		xsmall: 14,
 		small: 15,
@@ -17,12 +17,12 @@ const pxTextSizes = {
 		xxlarge: 28,
 		xxxlarge: 34,
 	},
-	bodySizes: {
+	body: {
 		xsmall: 14,
 		small: 15,
 		medium: 17,
 	},
-	headlineSizes: {
+	headline: {
 		xxxsmall: 17,
 		xxsmall: 20,
 		xsmall: 24,
@@ -31,7 +31,7 @@ const pxTextSizes = {
 		large: 42,
 		xlarge: 50,
 	},
-	titlepieceSizes: {
+	titlepiece: {
 		small: 42,
 		medium: 50,
 		large: 70,
@@ -48,8 +48,8 @@ const pxTextSizes = {
  *
  * See {@link [pxToRem](../utils/px-to-rem.ts)} for more details.
  */
-const remTextSizes = {
-	textSansSizes: {
+export const remTextSizes = {
+	textSans: {
 		xxsmall: pxToRem(12),
 		xsmall: pxToRem(14),
 		small: pxToRem(15),
@@ -59,12 +59,12 @@ const remTextSizes = {
 		xxlarge: pxToRem(28),
 		xxxlarge: pxToRem(34),
 	},
-	bodySizes: {
+	body: {
 		xsmall: pxToRem(14),
 		small: pxToRem(15),
 		medium: pxToRem(17),
 	},
-	headlineSizes: {
+	headline: {
 		xxxsmall: pxToRem(17),
 		xxsmall: pxToRem(20),
 		xsmall: pxToRem(24),
@@ -73,7 +73,7 @@ const remTextSizes = {
 		large: pxToRem(42),
 		xlarge: pxToRem(50),
 	},
-	titlepieceSizes: {
+	titlepiece: {
 		small: pxToRem(42),
 		medium: pxToRem(50),
 		large: pxToRem(70),
@@ -134,20 +134,20 @@ export const underlineThickness = {
 } as const;
 
 // Pixel font size exports
-export const textSansSizes = pxTextSizes.textSansSizes;
+export const textSansSizes = pxTextSizes.textSans;
 
-export const bodySizes = pxTextSizes.bodySizes;
+export const bodySizes = pxTextSizes.body;
 
-export const headlineSizes = pxTextSizes.headlineSizes;
+export const headlineSizes = pxTextSizes.headline;
 
-export const titlepieceSizes = pxTextSizes.titlepieceSizes;
+export const titlepieceSizes = pxTextSizes.titlepiece;
 
 // Computed rem font size exports
 
-export const remTitlepieceSizes = remTextSizes.titlepieceSizes;
+export const remTitlepieceSizes = remTextSizes.titlepiece;
 
-export const remHeadlineSizes = remTextSizes.headlineSizes;
+export const remHeadlineSizes = remTextSizes.headline;
 
-export const remBodySizes = remTextSizes.bodySizes;
+export const remBodySizes = remTextSizes.body;
 
-export const remTextSansSizes = remTextSizes.textSansSizes;
+export const remTextSansSizes = remTextSizes.textSans;

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported so it can be used for our doc comment
-import { pxToRem } from '../utils/px-to-rem';
-
 /**
  * Pixel size values for each font that we use in the design system.
  *
@@ -46,7 +43,7 @@ const pxTextSizes = {
  * The resulting scale that we draw from is:
  * [0.75, 0.875, 0.9375, 1.0625, 1.25, 1.5, 1.75, 2.125, 2.625, 3.125, 4.375]
  *
- * See {@link pxToRem} for more details.
+ * See {@link [pxToRem](../utils/px-to-rem.ts)} for more details.
  */
 const remTextSizes = {
 	titlepieceSizes: {

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -1,3 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- imported so it can be used for our doc comment
+import { pxToRem } from '../utils/px-to-rem';
+
+/**
+ * Pixel size values for each font that we use in the design system.
+ *
+ * These fit the following px size scale:
+ * [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70]
+ */
 const pxTextSizes = {
 	textSansSizes: {
 		xxsmall: 12,
@@ -30,6 +39,15 @@ const pxTextSizes = {
 	},
 } as const;
 
+/**
+ * Relative font sizes, calculated from the pixel sizes above;
+ * using the pxToRem method.
+ *
+ * The resulting scale that we draw from is:
+ * [0.75, 0.875, 0.9375, 1.0625, 1.25, 1.5, 1.75, 2.125, 2.625, 3.125, 4.375]
+ *
+ * See {@link pxToRem} for more details.
+ */
 const remTextSizes = {
 	titlepieceSizes: {
 		small: 2.625,
@@ -45,12 +63,12 @@ const remTextSizes = {
 		large: 2.625,
 		xlarge: 3.125,
 	},
-	remBodySizes: {
+	bodySizes: {
 		xsmall: 0.875,
 		small: 0.9375,
 		medium: 1.0625,
 	},
-	remTextSansSizes: {
+	textSansSizes: {
 		xxsmall: 0.75,
 		xsmall: 0.875,
 		small: 0.9375,
@@ -60,7 +78,7 @@ const remTextSizes = {
 		xxlarge: 1.75,
 		xxxlarge: 2.125,
 	},
-};
+} as const;
 
 export const fonts = {
 	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
@@ -124,12 +142,12 @@ export const headlineSizes = pxTextSizes.headlineSizes;
 
 export const titlepieceSizes = pxTextSizes.titlepieceSizes;
 
-// Rem font size exports
+// Computed rem font size exports
 
 export const remTitlepieceSizes = remTextSizes.titlepieceSizes;
 
 export const remHeadlineSizes = remTextSizes.headlineSizes;
 
-export const remBodySizes = remTextSizes.remBodySizes;
+export const remBodySizes = remTextSizes.bodySizes;
 
-export const remTextSansSizes = remTextSizes.remTextSansSizes;
+export const remTextSansSizes = remTextSizes.textSansSizes;

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -1,6 +1,6 @@
 import type { Category, FontWeight, FontWeightDefinition } from './types';
 
-const textSansSizes = {
+export const textSansSizes = {
 	xxsmall: 12,
 	xsmall: 14,
 	small: 15,
@@ -10,12 +10,14 @@ const textSansSizes = {
 	xxlarge: 28,
 	xxxlarge: 34,
 } as const;
-const bodySizes = {
+
+export const bodySizes = {
 	xsmall: 14,
 	small: 15,
 	medium: 17,
 } as const;
-const headlineSizes = {
+
+export const headlineSizes = {
 	xxxsmall: 17,
 	xxsmall: 20,
 	xsmall: 24,
@@ -24,25 +26,27 @@ const headlineSizes = {
 	large: 42,
 	xlarge: 50,
 } as const;
-const titlepieceSizes = {
+
+export const titlepieceSizes = {
 	small: 42,
 	medium: 50,
 	large: 70,
 } as const;
 
-const fontSizeMapping = {
+export const fontSizeMapping = {
 	titlepiece: titlepieceSizes,
 	headline: headlineSizes,
 	body: bodySizes,
 	textSans: textSansSizes,
 } as const;
 
-const remTitlepieceSizes = {
+export const remTitlepieceSizes = {
 	small: 2.625, //42px
 	medium: 3.125, //50px
 	large: 4.375, //70px
 } as const;
-const remHeadlineSizes = {
+
+export const remHeadlineSizes = {
 	xxxsmall: 1.0625, //17px
 	xxsmall: 1.25, //20px
 	xsmall: 1.5, //24px
@@ -51,12 +55,14 @@ const remHeadlineSizes = {
 	large: 2.625, //42px
 	xlarge: 3.125, //50px
 } as const;
-const remBodySizes = {
+
+export const remBodySizes = {
 	xsmall: 0.875, //14px
 	small: 0.9375, //15px
 	medium: 1.0625, //17px
 } as const;
-const remTextSansSizes = {
+
+export const remTextSansSizes = {
 	xxsmall: 0.75, //12px
 	xsmall: 0.875, //14px
 	small: 0.9375, //15px
@@ -67,14 +73,14 @@ const remTextSansSizes = {
 	xxxlarge: 2.125, //34px
 } as const;
 
-const remFontSizeMapping = {
+export const remFontSizeMapping = {
 	titlepiece: remTitlepieceSizes,
 	headline: remHeadlineSizes,
 	body: remBodySizes,
 	textSans: remTextSansSizes,
 } as const;
 
-const fontMapping = {
+export const fontMapping = {
 	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
 	headlineSerif: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif',
 	bodySerif: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
@@ -82,18 +88,20 @@ const fontMapping = {
 		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
 } as const;
 
-const lineHeightMapping = {
+export const lineHeightMapping = {
 	tight: 1.15,
 	regular: 1.35,
 	loose: 1.5,
 } as const;
-const fontWeightMapping = {
+
+export const fontWeightMapping = {
 	light: 300,
 	regular: 400,
 	medium: 500,
 	bold: 700,
 } as const;
-const availableFonts = {
+
+export const availableFonts = {
 	titlepiece: {
 		bold: {
 			hasItalic: false,
@@ -131,7 +139,7 @@ const availableFonts = {
 		[fontWeight in FontWeight]?: FontWeightDefinition;
 	};
 };
-const underlineThicknessMapping = {
+export const underlineThicknessMapping = {
 	textSans: {
 		xxsmall: 2,
 		xsmall: 2,
@@ -162,21 +170,3 @@ const underlineThicknessMapping = {
 		large: 6,
 	},
 } as const;
-
-export {
-	availableFonts,
-	fontSizeMapping,
-	remFontSizeMapping,
-	underlineThicknessMapping,
-	bodySizes,
-	fontMapping,
-	fontWeightMapping,
-	headlineSizes,
-	lineHeightMapping,
-	remBodySizes,
-	remHeadlineSizes,
-	remTextSansSizes,
-	remTitlepieceSizes,
-	textSansSizes,
-	titlepieceSizes,
-};

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -82,9 +82,9 @@ export const remTextSizes = {
 
 export const fonts = {
 	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
-	headlineSerif: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif',
-	bodySerif: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
-	bodySans:
+	headline: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif',
+	body: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
+	textSans:
 		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
 } as const;
 

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -3,7 +3,7 @@ import { pxToRem } from '../utils/px-to-rem';
 /**
  * Pixel size values for each font that we use in the design system.
  *
- * We assert that the values match those we expect in our
+ * We assert that the values match the guardian type scale in our
  * {@link [unit test suite](./typography.test.ts)}.
  */
 export const pxTextSizes = {

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -1,86 +1,68 @@
-import type { Category, FontWeight, FontWeightDefinition } from './types';
-
-export const textSansSizes = {
-	xxsmall: 12,
-	xsmall: 14,
-	small: 15,
-	medium: 17,
-	large: 20,
-	xlarge: 24,
-	xxlarge: 28,
-	xxxlarge: 34,
+const pxTextSizes = {
+	textSansSizes: {
+		xxsmall: 12,
+		xsmall: 14,
+		small: 15,
+		medium: 17,
+		large: 20,
+		xlarge: 24,
+		xxlarge: 28,
+		xxxlarge: 34,
+	},
+	bodySizes: {
+		xsmall: 14,
+		small: 15,
+		medium: 17,
+	},
+	headlineSizes: {
+		xxxsmall: 17,
+		xxsmall: 20,
+		xsmall: 24,
+		small: 28,
+		medium: 34,
+		large: 42,
+		xlarge: 50,
+	},
+	titlepieceSizes: {
+		small: 42,
+		medium: 50,
+		large: 70,
+	},
 } as const;
 
-export const bodySizes = {
-	xsmall: 14,
-	small: 15,
-	medium: 17,
-} as const;
+const remTextSizes = {
+	titlepieceSizes: {
+		small: 2.625,
+		medium: 3.125,
+		large: 4.375,
+	},
+	headlineSizes: {
+		xxxsmall: 1.0625,
+		xxsmall: 1.25,
+		xsmall: 1.5,
+		small: 1.75,
+		medium: 2.125,
+		large: 2.625,
+		xlarge: 3.125,
+	},
+	remBodySizes: {
+		xsmall: 0.875,
+		small: 0.9375,
+		medium: 1.0625,
+	},
+	remTextSansSizes: {
+		xxsmall: 0.75,
+		xsmall: 0.875,
+		small: 0.9375,
+		medium: 1.0625,
+		large: 1.25,
+		xlarge: 1.5,
+		xxlarge: 1.75,
+		xxxlarge: 2.125,
+	},
+};
 
-export const headlineSizes = {
-	xxxsmall: 17,
-	xxsmall: 20,
-	xsmall: 24,
-	small: 28,
-	medium: 34,
-	large: 42,
-	xlarge: 50,
-} as const;
-
-export const titlepieceSizes = {
-	small: 42,
-	medium: 50,
-	large: 70,
-} as const;
-
-export const fontSizeMapping = {
-	titlepiece: titlepieceSizes,
-	headline: headlineSizes,
-	body: bodySizes,
-	textSans: textSansSizes,
-} as const;
-
-export const remTitlepieceSizes = {
-	small: 2.625, //42px
-	medium: 3.125, //50px
-	large: 4.375, //70px
-} as const;
-
-export const remHeadlineSizes = {
-	xxxsmall: 1.0625, //17px
-	xxsmall: 1.25, //20px
-	xsmall: 1.5, //24px
-	small: 1.75, //28px
-	medium: 2.125, //34px
-	large: 2.625, //42px
-	xlarge: 3.125, //50px
-} as const;
-
-export const remBodySizes = {
-	xsmall: 0.875, //14px
-	small: 0.9375, //15px
-	medium: 1.0625, //17px
-} as const;
-
-export const remTextSansSizes = {
-	xxsmall: 0.75, //12px
-	xsmall: 0.875, //14px
-	small: 0.9375, //15px
-	medium: 1.0625, //17px
-	large: 1.25, //20px
-	xlarge: 1.5, //24px
-	xxlarge: 1.75, //28px
-	xxxlarge: 2.125, //34px
-} as const;
-
-export const remFontSizeMapping = {
-	titlepiece: remTitlepieceSizes,
-	headline: remHeadlineSizes,
-	body: remBodySizes,
-	textSans: remTextSansSizes,
-} as const;
-
-export const fontMapping = {
+export const fonts = {
 	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
 	headlineSerif: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif',
 	bodySerif: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
@@ -88,58 +70,20 @@ export const fontMapping = {
 		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
 } as const;
 
-export const lineHeightMapping = {
+export const lineHeights = {
 	tight: 1.15,
 	regular: 1.35,
 	loose: 1.5,
 } as const;
 
-export const fontWeightMapping = {
+export const fontWeights = {
 	light: 300,
 	regular: 400,
 	medium: 500,
 	bold: 700,
 } as const;
 
-export const availableFonts = {
-	titlepiece: {
-		bold: {
-			hasItalic: false,
-		},
-	},
-	headline: {
-		light: {
-			hasItalic: true,
-		},
-		medium: {
-			hasItalic: true,
-		},
-		bold: {
-			hasItalic: false,
-		},
-	},
-	body: {
-		regular: {
-			hasItalic: true,
-		},
-		bold: {
-			hasItalic: true,
-		},
-	},
-	textSans: {
-		regular: {
-			hasItalic: true,
-		},
-		bold: {
-			hasItalic: false,
-		},
-	},
-} as {
-	[cat in Category]: {
-		[fontWeight in FontWeight]?: FontWeightDefinition;
-	};
-};
-export const underlineThicknessMapping = {
+export const underlineThickness = {
 	textSans: {
 		xxsmall: 2,
 		xsmall: 2,
@@ -170,3 +114,39 @@ export const underlineThicknessMapping = {
 		large: 6,
 	},
 } as const;
+
+// Pixel font size exports
+export const textSansSizes = pxTextSizes.textSansSizes;
+
+export const bodySizes = pxTextSizes.bodySizes;
+
+export const headlineSizes = pxTextSizes.headlineSizes;
+
+export const titlepieceSizes = pxTextSizes.titlepieceSizes;
+
+// Rem font size exports
+
+export const remTitlepieceSizes = remTextSizes.titlepieceSizes;
+
+export const remHeadlineSizes = remTextSizes.headlineSizes;
+
+export const remBodySizes = remTextSizes.remBodySizes;
+
+export const remTextSansSizes = remTextSizes.remTextSansSizes;
+
+/**
+ * @deprecated use `fonts` instead
+ */
+export const fontMapping = fonts;
+/**
+ * @deprecated use `lineHeights` instead
+ */
+export const lineHeightMapping = lineHeights;
+/**
+ * @deprecated use `fontWeights` instead
+ */
+export const fontWeightMapping = fontWeights;
+/**
+ * @deprecated use `underlineThickness` instead
+ */
+export const underlineThicknessMapping = underlineThickness;

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -1,3 +1,5 @@
+import { pxToRem } from '../utils/px-to-rem';
+
 /**
  * Pixel size values for each font that we use in the design system.
  *
@@ -43,37 +45,38 @@ const pxTextSizes = {
  * The resulting scale that we draw from is:
  * [0.75, 0.875, 0.9375, 1.0625, 1.25, 1.5, 1.75, 2.125, 2.625, 3.125, 4.375]
  *
+ *
  * See {@link [pxToRem](../utils/px-to-rem.ts)} for more details.
  */
 const remTextSizes = {
-	titlepieceSizes: {
-		small: 2.625,
-		medium: 3.125,
-		large: 4.375,
-	},
-	headlineSizes: {
-		xxxsmall: 1.0625,
-		xxsmall: 1.25,
-		xsmall: 1.5,
-		small: 1.75,
-		medium: 2.125,
-		large: 2.625,
-		xlarge: 3.125,
+	textSansSizes: {
+		xxsmall: pxToRem(12),
+		xsmall: pxToRem(14),
+		small: pxToRem(15),
+		medium: pxToRem(17),
+		large: pxToRem(20),
+		xlarge: pxToRem(24),
+		xxlarge: pxToRem(28),
+		xxxlarge: pxToRem(34),
 	},
 	bodySizes: {
-		xsmall: 0.875,
-		small: 0.9375,
-		medium: 1.0625,
+		xsmall: pxToRem(14),
+		small: pxToRem(15),
+		medium: pxToRem(17),
 	},
-	textSansSizes: {
-		xxsmall: 0.75,
-		xsmall: 0.875,
-		small: 0.9375,
-		medium: 1.0625,
-		large: 1.25,
-		xlarge: 1.5,
-		xxlarge: 1.75,
-		xxxlarge: 2.125,
+	headlineSizes: {
+		xxxsmall: pxToRem(17),
+		xxsmall: pxToRem(20),
+		xsmall: pxToRem(24),
+		small: pxToRem(28),
+		medium: pxToRem(34),
+		large: pxToRem(42),
+		xlarge: pxToRem(50),
+	},
+	titlepieceSizes: {
+		small: pxToRem(42),
+		medium: pxToRem(50),
+		large: pxToRem(70),
 	},
 } as const;
 

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -133,20 +133,3 @@ export const remHeadlineSizes = remTextSizes.headlineSizes;
 export const remBodySizes = remTextSizes.remBodySizes;
 
 export const remTextSansSizes = remTextSizes.remTextSansSizes;
-
-/**
- * @deprecated use `fonts` instead
- */
-export const fontMapping = fonts;
-/**
- * @deprecated use `lineHeights` instead
- */
-export const lineHeightMapping = lineHeights;
-/**
- * @deprecated use `fontWeights` instead
- */
-export const fontWeightMapping = fontWeights;
-/**
- * @deprecated use `underlineThickness` instead
- */
-export const underlineThicknessMapping = underlineThickness;

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -1,53 +1,33 @@
-import { pxToRem } from '../utils/px-to-rem';
 import type { Category, FontWeight, FontWeightDefinition } from './types';
 
-const fontSizes = [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70] as const;
-
-const fonts = {
-	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
-	headlineSerif: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif',
-	bodySerif: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
-	bodySans:
-		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
-} as const;
-
-const lineHeights = [1.15, 1.35, 1.5] as const;
-
-const fontWeights = [300, 400, 500, 700] as const;
-
-const underlineThickness = [2, 3, 4, 5, 6] as const;
-
-const titlepieceSizes = {
-	small: fontSizes[8], //42px
-	medium: fontSizes[9], //50px
-	large: fontSizes[10], //70px
-} as const;
-
-const headlineSizes = {
-	xxxsmall: fontSizes[3], //17px
-	xxsmall: fontSizes[4], //20px
-	xsmall: fontSizes[5], //24px
-	small: fontSizes[6], //28px
-	medium: fontSizes[7], //34px
-	large: fontSizes[8], //42px
-	xlarge: fontSizes[9], //50px
-} as const;
-
-const bodySizes = {
-	xsmall: fontSizes[1], //14px
-	small: fontSizes[2], //15px
-	medium: fontSizes[3], //17px
-} as const;
-
 const textSansSizes = {
-	xxsmall: fontSizes[0], //12px
-	xsmall: fontSizes[1], //14px
-	small: fontSizes[2], //15px
-	medium: fontSizes[3], //17px
-	large: fontSizes[4], //20px
-	xlarge: fontSizes[5], //24px
-	xxlarge: fontSizes[6], //28px
-	xxxlarge: fontSizes[7], //34px
+	xxsmall: 12,
+	xsmall: 14,
+	small: 15,
+	medium: 17,
+	large: 20,
+	xlarge: 24,
+	xxlarge: 28,
+	xxxlarge: 34,
+} as const;
+const bodySizes = {
+	xsmall: 14,
+	small: 15,
+	medium: 17,
+} as const;
+const headlineSizes = {
+	xxxsmall: 17,
+	xxsmall: 20,
+	xsmall: 24,
+	small: 28,
+	medium: 34,
+	large: 42,
+	xlarge: 50,
+} as const;
+const titlepieceSizes = {
+	small: 42,
+	medium: 50,
+	large: 70,
 } as const;
 
 const fontSizeMapping = {
@@ -55,41 +35,36 @@ const fontSizeMapping = {
 	headline: headlineSizes,
 	body: bodySizes,
 	textSans: textSansSizes,
-} as const;
-
-const remFontSizes = fontSizes.map((fontSize) => pxToRem(fontSize));
+};
 
 const remTitlepieceSizes = {
-	small: remFontSizes[8], //42px
-	medium: remFontSizes[9], //50px
-	large: remFontSizes[10], //70px
+	small: 2.625, //42px
+	medium: 3.125, //50px
+	large: 4.375, //70px
 } as const;
-
 const remHeadlineSizes = {
-	xxxsmall: remFontSizes[3], //17px
-	xxsmall: remFontSizes[4], //20px
-	xsmall: remFontSizes[5], //24px
-	small: remFontSizes[6], //28px
-	medium: remFontSizes[7], //34px
-	large: remFontSizes[8], //42px
-	xlarge: remFontSizes[9], //50px
+	xxxsmall: 1.0625, //17px
+	xxsmall: 1.25, //20px
+	xsmall: 1.5, //24px
+	small: 1.75, //28px
+	medium: 2.125, //34px
+	large: 2.625, //42px
+	xlarge: 3.125, //50px
 } as const;
-
 const remBodySizes = {
-	xsmall: remFontSizes[1], //14px
-	small: remFontSizes[2], //15px
-	medium: remFontSizes[3], //17px
+	xsmall: 0.875, //14px
+	small: 0.9375, //15px
+	medium: 1.0625, //17px
 } as const;
-
 const remTextSansSizes = {
-	xxsmall: remFontSizes[0], //12px
-	xsmall: remFontSizes[1], //14px
-	small: remFontSizes[2], //15px
-	medium: remFontSizes[3], //17px
-	large: remFontSizes[4], //20px
-	xlarge: remFontSizes[5], //24px
-	xxlarge: remFontSizes[6], //28px
-	xxxlarge: remFontSizes[7], //34px
+	xxsmall: 0.75, //12px
+	xsmall: 0.875, //14px
+	small: 0.9375, //15px
+	medium: 1.0625, //17px
+	large: 1.25, //20px
+	xlarge: 1.5, //24px
+	xxlarge: 1.75, //28px
+	xxxlarge: 2.125, //34px
 } as const;
 
 const remFontSizeMapping = {
@@ -97,33 +72,28 @@ const remFontSizeMapping = {
 	headline: remHeadlineSizes,
 	body: remBodySizes,
 	textSans: remTextSansSizes,
-} as const;
+};
 
 const fontMapping = {
-	titlepiece: fonts.titlepiece,
-	headline: fonts.headlineSerif,
-	body: fonts.bodySerif,
-	textSans: fonts.bodySans,
-} as const;
+	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
+	headlineSerif: 'GH Guardian Headline, Guardian Egyptian Web, Georgia, serif',
+	bodySerif: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
+	bodySans:
+		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
+};
 
 const lineHeightMapping = {
-	tight: lineHeights[0],
-	regular: lineHeights[1],
-	loose: lineHeights[2],
-} as const;
-
+	tight: 1.15,
+	regular: 1.35,
+	loose: 1.5,
+};
 const fontWeightMapping = {
-	light: fontWeights[0],
-	regular: fontWeights[1],
-	medium: fontWeights[2],
-	bold: fontWeights[3],
-} as const;
-
-const availableFonts: {
-	[cat in Category]: {
-		[fontWeight in FontWeight]?: FontWeightDefinition;
-	};
-} = {
+	light: 300,
+	regular: 400,
+	medium: 500,
+	bold: 700,
+};
+const availableFonts = {
 	titlepiece: {
 		bold: {
 			hasItalic: false,
@@ -156,86 +126,57 @@ const availableFonts: {
 			hasItalic: false,
 		},
 	},
+} as {
+	[cat in Category]: {
+		[fontWeight in FontWeight]?: FontWeightDefinition;
+	};
 };
-
-const titlepieceUnderlineThickness = {
-	small: underlineThickness[3], //5px
-	medium: underlineThickness[4], //6px
-	large: underlineThickness[4], //6px
-} as const;
-
-const headlineUnderlineThickness = {
-	xxxsmall: underlineThickness[0], //2px
-	xxsmall: underlineThickness[1], //3px
-	xsmall: underlineThickness[1], //3px
-	small: underlineThickness[1], //3px
-	medium: underlineThickness[2], //4px
-	large: underlineThickness[3], //5px
-	xlarge: underlineThickness[4], //6px
-} as const;
-
-const bodyUnderlineThickness = {
-	xsmall: underlineThickness[0], //2px
-	small: underlineThickness[0], //2px
-	medium: underlineThickness[0], //2px
-} as const;
-
-const textSansUnderlineThickness = {
-	xxsmall: underlineThickness[0], //2px
-	xsmall: underlineThickness[0], //2px
-	small: underlineThickness[0], //2px
-	medium: underlineThickness[0], //2px
-	large: underlineThickness[1], //3px
-	xlarge: underlineThickness[1], //3px
-	xxlarge: underlineThickness[1], //3px
-	xxxlarge: underlineThickness[2], //4px
-} as const;
-
 const underlineThicknessMapping = {
-	titlepiece: titlepieceUnderlineThickness,
-	headline: headlineUnderlineThickness,
-	body: bodyUnderlineThickness,
-	textSans: textSansUnderlineThickness,
+	textSans: {
+		xxsmall: 2,
+		xsmall: 2,
+		small: 2,
+		medium: 2,
+		large: 3,
+		xlarge: 3,
+		xxlarge: 3,
+		xxxlarge: 4,
+	},
+	body: {
+		xsmall: 2,
+		small: 2,
+		medium: 2,
+	},
+	headline: {
+		xxxsmall: 2,
+		xxsmall: 3,
+		xsmall: 3,
+		small: 3,
+		medium: 4,
+		large: 5,
+		xlarge: 6,
+	},
+	titlepiece: {
+		small: 5,
+		medium: 6,
+		large: 6,
+	},
 };
-
-Object.freeze(titlepieceSizes);
-Object.freeze(headlineSizes);
-Object.freeze(bodySizes);
-Object.freeze(textSansSizes);
-Object.freeze(remTitlepieceSizes);
-Object.freeze(remHeadlineSizes);
-Object.freeze(remBodySizes);
-Object.freeze(remTextSansSizes);
-Object.freeze(fontMapping);
-Object.freeze(fontSizeMapping);
-Object.freeze(fontWeightMapping);
-Object.freeze(lineHeightMapping);
-Object.freeze(availableFonts);
-Object.freeze(titlepieceUnderlineThickness);
-Object.freeze(headlineUnderlineThickness);
-Object.freeze(bodyUnderlineThickness);
-Object.freeze(textSansUnderlineThickness);
-Object.freeze(underlineThicknessMapping);
 
 export {
-	titlepieceSizes,
-	headlineSizes,
-	bodySizes,
-	textSansSizes,
-	remFontSizes,
-	remTitlepieceSizes,
-	remHeadlineSizes,
-	remBodySizes,
-	remTextSansSizes,
-	remFontSizeMapping,
-	fontMapping,
-	fontSizeMapping,
-	lineHeightMapping,
-	fontWeightMapping,
 	availableFonts,
-	titlepieceUnderlineThickness,
-	headlineUnderlineThickness,
-	bodyUnderlineThickness,
-	textSansUnderlineThickness,
+	fontSizeMapping,
+	remFontSizeMapping,
 	underlineThicknessMapping,
+	bodySizes,
+	fontMapping,
+	fontWeightMapping,
+	headlineSizes,
+	lineHeightMapping,
+	remBodySizes,
+	remHeadlineSizes,
+	remTextSansSizes,
+	remTitlepieceSizes,
+	textSansSizes,
+	titlepieceSizes,
 };

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -35,7 +35,7 @@ const fontSizeMapping = {
 	headline: headlineSizes,
 	body: bodySizes,
 	textSans: textSansSizes,
-};
+} as const;
 
 const remTitlepieceSizes = {
 	small: 2.625, //42px
@@ -72,7 +72,7 @@ const remFontSizeMapping = {
 	headline: remHeadlineSizes,
 	body: remBodySizes,
 	textSans: remTextSansSizes,
-};
+} as const;
 
 const fontMapping = {
 	titlepiece: 'GT Guardian Titlepiece, Georgia, serif',
@@ -80,19 +80,19 @@ const fontMapping = {
 	bodySerif: 'GuardianTextEgyptian, Guardian Text Egyptian Web, Georgia, serif',
 	bodySans:
 		'GuardianTextSans, Guardian Text Sans Web, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif',
-};
+} as const;
 
 const lineHeightMapping = {
 	tight: 1.15,
 	regular: 1.35,
 	loose: 1.5,
-};
+} as const;
 const fontWeightMapping = {
 	light: 300,
 	regular: 400,
 	medium: 500,
 	bold: 700,
-};
+} as const;
 const availableFonts = {
 	titlepiece: {
 		bold: {
@@ -161,7 +161,7 @@ const underlineThicknessMapping = {
 		medium: 6,
 		large: 6,
 	},
-};
+} as const;
 
 export {
 	availableFonts,

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -42,41 +42,37 @@ export const pxTextSizes = {
  * Relative font sizes, calculated from the pixel sizes above;
  * using the pxToRem method.
  *
- * The resulting scale that we draw from is:
- * [0.75, 0.875, 0.9375, 1.0625, 1.25, 1.5, 1.75, 2.125, 2.625, 3.125, 4.375]
- *
- *
  * See {@link [pxToRem](../utils/px-to-rem.ts)} for more details.
  */
 export const remTextSizes = {
 	textSans: {
-		xxsmall: pxToRem(12),
-		xsmall: pxToRem(14),
-		small: pxToRem(15),
-		medium: pxToRem(17),
-		large: pxToRem(20),
-		xlarge: pxToRem(24),
-		xxlarge: pxToRem(28),
-		xxxlarge: pxToRem(34),
+		xxsmall: pxToRem(pxTextSizes.textSans.xxsmall),
+		xsmall: pxToRem(pxTextSizes.textSans.xsmall),
+		small: pxToRem(pxTextSizes.textSans.small),
+		medium: pxToRem(pxTextSizes.textSans.medium),
+		large: pxToRem(pxTextSizes.textSans.large),
+		xlarge: pxToRem(pxTextSizes.textSans.xlarge),
+		xxlarge: pxToRem(pxTextSizes.textSans.xxlarge),
+		xxxlarge: pxToRem(pxTextSizes.textSans.xxxlarge),
 	},
 	body: {
-		xsmall: pxToRem(14),
-		small: pxToRem(15),
-		medium: pxToRem(17),
+		xsmall: pxToRem(pxTextSizes.body.xsmall),
+		small: pxToRem(pxTextSizes.body.small),
+		medium: pxToRem(pxTextSizes.body.medium),
 	},
 	headline: {
-		xxxsmall: pxToRem(17),
-		xxsmall: pxToRem(20),
-		xsmall: pxToRem(24),
-		small: pxToRem(28),
-		medium: pxToRem(34),
-		large: pxToRem(42),
-		xlarge: pxToRem(50),
+		xxxsmall: pxToRem(pxTextSizes.headline.xxxsmall),
+		xxsmall: pxToRem(pxTextSizes.headline.xxsmall),
+		xsmall: pxToRem(pxTextSizes.headline.xsmall),
+		small: pxToRem(pxTextSizes.headline.small),
+		medium: pxToRem(pxTextSizes.headline.medium),
+		large: pxToRem(pxTextSizes.headline.large),
+		xlarge: pxToRem(pxTextSizes.headline.xlarge),
 	},
 	titlepiece: {
-		small: pxToRem(42),
-		medium: pxToRem(50),
-		large: pxToRem(70),
+		small: pxToRem(pxTextSizes.titlepiece.small),
+		medium: pxToRem(pxTextSizes.titlepiece.medium),
+		large: pxToRem(pxTextSizes.titlepiece.large),
 	},
 } as const;
 

--- a/packages/@guardian/source-foundations/src/typography/data.ts
+++ b/packages/@guardian/source-foundations/src/typography/data.ts
@@ -3,8 +3,8 @@ import { pxToRem } from '../utils/px-to-rem';
 /**
  * Pixel size values for each font that we use in the design system.
  *
- * These fit the following px size scale:
- * [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70]
+ * We assert that the values match those we expect in our
+ * {@link [unit test suite](./typography.test.ts)}.
  */
 export const pxTextSizes = {
 	textSans: {
@@ -41,6 +41,9 @@ export const pxTextSizes = {
 /**
  * Relative font sizes, calculated from the pixel sizes above;
  * using the pxToRem method.
+ *
+ * We assert that the computed rem values match the expected values
+ * in our {@link [unit test suite](./typography.test.ts)}.
  *
  * See {@link [pxToRem](../utils/px-to-rem.ts)} for more details.
  */

--- a/packages/@guardian/source-foundations/src/typography/fs.ts
+++ b/packages/@guardian/source-foundations/src/typography/fs.ts
@@ -1,15 +1,9 @@
 import {
-	bodySizes,
 	fonts,
 	fontWeights,
-	headlineSizes,
 	lineHeights,
-	remBodySizes,
-	remHeadlineSizes,
-	remTextSansSizes,
-	remTitlepieceSizes,
-	textSansSizes,
-	titlepieceSizes,
+	pxTextSizes,
+	remTextSizes,
 	underlineThickness,
 } from './data';
 import type {
@@ -19,20 +13,6 @@ import type {
 	Fs,
 	Option,
 } from './types';
-
-const fontSizes = {
-	titlepiece: titlepieceSizes,
-	headline: headlineSizes,
-	body: bodySizes,
-	textSans: textSansSizes,
-} as const;
-
-const remFontSizes = {
-	titlepiece: remTitlepieceSizes,
-	headline: remHeadlineSizes,
-	body: remBodySizes,
-	textSans: remTextSansSizes,
-} as const;
 
 export const availableFonts = {
 	titlepiece: {
@@ -90,14 +70,13 @@ export const fs: Fs =
 		const fontFamilyValue = fonts[category];
 		const fontSizeValue: `${number}rem` | number =
 			unit === 'px'
-				? Number(fontSizes[category][level])
-				: // @ts-expect-error -- the types actually overlap, see https://gist.github.com/mxdvl/5e31fd5b13670b6a41ddac6c65efeee4
-				  `${Number(remFontSizes[category][level])}rem`;
+				? Number(pxTextSizes[category][level])
+				: `${Number(remTextSizes[category][level])}rem`;
 		const lineHeightValue: `${number}px` | number =
 			unit === 'px'
 				? // line-height is defined as a unitless value, so we multiply
 				  // by the element's font-size in px to get the px value
-				  `${lineHeights[lineHeight] * Number(fontSizes[category][level])}px`
+				  `${lineHeights[lineHeight] * Number(pxTextSizes[category][level])}px`
 				: lineHeights[lineHeight];
 		// TODO: consider logging an error in development if a requested
 		// font is unavailable
@@ -105,7 +84,6 @@ export const fs: Fs =
 		const fontWeightValue = requestedFont ? fontWeights[fontWeight] : '';
 		const fontStyleValue = getFontStyle(requestedFont, fontStyle);
 		const textDecorationThicknessValue = Number(
-			// @ts-expect-error -- the types actually overlap, see https://gist.github.com/mxdvl/5e31fd5b13670b6a41ddac6c65efeee4
 			underlineThickness[category][level],
 		);
 

--- a/packages/@guardian/source-foundations/src/typography/fs.ts
+++ b/packages/@guardian/source-foundations/src/typography/fs.ts
@@ -14,7 +14,7 @@ import type {
 	Option,
 } from './types';
 
-export const availableFonts = {
+export const availableFonts: AvailableFontsMapping = {
 	titlepiece: {
 		bold: {
 			hasItalic: false,
@@ -47,7 +47,7 @@ export const availableFonts = {
 			hasItalic: false,
 		},
 	},
-} as AvailableFontsMapping;
+};
 
 function getFontStyle(
 	font: FontWeightDefinition | undefined,

--- a/packages/@guardian/source-foundations/src/typography/fs.ts
+++ b/packages/@guardian/source-foundations/src/typography/fs.ts
@@ -1,13 +1,73 @@
 import {
-	availableFonts,
-	fontMapping,
-	fontSizeMapping,
-	fontWeightMapping,
-	lineHeightMapping,
-	remFontSizeMapping,
-	underlineThicknessMapping,
+	bodySizes,
+	fonts,
+	fontWeights,
+	headlineSizes,
+	lineHeights,
+	remBodySizes,
+	remHeadlineSizes,
+	remTextSansSizes,
+	remTitlepieceSizes,
+	textSansSizes,
+	titlepieceSizes,
+	underlineThickness,
 } from './data';
-import type { FontStyle, FontWeightDefinition, Fs, Option } from './types';
+import type {
+	AvailableFontsMapping,
+	FontStyle,
+	FontWeightDefinition,
+	Fs,
+	Option,
+} from './types';
+
+const fontSizes = {
+	titlepiece: titlepieceSizes,
+	headline: headlineSizes,
+	body: bodySizes,
+	textSans: textSansSizes,
+} as const;
+
+const remFontSizes = {
+	titlepiece: remTitlepieceSizes,
+	headline: remHeadlineSizes,
+	body: remBodySizes,
+	textSans: remTextSansSizes,
+} as const;
+
+export const availableFonts = {
+	titlepiece: {
+		bold: {
+			hasItalic: false,
+		},
+	},
+	headline: {
+		light: {
+			hasItalic: true,
+		},
+		medium: {
+			hasItalic: true,
+		},
+		bold: {
+			hasItalic: false,
+		},
+	},
+	body: {
+		regular: {
+			hasItalic: true,
+		},
+		bold: {
+			hasItalic: true,
+		},
+	},
+	textSans: {
+		regular: {
+			hasItalic: true,
+		},
+		bold: {
+			hasItalic: false,
+		},
+	},
+} as AvailableFontsMapping;
 
 function getFontStyle(
 	font: FontWeightDefinition | undefined,
@@ -27,29 +87,26 @@ function getFontStyle(
 export const fs: Fs =
 	(category) =>
 	(level, { lineHeight, fontWeight, fontStyle, unit }) => {
-		const fontFamilyValue = fontMapping[category];
+		const fontFamilyValue = fonts[category];
 		const fontSizeValue: `${number}rem` | number =
 			unit === 'px'
-				? Number(fontSizeMapping[category][level])
+				? Number(fontSizes[category][level])
 				: // @ts-expect-error -- the types actually overlap, see https://gist.github.com/mxdvl/5e31fd5b13670b6a41ddac6c65efeee4
-				  `${Number(remFontSizeMapping[category][level])}rem`;
+				  `${Number(remFontSizes[category][level])}rem`;
 		const lineHeightValue: `${number}px` | number =
 			unit === 'px'
 				? // line-height is defined as a unitless value, so we multiply
 				  // by the element's font-size in px to get the px value
-				  `${
-						lineHeightMapping[lineHeight] *
-						Number(fontSizeMapping[category][level])
-				  }px`
-				: lineHeightMapping[lineHeight];
+				  `${lineHeights[lineHeight] * Number(fontSizes[category][level])}px`
+				: lineHeights[lineHeight];
 		// TODO: consider logging an error in development if a requested
 		// font is unavailable
 		const requestedFont = availableFonts[category][fontWeight];
-		const fontWeightValue = requestedFont ? fontWeightMapping[fontWeight] : '';
+		const fontWeightValue = requestedFont ? fontWeights[fontWeight] : '';
 		const fontStyleValue = getFontStyle(requestedFont, fontStyle);
 		const textDecorationThicknessValue = Number(
 			// @ts-expect-error -- the types actually overlap, see https://gist.github.com/mxdvl/5e31fd5b13670b6a41ddac6c65efeee4
-			underlineThicknessMapping[category][level],
+			underlineThickness[category][level],
 		);
 
 		return Object.assign(

--- a/packages/@guardian/source-foundations/src/typography/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/index.ts
@@ -4,31 +4,12 @@ import {
 	textSans as textSansAsObj,
 	titlepiece as titlepieceAsObj,
 } from './api';
-import {
-	bodySizes,
-	fontMapping,
-	fontWeightMapping,
-	headlineSizes,
-	lineHeightMapping,
-	remBodySizes,
-	remHeadlineSizes,
-	remTextSansSizes,
-	remTitlepieceSizes,
-	textSansSizes,
-	titlepieceSizes,
-} from './data';
 import { objectStylesToString } from './object-styles-to-string';
 import type {
 	BodySizes,
-	Category,
 	FontScaleArgs,
 	FontScaleFunctionStr,
-	FontStyle,
-	FontWeight,
-	FontWeightDefinition,
 	HeadlineSizes,
-	LineHeight,
-	ScaleUnit,
 	TextSansSizes,
 	TitlepieceSizes,
 } from './types';
@@ -45,7 +26,7 @@ type TypographyApi<Sizes> = {
  * font-family: 'GT Guardian Titlepiece';
  * ```
  */
-const titlepiece: TypographyApi<TitlepieceSizes> = {
+export const titlepiece: TypographyApi<TitlepieceSizes> = {
 	small: (options?: FontScaleArgs) =>
 		objectStylesToString(titlepieceAsObj.small(options)),
 	medium: (options?: FontScaleArgs) =>
@@ -62,7 +43,7 @@ const titlepiece: TypographyApi<TitlepieceSizes> = {
  * font-family: 'GH Guardian Headline';
  * ```
  */
-const headline: TypographyApi<HeadlineSizes> = {
+export const headline: TypographyApi<HeadlineSizes> = {
 	xxxsmall: (options?: FontScaleArgs) =>
 		objectStylesToString(headlineAsObj.xxxsmall(options)),
 	xxsmall: (options?: FontScaleArgs) =>
@@ -87,7 +68,7 @@ const headline: TypographyApi<HeadlineSizes> = {
  * font-family: 'GuardianTextEgyptian';
  * ```
  */
-const body: TypographyApi<BodySizes> = {
+export const body: TypographyApi<BodySizes> = {
 	xsmall: (options?: FontScaleArgs) =>
 		objectStylesToString(bodyAsObj.small(options)),
 	small: (options?: FontScaleArgs) =>
@@ -104,7 +85,7 @@ const body: TypographyApi<BodySizes> = {
  * font-family: 'GuardianTextSans';
  * ```
  */
-const textSans: TypographyApi<TextSansSizes> = {
+export const textSans: TypographyApi<TextSansSizes> = {
 	xxsmall: (options?: FontScaleArgs) =>
 		objectStylesToString(textSansAsObj.xxsmall(options)),
 	xsmall: (options?: FontScaleArgs) =>
@@ -124,22 +105,18 @@ const textSans: TypographyApi<TextSansSizes> = {
 };
 
 export {
-	titlepiece,
-	headline,
-	body,
-	textSans,
-	titlepieceSizes,
-	headlineSizes,
 	bodySizes,
-	textSansSizes,
-	remTitlepieceSizes,
-	remHeadlineSizes,
+	headlineSizes,
 	remBodySizes,
+	remHeadlineSizes,
 	remTextSansSizes,
-	fontMapping,
-	fontWeightMapping,
-	lineHeightMapping,
-};
+	remTitlepieceSizes,
+	textSansSizes,
+	titlepieceSizes,
+	fonts,
+	lineHeights,
+	fontWeights,
+} from './data';
 
 export type {
 	ScaleUnit,
@@ -148,4 +125,4 @@ export type {
 	FontWeight,
 	FontStyle,
 	FontWeightDefinition,
-};
+} from './types';

--- a/packages/@guardian/source-foundations/src/typography/obj/index.ts
+++ b/packages/@guardian/source-foundations/src/typography/obj/index.ts
@@ -1,10 +1,10 @@
 import { body, headline, textSans, titlepiece } from '../api';
 import {
 	bodySizes,
-	fontMapping,
-	fontWeightMapping,
+	fonts,
+	fontWeights,
 	headlineSizes,
-	lineHeightMapping,
+	lineHeights,
 	remBodySizes,
 	remHeadlineSizes,
 	remTextSansSizes,
@@ -26,7 +26,7 @@ export {
 	remHeadlineSizes,
 	remBodySizes,
 	remTextSansSizes,
-	fontMapping as fonts,
-	fontWeightMapping as fontWeights,
-	lineHeightMapping as lineHeights,
+	fonts,
+	fontWeights,
+	lineHeights,
 };

--- a/packages/@guardian/source-foundations/src/typography/types.ts
+++ b/packages/@guardian/source-foundations/src/typography/types.ts
@@ -3,6 +3,10 @@ import type {
 	fontWeights,
 	headlineSizes,
 	lineHeights,
+	remBodySizes,
+	remHeadlineSizes,
+	remTextSansSizes,
+	remTitlepieceSizes,
 	textSansSizes,
 	titlepieceSizes,
 } from './data';
@@ -28,10 +32,12 @@ export type TypographySizes = {
 	[key in string]: number;
 };
 
-export type TitlepieceSizes = typeof titlepieceSizes;
-export type HeadlineSizes = typeof headlineSizes;
-export type BodySizes = typeof bodySizes;
-export type TextSansSizes = typeof textSansSizes;
+export type TitlepieceSizes =
+	| typeof titlepieceSizes
+	| typeof remTitlepieceSizes;
+export type HeadlineSizes = typeof headlineSizes | typeof remHeadlineSizes;
+export type BodySizes = typeof bodySizes | typeof remBodySizes;
+export type TextSansSizes = typeof textSansSizes | typeof remTextSansSizes;
 
 type Categories = {
 	titlepiece: TitlepieceSizes;

--- a/packages/@guardian/source-foundations/src/typography/types.ts
+++ b/packages/@guardian/source-foundations/src/typography/types.ts
@@ -1,14 +1,14 @@
 import type {
 	bodySizes,
-	fontWeightMapping,
+	fontWeights,
 	headlineSizes,
-	lineHeightMapping,
+	lineHeights,
 	textSansSizes,
 	titlepieceSizes,
 } from './data';
 
 export type ScaleUnit = 'rem' | 'px';
-export type LineHeight = keyof typeof lineHeightMapping;
+export type LineHeight = keyof typeof lineHeights;
 export type FontWeight = 'light' | 'regular' | 'medium' | 'bold';
 export type FontStyle = 'normal' | 'italic';
 export type FontWeightDefinition = { hasItalic: boolean };
@@ -18,9 +18,7 @@ export type TypographyStyles<Unit extends ScaleUnit = ScaleUnit> = {
 	fontFamily: string;
 	fontSize: Unit extends 'px' ? number : `${number}rem`;
 	lineHeight: string | number;
-	fontWeight?:
-		| typeof fontWeightMapping[keyof typeof fontWeightMapping]
-		| FontWeight;
+	fontWeight?: typeof fontWeights[keyof typeof fontWeights] | FontWeight;
 	fontStyle?: 'normal' | 'italic';
 	textDecorationThickness?: number;
 };

--- a/packages/@guardian/source-foundations/src/typography/types.ts
+++ b/packages/@guardian/source-foundations/src/typography/types.ts
@@ -44,6 +44,12 @@ type Categories = {
 
 export type Category = keyof Categories;
 
+export type AvailableFontsMapping = {
+	[cat in Category]: {
+		[fontWeight in FontWeight]?: FontWeightDefinition;
+	};
+};
+
 export type Fs = <
 	Category extends keyof Categories,
 	Level extends keyof Categories[Category],

--- a/packages/@guardian/source-foundations/src/typography/typography.test.ts
+++ b/packages/@guardian/source-foundations/src/typography/typography.test.ts
@@ -1,3 +1,5 @@
+import { rootPixelFontSize } from '../utils/px-to-rem';
+import { pxTextSizes, remTextSizes } from './data';
 import {
 	fonts,
 	fontWeights,
@@ -83,4 +85,43 @@ it('should not include italic font style if it is not available for requested fo
 
 	expect(mediumHeadlineStyles).not.toContain('font-style: italic;');
 	expect(largeHeadlineStyles).not.toContain('font-style: italic;');
+});
+
+describe('Validate that the font size px and rem values match those expected for each entry in the scale', () => {
+	const sizes = [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70] as const;
+	const names = [
+		'xxxsmall',
+		'xxsmall',
+		'xsmall',
+		'small',
+		'medium',
+		'large',
+		'xlarge',
+		'xxlarge',
+		'xxxlarge',
+	] as const;
+
+	it.each(Object.entries(pxTextSizes))(
+		'pxTextSizes has valid values for %s',
+		(key, value) => {
+			expect(typeof key).toBe('string');
+			for (const [name, size] of Object.entries(value)) {
+				expect(names).toContain(name);
+				expect(sizes).toContain(size);
+			}
+		},
+	);
+
+	it.each(Object.entries(remTextSizes))(
+		'remTextSizes has valid values for %s',
+		(key, value) => {
+			expect(typeof key).toBe('string');
+			for (const [name, remSize] of Object.entries(value)) {
+				// @ts-expect-error -- we’re testing
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- we’re testing
+				const pxSize: number = pxTextSizes[key][name] ?? -1;
+				expect(remSize).toBeCloseTo(pxSize / rootPixelFontSize, 6);
+			}
+		},
+	);
 });

--- a/packages/@guardian/source-foundations/src/typography/typography.test.ts
+++ b/packages/@guardian/source-foundations/src/typography/typography.test.ts
@@ -1,9 +1,9 @@
 import {
-	fontMapping as fonts,
-	fontWeightMapping as fontWeights,
+	fonts,
+	fontWeights,
 	headline,
 	headlineSizes,
-	lineHeightMapping as lineHeights,
+	lineHeights,
 	remHeadlineSizes,
 } from '.';
 


### PR DESCRIPTION
## What is the purpose of this change?

We'd like to simplify the internals of our Typography infrastructure as it has been noted over time that it's becoming quite difficult for developers unfamiliar with the codebase to make modifications and, more generally, to understand what is going on. 

Before beginning this work, we spent some time digging into the reasons *why* developers might find it difficult to approach this part of our codebase and whittled it down to a few key areas that this sequence of changes aims to address.

This pull request covers the following subset of these areas:

* A level of indirection exists in our typography theme token definitions; making it hard to quickly find the value required because of a mapping from each value to an array containing the scale.
  - The file also seemed large with some unnecessary abstractions and comments describing the mapping instead of it being described statically in our code.
* We noticed that in some areas, the code could be better documented, both in terms of doc comments and self documentation

We plan to follow this PR with some further changes to how we internally compute and define the final font styles (specifically focusing on the `fs` method of legend and looking at how to simplify the distinction between `api.ts` and `index.ts` where the same font style object is exposed as a string and as an object).

## What does this change?

The set of changes captured in this PR seek to address the items raised in the list above.

### Flattening of the token data structure 

Each group of design tokens (fontWeights, lineHeights, textSizes, etc...) was defined as a two-level mapping; with a lookup pulling each value from an array of every possible value in the given scale.

To illustrate with an example. A lot of our mappings looked like this:

```ts
const fontSizes = [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70] as const;

const titlepieceSizes = {
	small: fontSizes[8], //42px
	medium: fontSizes[9], //50px
	large: fontSizes[10], //70px
} as const;
```

We noticed that we've introduced a potentially confusing of abstraction here. Over time as the file grew, more font definitions were added, creating a scenario in which developers were not able to easily determine what the value for each of the size aliases was without an adjacent comment in place to stop the necessity to continually scroll back up to refer back to the `fontSizes` scale.

This mapping is liable to easily fall out of date over time and potentially cause real confusion due to simple human error, because we have no way of checking to see if the comments are correct.

To address this, we instead take the step of concretely defining the values for each size alias at the point of defining the mapping. The benefit of this approach is that the values are kept in the same place as the alias at the point of definition, reducing mental load on the developer when they need to understand/modify an element of the file.

A downside of this approach is that we lose our tight adherence to a well defined scale, as the `fontSizes` array ceases to exist. This can be remedied in the future at the level of our type checker, ensuring that any values entered into the data structure are valid and belong to the scale as defined in our design system.

### Reorganisation of objects and their exports

- Some objects were exported in a way which didn't allow us to see the references to them. We change the way we export some objects so that, in the editor, we can get a clearer picture of the use of each object.
- The mapping objects: `fontSizes`, `remFontSizes` and `availableFonts` were only used by `fs.ts` and have been moved into this file. 
- The type `AvailableFontsMapping` was moved to `types.ts`
- Three exported references to "mapping" were renamed to: `fonts`, `fontWeights`, and `lineHeights` now that the mapping relation has been removed in favour of defining the values as constants.
