### PR TITLE
Release package updates

### DIFF
--- a/.changeset/clean-kings-judge.md
+++ b/.changeset/clean-kings-judge.md
@@ -1,5 +1,0 @@
----
-'@guardian/source-react-components-development-kitchen': patch
----
-
-noop to test release - you can ignore this

--- a/packages/@guardian/source-react-components-development-kitchen/CHANGELOG.md
+++ b/packages/@guardian/source-react-components-development-kitchen/CHANGELOG.md
@@ -1,63 +1,69 @@
 # @guardian/source-react-components-development-kitchen
 
+## 3.1.6
+
+### Patch Changes
+
+-   e45b80b1: noop to test release - you can ignore this
+
 ## 3.1.5
 
 ### Patch Changes
 
-- e6d86ab6: noop to test release again - you can ignore this release
+-   e6d86ab6: noop to test release again - you can ignore this release
 
 ## 3.1.4
 
 ### Patch Changes
 
-- f4522bd4: noop to test release again - you can ignore this release
+-   f4522bd4: noop to test release again - you can ignore this release
 
 ## 3.1.3
 
 ### Patch Changes
 
-- e3a3c742: noop to test releases – you can ignore this version
+-   e3a3c742: noop to test releases – you can ignore this version
 
 ## 3.1.2
 
 ### Patch Changes
 
-- 6ff6fede: noop to test pipeline - ignore this release
+-   6ff6fede: noop to test pipeline - ignore this release
 
 ## 3.1.1
 
 ### Patch Changes
 
-- 430276ce: Noop to test release pipeline
+-   430276ce: Noop to test release pipeline
 
 ## 3.1.0
 
 ### Minor Changes
 
-- c7afdedb: add FooterWithContents and FooterLinks components
+-   c7afdedb: add FooterWithContents and FooterLinks components
 
 ## 3.0.0
 
 ### Patch Changes
 
-- Updated dependencies [12a9fce5]
-- Updated dependencies [8e8535ba]
-  - @guardian/source-react-components@7.0.0
+-   Updated dependencies [12a9fce5]
+-   Updated dependencies [8e8535ba]
+    -   @guardian/source-react-components@7.0.0
 
 ## 2.0.0
 
 ### Patch Changes
 
-- Updated dependencies [07bfaf1b]
-- Updated dependencies [78ff24be]
-- Updated dependencies [fd69cf60]
-  - @guardian/source-react-components@6.0.0
+-   Updated dependencies [07bfaf1b]
+-   Updated dependencies [78ff24be]
+-   Updated dependencies [fd69cf60]
+    -   @guardian/source-react-components@6.0.0
 
 ## 1.0.1
 
 ### Patch Changes
 
-- 32ca5c1e: Add tooltip to ToggleSwitch
+-   32ca5c1e: Add tooltip to ToggleSwitch
 
 ## 1.0.0
 
@@ -67,67 +73,67 @@ So to accompany the major version releases to its peer deps, the dev kitchen is 
 
 ### Patch Changes
 
-- Updated dependencies [b87baf5c]
-- Updated dependencies [94a6de68]
-- Updated dependencies [1e129d0b]
-- Updated dependencies [d55bc4b6]
-- Updated dependencies [ef458f83]
-- Updated dependencies [8bd1adce]
-- Updated dependencies [a5a14a49]
-- Updated dependencies [51f8737e]
-- Updated dependencies [f6865ac5]
-- Updated dependencies [c37e5be9]
-- Updated dependencies [34ec716d]
-  - @guardian/source-foundations@5.0.0
-  - @guardian/source-react-components@5.0.0
+-   Updated dependencies [b87baf5c]
+-   Updated dependencies [94a6de68]
+-   Updated dependencies [1e129d0b]
+-   Updated dependencies [d55bc4b6]
+-   Updated dependencies [ef458f83]
+-   Updated dependencies [8bd1adce]
+-   Updated dependencies [a5a14a49]
+-   Updated dependencies [51f8737e]
+-   Updated dependencies [f6865ac5]
+-   Updated dependencies [c37e5be9]
+-   Updated dependencies [34ec716d]
+    -   @guardian/source-foundations@5.0.0
+    -   @guardian/source-react-components@5.0.0
 
 ## 0.0.36
 
 ### Patch Changes
 
-- 0dc5d08e: Empty release to test release process
+-   0dc5d08e: Empty release to test release process
 
 ## 0.0.35
 
 ### Patch Changes
 
-- 56471081: Use an SVG to render straight lines, too.
-- 96510c75: StarRating uses pure SVG instead of a background-image.
-- 56471081: Drop the background-image repeating css rules in favour of pure SVG patterns that can fill up to our largest breakpoint of 1300px.
+-   56471081: Use an SVG to render straight lines, too.
+-   96510c75: StarRating uses pure SVG instead of a background-image.
+-   56471081: Drop the background-image repeating css rules in favour of pure SVG patterns that can fill up to our largest breakpoint of 1300px.
 
 ## 0.0.34
 
 ### Patch Changes
 
-- 0e938355: Add optional id prop on ToggleSwitch
-- 742bd7c2: Add optional LabelPosition prop to Toggle Switch
+-   0e938355: Add optional id prop on ToggleSwitch
+-   742bd7c2: Add optional LabelPosition prop to Toggle Switch
 
 ## 0.0.33
 
 ### Patch Changes
 
-- 7fbe272a: Remove margin from ToggleSwitch component
+-   7fbe272a: Remove margin from ToggleSwitch component
 
 ## 0.0.32
 
 ### Patch Changes
 
-- 45d4d8df: React minimum version is 17.0.1 (instead of 17.0.0)
-- 71148ecf: Stop publishing packages as single files, so they can be properly tree-shaken.
-- 5935b4fe: Fixes styling on toggle switch and adds clickable label
-- Updated dependencies [45d4d8df]
-- Updated dependencies [71148ecf]
-  - @guardian/source-react-components@4.0.2
-  - @guardian/source-foundations@4.0.3
+-   45d4d8df: React minimum version is 17.0.1 (instead of 17.0.0)
+-   71148ecf: Stop publishing packages as single files, so they can be properly tree-shaken.
+-   5935b4fe: Fixes styling on toggle switch and adds clickable label
+-   Updated dependencies [45d4d8df]
+-   Updated dependencies [71148ecf]
+    -   @guardian/source-react-components@4.0.2
+    -   @guardian/source-foundations@4.0.3
 
 ## 0.0.31
 
 ### Patch Changes
 
-- 29b6a907: No-op to test changesets again
+-   29b6a907: No-op to test changesets again
 
 ## 0.0.30
 
 ### Patch Changes
 
-- c0967fb6: No-op to test changesets
+-   c0967fb6: No-op to test changesets

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/source-react-components-development-kitchen",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
This PR was opened by @sndrs. When you're ready to do a release, you can merge this and the packages will be published to npm automatically. If you're not ready to do a release yet, that's fine, whenever you add more changesets to main, this PR will be updated.


# Releases
## @guardian/source-react-components-development-kitchen@3.1.6

### Patch Changes

-   e45b80b1: noop to test release - you can ignore this
