### PR TITLE
Fully deprecate `opinion.300` & `culture.350`

### DIFF
--- a/packages/@guardian/source-foundations/src/colour/palette.stories.mdx
+++ b/packages/@guardian/source-foundations/src/colour/palette.stories.mdx
@@ -39,8 +39,29 @@ const headline = css`
 			https://github.com/storybookjs/storybook/issues/9832 */
 			}
 			if (category !== '__docgenInfo' && category !== 'displayName') {
+				// These colours have been deprecated and should not be used.
+				const deprecatedColours = {
+					opinion: ['300'],
+					culture: ['350'],
+				};
+				const shadesWithoutDeprecated = {};
+				for (const shade in shades) {
+					const isShadeDeprecated =
+						deprecatedColours[category] &&
+						deprecatedColours[category].includes(shade);
+					// Skip deprecated colours
+					if (isShadeDeprecated) {
+						continue;
+					} else {
+						shadesWithoutDeprecated[shade] = shades[shade];
+					}
+				}
 				return (
-					<ColorItem key={category} title={category} colors={{ ...shades }} />
+					<ColorItem
+						key={category}
+						title={category}
+						colors={{ ...shadesWithoutDeprecated }}
+					/>
 				);
 			}
 		})}

--- a/packages/@guardian/source-foundations/src/colour/palette.tsx
+++ b/packages/@guardian/source-foundations/src/colour/palette.tsx
@@ -153,7 +153,10 @@ export const palette = {
 	opinion: {
 		100: colors.oranges[0],
 		200: colors.oranges[1],
-		300: colors.oranges[2], // deprecated, use opinion[400]
+		/**
+		 * @deprecated, use opinion[400]
+		 */
+		300: colors.oranges[2],
 		400: colors.oranges[2],
 		450: colors.oranges[3],
 		500: colors.oranges[4],
@@ -175,7 +178,10 @@ export const palette = {
 		100: colors.browns[1],
 		200: colors.browns[2],
 		300: colors.browns[3],
-		350: colors.browns[4], // deprecated, use culture[400]
+		/**
+		 * @deprecated, use culture[400]
+		 */
+		350: colors.browns[4],
 		400: colors.browns[4],
 		450: colors.browns[5],
 		500: colors.browns[6],


### PR DESCRIPTION
## What is the purpose of this change?

We'd like to ensure that `opinion.300` and `culture.350` are visibly indicated as being deprecated. 

Previously there was a comment next to them, but it was not picked up by the editor.

## What does this change?

- Adds a full deprecation notice to each colour
- Removes the deprecated colours from the colour palette story

Now deprecated, these colours will appear like this in the editor:

![Screenshot 2022-10-03 at 15 46 04](https://user-images.githubusercontent.com/1771189/193606666-2acfdd6a-ee34-48f0-8b0a-e3d0d83dbfa8.png)
