### PR TITLE
Downgrade the changelog for #1489 from 'major' to a 'patch'

### DIFF
--- a/.changeset/wild-carrots-draw.md
+++ b/.changeset/wild-carrots-draw.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/source-react-components': major
+'@guardian/source-react-components': patch
 ---
 
 Bump dev dependencies


### PR DESCRIPTION
## What is the purpose of this change?
#1489 was mistakenly merged with a `major` bump. This PR changes that to a `patch` so the changes can be released properly.