### PR TITLE
Apply visually hidden css rules recommended by the DAC 

### DIFF
--- a/.changeset/tidy-suits-pay.md
+++ b/.changeset/tidy-suits-pay.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/source-foundations': minor
+'@guardian/source-foundations': major
 ---
 
 - change the visually hidden CSS to conform to the DAC standard. **Note:** this may cause changes to your layout, please ensure that it is not affected after updating to this version

--- a/.changeset/tidy-suits-pay.md
+++ b/.changeset/tidy-suits-pay.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': minor
+---
+
+- change the visually hidden CSS to conform to the DAC standard. **Note:** this may cause changes to your layout, please ensure that it is not affected after updating to this version

--- a/packages/@guardian/source-foundations/src/accessibility/visually-hidden.ts
+++ b/packages/@guardian/source-foundations/src/accessibility/visually-hidden.ts
@@ -2,18 +2,21 @@
  * [Storybook](https://guardian.github.io/source/?path=/docs/packages-source-foundations-visuallyhidden--page)
  *
  * CSS rules that hide something from sight while still being available to screen readers.
+ *
+ * @see https://webaim.org/techniques/css/invisiblecontent/
+ * @see https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+ * @see https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
  */
-
 export const visuallyHidden = `
 	position: absolute !important;
-	overflow: hidden !important;
-	white-space: nowrap !important;
-	width: 1px !important;
-	height: 1px !important;
-	margin: -1px !important;
-	padding: 0 !important;
+	overflow: hidden !important; /* gets rid of horizontal scrollbar that appears in some circumstances */
+	white-space: nowrap !important; /* The white-space property forces the content to render on one line. */
+	width: 1px !important;  /* ensures content is announced by VoiceOver. */
+	height: 1px !important; /* ensures content is announced by VoiceOver. */
+	margin: -1px !important; /* hide or clip content that does not fit into a 1-pixel visible area. */
+	padding: 0 !important; /* hide or clip content that does not fit into a 1-pixel visible area. */
 	border: 0 !important;
-	clip: rect(1px, 1px, 1px, 1px) !important;
-	-webkit-clip-path: inset(50%) !important;
-	clip-path: inset(50%) !important;
+	clip: rect(1px, 1px, 1px, 1px) !important; /* clip removes any visible trace of the element */
+	-webkit-clip-path: inset(50%) !important; /* clip removes any visible trace of the element */
+	clip-path: inset(50%) !important; /* clip removes any visible trace of the element */
 `;

--- a/packages/@guardian/source-foundations/src/accessibility/visually-hidden.ts
+++ b/packages/@guardian/source-foundations/src/accessibility/visually-hidden.ts
@@ -5,10 +5,15 @@
  */
 
 export const visuallyHidden = `
-	position: absolute;
-	opacity: 0;
-	height: 0;
-	width: 0;
-	top: 0;
-	left: 0;
+	position: absolute !important;
+	overflow: hidden !important;
+	white-space: nowrap !important;
+	width: 1px !important;
+	height: 1px !important;
+	margin: -1px !important;
+	padding: 0 !important;
+	border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	-webkit-clip-path: inset(50%) !important;
+	clip-path: inset(50%) !important;
 `;


### PR DESCRIPTION
## What is the purpose of this change?

Modernise our visually hidden rules so that they follow DAC recommendations.

What is the purpose of the class?

> Smushes, clips, de-flows and hides content so that it is only perceptible to assistive technology like a screen reader [^1]

An annotated version of the CSS rules, explaining why they are there (thanks @SiAdcock for providing some of the context around these!):

[^1]: https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe#:~:text=Basically%2C%20the%20technique%20smushes%2C%20clips,technology%20like%20a%20screen%20reader.

```css
	position: absolute !important;
	overflow: hidden !important; /* gets rid of horizontal scrollbar that appears in some circumstances */
	white-space: nowrap !important; /* The white-space property forces the content to render on one line. */
	width: 1px !important;  /* ensures content is announced by VoiceOver. */
	height: 1px !important; /* ensures content is announced by VoiceOver. */
	margin: -1px !important; /* hide or clip content that does not fit into a 1-pixel visible area. */
	padding: 0 !important; /* hide or clip content that does not fit into a 1-pixel visible area. */
	border: 0 !important;
	clip: rect(1px, 1px, 1px, 1px) !important; /* clip removes any visible trace of the element */
	-webkit-clip-path: inset(50%) !important; /* clip removes any visible trace of the element */
	clip-path: inset(50%) !important; /* clip removes any visible trace of the element */
```