### PR TITLE
Revert "Make `textSans` default line-height "regular""

### DIFF
--- a/.changeset/cool-deers-chew.md
+++ b/.changeset/cool-deers-chew.md
@@ -1,9 +1,0 @@
----
-'@guardian/eslint-plugin-source-foundations': major
-'@guardian/eslint-plugin-source-react-components': major
-'@guardian/source-foundations': major
-'@guardian/source-react-components': major
-'@guardian/source-react-components-development-kitchen': major
----
-
-Set default textSans line height to 'regular', there should be no change to Source components but any consumers using textSans should expect a default line height of 1.35 rather than 1.5

--- a/packages/@guardian/source-foundations/src/typography/api.ts
+++ b/packages/@guardian/source-foundations/src/typography/api.ts
@@ -83,7 +83,7 @@ type TextSansFunctions = {
 };
 
 const textSansDefaults = {
-	lineHeight: 'regular',
+	lineHeight: 'loose',
 	fontWeight: 'regular',
 	fontStyle: null,
 	unit: 'rem',

--- a/packages/@guardian/source-react-components-development-kitchen/src/summary/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/summary/styles.ts
@@ -24,10 +24,7 @@ export const messageStyles = (
 	color: string,
 	isBold = true,
 ): SerializedStyles => css`
-	${textSans.medium({
-		fontWeight: isBold ? 'bold' : 'regular',
-		lineHeight: 'loose',
-	})};
+	${textSans.medium({ fontWeight: isBold ? 'bold' : 'regular' })}
 	color: ${color};
 `;
 

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -111,7 +111,7 @@ const fontSpacingVerticalOffset = css`
 `;
 
 const defaultSize = css`
-	${textSans.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
+	${textSans.medium({ fontWeight: 'bold' })};
 	height: ${height.ctaMedium}px;
 	min-height: ${height.ctaMedium}px;
 	padding: 0 ${space[5]}px;
@@ -120,7 +120,7 @@ const defaultSize = css`
 `;
 
 const smallSize = css`
-	${textSans.medium({ fontWeight: 'bold', lineHeight: 'loose' })};
+	${textSans.medium({ fontWeight: 'bold' })};
 	height: ${height.ctaSmall}px;
 	min-height: ${height.ctaSmall}px;
 	padding: 0 ${space[4]}px;
@@ -129,7 +129,7 @@ const smallSize = css`
 `;
 
 const xsmallSize = css`
-	${textSans.small({ fontWeight: 'bold', lineHeight: 'loose' })};
+	${textSans.small({ fontWeight: 'bold' })};
 	height: ${height.ctaXsmall}px;
 	min-height: ${height.ctaXsmall}px;
 	padding: 0 ${space[3]}px;

--- a/packages/@guardian/source-react-components/src/checkbox/styles.ts
+++ b/packages/@guardian/source-react-components/src/checkbox/styles.ts
@@ -84,7 +84,7 @@ export const checkbox = (
 				color: ${checkbox.textIndeterminate};
 				content: '-';
 				position: absolute;
-				top: -${space[2]}px;
+				top: -10px;
 				left: 5px;
 				z-index: 5;
 			}
@@ -95,19 +95,19 @@ export const checkbox = (
 export const labelText = (
 	checkbox = checkboxThemeDefault.checkbox,
 ): SerializedStyles => css`
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: 'regular' })};
 	color: ${checkbox.textLabel};
 	width: 100%;
 `;
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: 'regular' })};
 `;
 
 export const supportingText = (
 	checkbox = checkboxThemeDefault.checkbox,
 ): SerializedStyles => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: 'regular' })};
 	color: ${checkbox.textLabelSupporting};
 `;
 

--- a/packages/@guardian/source-react-components/src/choice-card/styles.ts
+++ b/packages/@guardian/source-react-components/src/choice-card/styles.ts
@@ -173,7 +173,7 @@ export const contentWrapper = css`
 	}
 
 	& > * {
-		${textSans.medium({ fontWeight: 'bold' })};
+		${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
 		text-align: center;
 	}
 

--- a/packages/@guardian/source-react-components/src/label/styles.ts
+++ b/packages/@guardian/source-react-components/src/label/styles.ts
@@ -10,14 +10,14 @@ export const legend = css`
 export const labelText = (
 	label = labelThemeDefault.label,
 ): SerializedStyles => css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
 	color: ${label.textLabel};
 `;
 
 export const optionalText = (
 	label = labelThemeDefault.label,
 ): SerializedStyles => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: 'regular' })};
 	color: ${label.textOptional};
 	font-style: italic;
 `;
@@ -25,7 +25,7 @@ export const optionalText = (
 export const supportingText = (
 	label = labelThemeDefault.label,
 ): SerializedStyles => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: 'regular' })};
 	color: ${label.textSupporting};
 	margin: 2px 0 0;
 `;

--- a/packages/@guardian/source-react-components/src/radio/styles.ts
+++ b/packages/@guardian/source-react-components/src/radio/styles.ts
@@ -107,18 +107,18 @@ export const radio = (radio = radioThemeDefault.radio): SerializedStyles => css`
 export const labelText = (
 	radio = radioThemeDefault.radio,
 ): SerializedStyles => css`
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: 'regular' })};
 	color: ${radio.textLabel};
 	width: 100%;
 `;
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium({ fontWeight: 'bold' })};
+	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
 `;
 
 export const supportingText = (
 	radio = radioThemeDefault.radio,
 ): SerializedStyles => css`
-	${textSans.small()};
+	${textSans.small({ lineHeight: 'regular' })};
 	color: ${radio.textLabelSupporting};
 `;

--- a/packages/@guardian/source-react-components/src/select/styles.ts
+++ b/packages/@guardian/source-react-components/src/select/styles.ts
@@ -71,7 +71,7 @@ export const select = (select = selectThemeDefault.select): SerializedStyles =>
 		box-sizing: border-box;
 		height: ${height.inputMedium}px;
 		width: 100%;
-		${textSans.medium()};
+		${textSans.medium({ lineHeight: 'regular' })};
 		background-color: ${select.backgroundInput};
 		border: 2px solid ${select.border};
 		padding-left: ${space[2]}px;

--- a/packages/@guardian/source-react-components/src/text-area/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-area/styles.ts
@@ -30,7 +30,7 @@ export const successInput = css`
 export const textArea = css`
 	${resets.input};
 	box-sizing: border-box;
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: 'regular' })};
 	color: ${palette.neutral[7]};
 	background-color: ${palette.neutral[100]};
 	border: 2px solid ${palette.neutral[46]};

--- a/packages/@guardian/source-react-components/src/text-input/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-input/styles.ts
@@ -40,7 +40,7 @@ export const textInput = (
 		${resets.input};
 		box-sizing: border-box;
 		height: ${height.inputMedium}px;
-		${textSans.medium()};
+		${textSans.medium({ lineHeight: 'regular' })};
 		color: ${textInput.textUserInput};
 		background-color: ${textInput.backgroundInput};
 		border: 2px solid ${textInput.border};

--- a/packages/@guardian/source-react-components/src/user-feedback/styles.ts
+++ b/packages/@guardian/source-react-components/src/user-feedback/styles.ts
@@ -6,7 +6,7 @@ import { userFeedbackThemeDefault } from './theme';
 const inlineMessage = css`
 	display: flex;
 	align-items: flex-start;
-	${textSans.medium()};
+	${textSans.medium({ lineHeight: 'regular' })};
 
 	svg {
 		fill: currentColor;


### PR DESCRIPTION
@mxdvl flagged that the line height changes to text sans could break accessibility guidelines, we're checking with DAC and rolling this back in the meantime. 

Reverts guardian/source#1531