### PR TITLE
Lock typographic scales

### DIFF
--- a/packages/@guardian/source-foundations/src/typography/typography.test.ts
+++ b/packages/@guardian/source-foundations/src/typography/typography.test.ts
@@ -1,3 +1,5 @@
+import { rootPixelFontSize } from '../utils/px-to-rem';
+import { pxTextSizes, remTextSizes } from './data';
 import {
 	fonts,
 	fontWeights,
@@ -83,4 +85,43 @@ it('should not include italic font style if it is not available for requested fo
 
 	expect(mediumHeadlineStyles).not.toContain('font-style: italic;');
 	expect(largeHeadlineStyles).not.toContain('font-style: italic;');
+});
+
+describe('Validate data', () => {
+	const sizes = [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70] as const;
+	const names = [
+		'xxxsmall',
+		'xxsmall',
+		'xsmall',
+		'small',
+		'medium',
+		'large',
+		'xlarge',
+		'xxlarge',
+		'xxxlarge',
+	] as const;
+
+	it.each(Object.entries(pxTextSizes))(
+		'pxTextSizes has valid values for %s',
+		(key, value) => {
+			expect(typeof key).toBe('string');
+			for (const [name, size] of Object.entries(value)) {
+				expect(names).toContain(name);
+				expect(sizes).toContain(size);
+			}
+		},
+	);
+
+	it.each(Object.entries(remTextSizes))(
+		'remTextSizes has valid values for %s',
+		(key, value) => {
+			expect(typeof key).toBe('string');
+			for (const [name, remSize] of Object.entries(value)) {
+				// @ts-expect-error -- we’re testing
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- we’re testing
+				const pxSize: number = pxTextSizes[key][name] ?? -1;
+				expect(remSize).toBeCloseTo(pxSize / rootPixelFontSize, 6);
+			}
+		},
+	);
 });

--- a/packages/@guardian/source-foundations/src/typography/typography.test.ts
+++ b/packages/@guardian/source-foundations/src/typography/typography.test.ts
@@ -87,7 +87,7 @@ it('should not include italic font style if it is not available for requested fo
 	expect(largeHeadlineStyles).not.toContain('font-style: italic;');
 });
 
-describe('Validate data', () => {
+describe('Validate that the font size px and rem values match those expected for each entry in the scale', () => {
 	const sizes = [12, 14, 15, 17, 20, 24, 28, 34, 42, 50, 70] as const;
 	const names = [
 		'xxxsmall',


### PR DESCRIPTION
## What is the purpose of this change?

Ensure `px` and `rem` scales don’t shift.

## What does this change?

- Add a test to make sure we use expected pixel values.
- Add a test to make sure the `rem` match perfectly.