### PR TITLE
Experiment with turning off `noCi` to see if gh actions are still disabled for the bot PR

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,6 +5,7 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "skipCI": false,
   "updateInternalDependencies": "patch",
   "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {


### PR DESCRIPTION
Experiment with turning off `noCi` to see if gh actions are still disabled for the bot PR