### PR TITLE
Apply correct loading spinner size on buttons

### DIFF
--- a/.changeset/smooth-garlics-swim.md
+++ b/.changeset/smooth-garlics-swim.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components': patch
+---
+
+- fix the size of the loading spinner on buttons of size: small and xsmall

--- a/packages/@guardian/source-react-components/src/button/Button.stories.tsx
+++ b/packages/@guardian/source-react-components/src/button/Button.stories.tsx
@@ -283,6 +283,24 @@ asChromaticStory(IsLoadingPrimary);
 
 // *****************************************************************************
 
+export const IsLoadingPrimarySmall = Template.bind({});
+IsLoadingPrimarySmall.args = {
+	isLoading: true,
+	size: 'small',
+};
+asChromaticStory(IsLoadingPrimarySmall);
+
+// *****************************************************************************
+
+export const IsLoadingPrimaryXSmall = Template.bind({});
+IsLoadingPrimaryXSmall.args = {
+	isLoading: true,
+	size: 'xsmall',
+};
+asChromaticStory(IsLoadingPrimaryXSmall);
+
+// *****************************************************************************
+
 export const IsLoadingSecondary = Template.bind({});
 IsLoadingSecondary.args = {
 	isLoading: true,

--- a/packages/@guardian/source-react-components/src/button/styles.ts
+++ b/packages/@guardian/source-react-components/src/button/styles.ts
@@ -39,24 +39,33 @@ const button = css`
 	}
 `;
 
-const applyButtonStylesToLoadingSpinner = css`
-	path,
-	circle {
-		transition: stroke ${transitions.medium};
-		stroke: transparent;
-	}
-	path {
-		stroke: currentColor;
-	}
-	svg {
-		/*
+// Width of the loading spinner in pixels for each button size.
+const loadingSpinnerSizes: Record<Size, number> = {
+	xsmall: 16,
+	small: 20,
+	default: 24,
+};
+
+const applyButtonStylesToLoadingSpinner = (size: Size) => {
+	return css`
+		path,
+		circle {
+			transition: stroke ${transitions.medium};
+			stroke: transparent;
+		}
+		path {
+			stroke: currentColor;
+		}
+		svg {
+			/*
 		 * The loading spinner width has been specified as 24px in the design
 		 * which falls outside of the icon sizes in source-foundations, so we
 		 * override the width here.
 		 */
-		width: 24px;
-	}
-`;
+			width: ${loadingSpinnerSizes[size]}px;
+		}
+	`;
+};
 
 const primary = (
 	button: ButtonTheme = buttonThemeDefault.button,
@@ -299,6 +308,6 @@ export const buttonStyles =
 			(iconSvg || isLoading) && !hideLabel ? iconSides[iconSide] : '',
 			nudgeIcon ? iconNudgeAnimation : '',
 			hideLabel ? iconOnlySizes[size] : '',
-			isLoading ? applyButtonStylesToLoadingSpinner : undefined,
+			isLoading ? applyButtonStylesToLoadingSpinner(size) : undefined,
 			cssOverrides,
 		];


### PR DESCRIPTION
## What is the purpose of this change?

The loading spinner is currently not displaying at the correct width for button sizes `small`, and `xsmall`. We'd like to correct this so the spinner renders at the correct size for every provided button size.

## What does this change?

This change defines the desired spinner width in pixels as a mapping for each possible button size and applies it when rendering the button.


## Screenshots

**Before**
<img width="266" alt="Screenshot 2022-09-26 at 14 11 40" src="https://user-images.githubusercontent.com/1771189/192285307-822d588b-6eb3-44c5-b367-72c47b272071.png">

**After**
<img width="251" alt="Screenshot 2022-09-26 at 14 10 21" src="https://user-images.githubusercontent.com/1771189/192285173-9d676318-c798-4722-81d1-ab014f231a96.png">
