### PR TITLE
Remove two deprecated colours from our palette

### DIFF
--- a/.changeset/wise-ears-repair.md
+++ b/.changeset/wise-ears-repair.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-foundations': major
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Removes two deprecated colours: `culture.350` and `opinion.300`. To fix, please change each to use `culture.400` and `opinion.400`, these represent the same hex codes.

--- a/packages/@guardian/source-foundations/src/colour/palette.tsx
+++ b/packages/@guardian/source-foundations/src/colour/palette.tsx
@@ -153,7 +153,6 @@ export const palette = {
 	opinion: {
 		100: colors.oranges[0],
 		200: colors.oranges[1],
-		300: colors.oranges[2], // deprecated, use opinion[400]
 		400: colors.oranges[2],
 		450: colors.oranges[3],
 		500: colors.oranges[4],
@@ -175,7 +174,6 @@ export const palette = {
 		100: colors.browns[1],
 		200: colors.browns[2],
 		300: colors.browns[3],
-		350: colors.browns[4], // deprecated, use culture[400]
 		400: colors.browns[4],
 		450: colors.browns[5],
 		500: colors.browns[6],

--- a/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/styles.ts
@@ -69,7 +69,7 @@ export const decideBackground = (
 					`;
 				case ArticlePillar.Opinion:
 					return css`
-						background-color: ${opinion[300]};
+						background-color: ${opinion[400]};
 						:hover {
 							background-color: ${opinion[400]};
 							border: 1px solid ${opinion[400]};


### PR DESCRIPTION
## What is the purpose of this change?

The colours `opinion.300` and `culture.350` are duplicates of `opinion.400` and `culture.400` and have been deprecated for a while.

This pull request removes both values and changes one instance where we were using `opinion.300` in the dev kitchen.