### PR TITLE
Make BackToTop an explicit export from source-react-components

### DIFF
--- a/.changeset/honest-cougars-leave.md
+++ b/.changeset/honest-cougars-leave.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-react-components': minor
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+make BackToTop an explicit export of source-react-components so it can be used in the FooterWithContents dev kitchen component

--- a/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/footer-with-contents/FooterWithContents.tsx
@@ -1,7 +1,6 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { brand } from '@guardian/source-foundations';
-import { Container } from '@guardian/source-react-components';
-import { BackToTop } from '@guardian/source-react-components/src/footer/BackToTop';
+import { BackToTop, Container } from '@guardian/source-react-components';
 import type { ReactNode } from 'react';
 import {
 	backToTopStyles,

--- a/packages/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
+++ b/packages/@guardian/source-react-components/src/footer/BackToTop.stories.tsx
@@ -1,0 +1,19 @@
+import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
+import {
+	asChromaticStory,
+	asPlayground,
+} from '../../../../../lib/story-intents';
+import { BackToTop } from './BackToTop';
+
+export default {
+	component: BackToTop,
+	title: 'Packages/source-react-components/BackToTop',
+};
+
+const Template: Story = () => BackToTop;
+
+export const Playground = Template.bind({});
+asPlayground(Playground);
+
+export const Default = Template.bind({});
+asChromaticStory(Default);

--- a/packages/@guardian/source-react-components/src/index.test.ts
+++ b/packages/@guardian/source-react-components/src/index.test.ts
@@ -50,6 +50,7 @@ it('Should have exactly these exports', () => {
 	expect(Object.keys(pkgExports).sort()).toEqual([
 		'Accordion',
 		'AccordionRow',
+		'BackToTop',
 		'Button',
 		'ButtonLink',
 		'Checkbox',

--- a/packages/@guardian/source-react-components/src/index.ts
+++ b/packages/@guardian/source-react-components/src/index.ts
@@ -60,6 +60,7 @@ export type { ChoiceCardProps } from './choice-card/ChoiceCard';
 export { choiceCardThemeDefault } from './choice-card/theme';
 
 export { Footer } from './footer/Footer';
+export { BackToTop } from './footer/BackToTop';
 export type { FooterProps } from './footer/Footer';
 export { footerThemeBrand } from './footer/theme';
 


### PR DESCRIPTION
## What is the purpose of this change?

This fixes an issue with importing the `BackToTop` component in the dev kitchen `FooterWithContents` component.

## What does this change?

-   Make `BackToTop` an explicit export of `@guardian/source-react-components`
-   Import it directly from the package in `FooterWithContents`
