### PR TITLE
Create `ToggleSwitchApps` component

### DIFF
--- a/.changeset/thick-moons-reply.md
+++ b/.changeset/thick-moons-reply.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Create new `ToggleSwitchApps` component

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [the Source storybook](https://guardian.github.io/source) for examples of av
 - [Getting started](https://guardian.github.io/source/?path=/story/getting-started--page)
 - [Foundations](https://guardian.github.io/source/?path=/story/foundations--page)
 - [Components](https://guardian.github.io/source/?path=/story/components--page)
-- [Develoment Kitchen](https://guardian.github.io/source/?path=/story/development-kitchen--page)
+- [Development Kitchen](https://guardian.github.io/source/?path=/story/development-kitchen--page)
 - [ESLint plugins](https://guardian.github.io/source/?path=/story/eslint-plugins--page)
 
 ## Using the Source Design System 🎨

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.test.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.test.ts
@@ -14,6 +14,7 @@ export type {
 	QuoteIconProps,
 	StarRatingProps,
 	ToggleSwitchProps,
+	ToggleSwitchAppsProps,
 } from './index';
 
 it('Should have exactly these exports', () => {
@@ -35,6 +36,7 @@ it('Should have exactly these exports', () => {
 		'StraightLines',
 		'SuccessSummary',
 		'ToggleSwitch',
+		'ToggleSwitchApps',
 		'defaultGuardianLinks',
 	]);
 });

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.ts
@@ -33,6 +33,9 @@ export type { InfoSummaryProps } from './summary/InfoSummary';
 export { ToggleSwitch } from './toggle-switch/ToggleSwitch';
 export type { ToggleSwitchProps } from './toggle-switch/ToggleSwitch';
 
+export { ToggleSwitchApps } from './toggle-switch-apps/ToggleSwitchApps';
+export type { ToggleSwitchAppsProps } from './toggle-switch-apps/ToggleSwitchApps';
+
 export { FooterWithContents } from './footer-with-contents/FooterWithContents';
 export {
 	FooterLinks,

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/README.md
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/README.md
@@ -1,0 +1,25 @@
+# ToggleSwitchApps
+
+Displays an on/off switch for use in apps web views. See the accompanying stories for visual examples.
+
+## Install
+
+```sh
+$ yarn add @guardian/source-react-components-development-kitchen
+```
+
+or
+
+```sh
+$ npm i @guardian/source-react-components-development-kitchen
+```
+
+## Use
+
+### API
+
+See [storybook](https://guardian.github.io/source/?path=/docs/packages-source-react-components-development-kitchen-toggle-switch-apps--playground)
+
+### How to use
+
+For context and visual guides relating to usage see the [Source Design System website](https://theguardian.design).

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.stories.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import type { Story } from '../../../../../lib/@types/storybook-emotion-10-fixes';
+import {
+	asChromaticStory,
+	asPlayground,
+} from '../../../../../lib/story-intents';
+import { ToggleSwitchApps } from './ToggleSwitchApps';
+import type { ToggleSwitchAppsProps } from './ToggleSwitchApps';
+
+export default {
+	title:
+		'Packages/source-react-components-development-kitchen/ToggleSwitchApps',
+	component: ToggleSwitchApps,
+	args: {},
+};
+
+const Template: Story<ToggleSwitchAppsProps> = (
+	args: ToggleSwitchAppsProps,
+) => {
+	const [checked, setChecked] = useState(args.checked);
+	return (
+		<ToggleSwitchApps
+			{...args}
+			checked={checked}
+			onClick={() => {
+				setChecked(!checked);
+			}}
+		/>
+	);
+};
+
+// *****************************************************************************
+
+export const Playground = Template.bind({});
+asPlayground(Playground);
+
+// *****************************************************************************
+
+export const AndroidNoLabel = Template.bind({});
+AndroidNoLabel.args = {
+	platform: 'android',
+};
+asChromaticStory(AndroidNoLabel);
+
+// *****************************************************************************
+
+export const IosNoLabel = Template.bind({});
+IosNoLabel.args = {
+	platform: 'ios',
+};
+asChromaticStory(IosNoLabel);
+
+// *****************************************************************************
+
+export const AndroidWithLabel = Template.bind({});
+AndroidWithLabel.args = {
+	label: 'Get alerts on this story',
+	platform: 'android',
+};
+asChromaticStory(AndroidWithLabel);
+
+// *****************************************************************************
+
+export const IosWithLabel = Template.bind({});
+IosWithLabel.args = {
+	label: 'Get alerts on this story',
+	platform: 'ios',
+};
+asChromaticStory(IosWithLabel);
+
+// *****************************************************************************
+
+export const AndroidWithLabelLeft = Template.bind({});
+AndroidWithLabelLeft.args = {
+	label: 'Get alerts on this story',
+	labelPosition: 'left',
+	platform: 'android',
+};
+asChromaticStory(AndroidWithLabelLeft);
+
+// *****************************************************************************
+
+export const IosWithLabelLeft = Template.bind({});
+IosWithLabelLeft.args = {
+	label: 'Get alerts on this story',
+	labelPosition: 'left',
+	platform: 'ios',
+};
+asChromaticStory(IosWithLabelLeft);

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/ToggleSwitchApps.tsx
@@ -1,17 +1,12 @@
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
 import { descriptionId, generateSourceId } from '@guardian/source-foundations';
 import type { Props } from '@guardian/source-react-components';
-import { useEffect, useState } from 'react';
-import {
-	buttonStyles,
-	labelStyles,
-	toggleStyles,
-	tooltipStyles,
-} from './styles';
+import { androidStyles, buttonStyles, iosStyles, labelStyles } from './styles';
 
+export type Platform = 'android' | 'ios';
 export type LabelPosition = 'left' | 'right';
 
-export interface ToggleSwitchProps extends Props {
+export interface ToggleSwitchAppsProps extends Props {
 	/**
 	 * Whether the ToggleSwitch is checked. This is necessary when using the
 	 * [controlled approach](https://reactjs.org/docs/forms.html#controlled-components)
@@ -39,12 +34,10 @@ export interface ToggleSwitchProps extends Props {
 	 */
 	labelPosition?: LabelPosition;
 	/**
-	 * Whether the toggle has a tooltip.
-	 * The default is false.
+	 * Sets the toggle styling appropriate for each platform.
+	 * The default platform is 'ios'.
 	 */
-	tooltip?: boolean;
-	/**
-	 */
+	platform?: Platform;
 	/**
 	 * A callback function called when the component is checked or unchecked.
 	 * Receives the click event as an argument.
@@ -53,9 +46,9 @@ export interface ToggleSwitchProps extends Props {
 }
 
 /**
- * [Storybook](https://guardian.github.io/source/?path=/docs/packages-source-react-components-development-kitchen-toggle-switch--playground) •
+ * [Storybook](https://guardian.github.io/source/?path=/docs/packages-source-react-components-development-kitchen-toggle-switch-apps--playground) •
  * [Design System](https://theguardian.design) •
- * [GitHub](https://github.com/guardian/source/tree/main/packages/@guardian/source-react-components-development-kitchen/components/toggle-switch) •
+ * [GitHub](https://github.com/guardian/source/tree/main/packages/@guardian/source-react-components-development-kitchen/components/toggle-switch-apps) •
  * [NPM](https://www.npmjs.com/package/@guardian/source-react-components-development-kitchen)
  *
  * Displays an on/off toggle switch. This toggle has default styling and can be used on android, ios or web.
@@ -63,20 +56,19 @@ export interface ToggleSwitchProps extends Props {
  * To give it more custom styling cssOverride may be used.
  *
  */
-export const ToggleSwitch = ({
+export const ToggleSwitchApps = ({
 	checked,
 	id,
 	label,
 	labelPosition = 'right',
 	defaultChecked,
 	cssOverrides,
+	platform = 'ios',
 	onClick = () => undefined,
 	...props
-}: ToggleSwitchProps): EmotionJSX.Element => {
+}: ToggleSwitchAppsProps): EmotionJSX.Element => {
 	const buttonId = id ?? generateSourceId();
 	const labelId = descriptionId(buttonId);
-	const [isBrowser, setIsBrowser] = useState(false);
-	let tooltiptext = '';
 
 	const isChecked = (): boolean => {
 		if (checked != undefined) {
@@ -86,21 +78,16 @@ export const ToggleSwitch = ({
 		return !!defaultChecked;
 	};
 
-	useEffect(() => {
-		setIsBrowser(true);
-	});
-
-	if (!isBrowser) {
-		tooltiptext = 'tooltiptext';
-	}
-
 	return (
 		<>
 			<label id={labelId} css={[labelStyles, cssOverrides]} {...props}>
 				{labelPosition === 'left' && label}
 				<button
 					id={buttonId}
-					css={[buttonStyles(labelPosition), toggleStyles]}
+					css={[
+						buttonStyles(labelPosition),
+						platform === 'ios' ? iosStyles : androidStyles,
+					]}
 					role="switch"
 					aria-checked={isChecked()}
 					aria-labelledby={labelId}
@@ -108,9 +95,6 @@ export const ToggleSwitch = ({
 					className="tooltip"
 				></button>
 				{labelPosition === 'right' && label}
-				<div className={tooltiptext} css={tooltipStyles}>
-					<span>Please turn on JavaScript to use this feature</span>
-				</div>
 			</label>
 		</>
 	);

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch-apps/styles.ts
@@ -1,0 +1,98 @@
+import { css } from '@emotion/react';
+import { neutral, success, textSans } from '@guardian/source-foundations';
+import type { LabelPosition } from './ToggleSwitchApps';
+
+export const buttonStyles = (labelPosition: LabelPosition) => css`
+	flex: none;
+	border: none;
+	margin: ${labelPosition === 'left' ? '0px 0px 0px 8px' : '0px 8px 0px 0px'};
+	padding: 0;
+	display: inline-block;
+	text-align: center;
+	position: relative;
+	transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+	cursor: pointer;
+
+	&:after {
+		content: '';
+		position: absolute;
+		border-radius: 50%;
+		background: #fff;
+		will-change: left;
+		transition: left 0.15s ease-in-out;
+	}
+
+	:focus + .tooltiptext {
+		display: inline-block;
+		opacity: 1;
+		visibility: visible;
+	}
+`;
+
+export const iosStyles = css`
+	width: 3.188rem;
+	height: 1.938rem;
+	border-radius: 15.5px;
+
+	&:after {
+		height: 1.688rem;
+		width: 1.688rem;
+		margin: 2px;
+		top: 0;
+		left: 0;
+		box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.306272);
+	}
+
+	&[aria-checked='false'] {
+		background-color: rgba(153, 153, 153, 0.5);
+	}
+
+	&[aria-checked='true'] {
+		background: ${success[500]};
+	}
+
+	&[aria-checked='true']:after {
+		left: 20px;
+		background: ${neutral[100]};
+	}
+`;
+
+export const androidStyles = css`
+	width: 1.625rem;
+	height: 0.75rem;
+	border-radius: 6px;
+
+	&:after {
+		height: 1.125rem;
+		width: 1.125rem;
+		top: -3px;
+		box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.35);
+	}
+
+	&[aria-checked='false'] {
+		background: rgb(112, 112, 112, 0.5);
+	}
+
+	&[aria-checked='false']:after {
+		left: -2px;
+	}
+
+	&[aria-checked='true'] {
+		background: rgba(88, 208, 139, 0.65);
+	}
+
+	&[aria-checked='true']:after {
+		left: 8px;
+		background: ${success[500]};
+	}
+`;
+
+export const labelStyles = css`
+	${textSans.small()};
+	display: flex;
+	color: ${neutral[7]};
+	align-items: center;
+	cursor: pointer;
+	user-select: none;
+	position: relative;
+`;

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
@@ -10,7 +10,6 @@ import type { ToggleSwitchProps } from './ToggleSwitch';
 export default {
 	title: 'Packages/source-react-components-development-kitchen/ToggleSwitch',
 	component: ToggleSwitch,
-	args: {},
 };
 
 const Template: Story<ToggleSwitchProps> = (args: ToggleSwitchProps) => {
@@ -35,81 +34,24 @@ asPlayground(Playground);
 
 // *****************************************************************************
 
-export const AndroidNoLabel = Template.bind({});
-AndroidNoLabel.args = {
-	platform: 'android',
-};
-asChromaticStory(AndroidNoLabel);
+export const WithNoLabel = Template.bind({});
+asChromaticStory(WithNoLabel);
 
 // *****************************************************************************
 
-export const IosNoLabel = Template.bind({});
-IosNoLabel.args = {
-	platform: 'ios',
-};
-asChromaticStory(IosNoLabel);
-
-// *****************************************************************************
-
-export const WebNoLabel = Template.bind({});
-WebNoLabel.args = {
-	platform: 'web',
-};
-asChromaticStory(WebNoLabel);
-
-// *****************************************************************************
-
-export const AndroidWithLabel = Template.bind({});
-AndroidWithLabel.args = {
+export const WithLabel = Template.bind({});
+WithLabel.args = {
 	label: 'Get alerts on this story',
-	platform: 'android',
 };
-asChromaticStory(AndroidWithLabel);
+asChromaticStory(WithLabel);
 
 // *****************************************************************************
 
-export const IosWithLabel = Template.bind({});
-IosWithLabel.args = {
-	label: 'Get alerts on this story',
-	platform: 'ios',
-};
-asChromaticStory(IosWithLabel);
-
-// *****************************************************************************
-
-export const WebWithLabel = Template.bind({});
-WebWithLabel.args = {
-	label: 'Get alerts on this story',
-	platform: 'web',
-};
-asChromaticStory(WebWithLabel);
-
-// *****************************************************************************
-
-export const AndroidWithLabelLeft = Template.bind({});
-AndroidWithLabelLeft.args = {
+export const WithLabelLeft = Template.bind({});
+WithLabelLeft.args = {
 	label: 'Get alerts on this story',
 	labelPosition: 'left',
-	platform: 'android',
 };
-asChromaticStory(AndroidWithLabelLeft);
+asChromaticStory(WithLabelLeft);
 
 // *****************************************************************************
-
-export const IosWithLabelLeft = Template.bind({});
-IosWithLabelLeft.args = {
-	label: 'Get alerts on this story',
-	labelPosition: 'left',
-	platform: 'ios',
-};
-asChromaticStory(IosWithLabelLeft);
-
-// *****************************************************************************
-
-export const WebWithLabelLeft = Template.bind({});
-WebWithLabelLeft.args = {
-	label: 'Get alerts on this story',
-	labelPosition: 'left',
-	platform: 'web',
-};
-asChromaticStory(WebWithLabelLeft);

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.stories.tsx
@@ -15,15 +15,13 @@ export default {
 const Template: Story<ToggleSwitchProps> = (args: ToggleSwitchProps) => {
 	const [checked, setChecked] = useState(args.checked);
 	return (
-		<div style={{ height: '100px' }}>
-			<ToggleSwitch
-				{...args}
-				checked={checked}
-				onClick={() => {
-					setChecked(!checked);
-				}}
-			/>
-		</div>
+		<ToggleSwitch
+			{...args}
+			checked={checked}
+			onClick={() => {
+				setChecked(!checked);
+			}}
+		/>
 	);
 };
 

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/styles.ts
@@ -29,70 +29,12 @@ export const buttonStyles = (labelPosition: LabelPosition) => css`
 	}
 `;
 
-export const iosStyles = css`
-	width: 3.188rem;
-	height: 1.938rem;
-	border-radius: 15.5px;
-
-	&:after {
-		height: 1.688rem;
-		width: 1.688rem;
-		margin: 2px;
-		top: 0;
-		left: 0;
-		box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.306272);
-	}
-
-	&[aria-checked='false'] {
-		background-color: rgba(153, 153, 153, 0.5);
-	}
-
-	&[aria-checked='true'] {
-		background: ${success[500]};
-	}
-
-	&[aria-checked='true']:after {
-		left: 20px;
-		background: ${neutral[100]};
-	}
-`;
-
-export const androidStyles = css`
-	width: 1.625rem;
-	height: 0.75rem;
-	border-radius: 6px;
-
-	&:after {
-		height: 1.125rem;
-		width: 1.125rem;
-		top: -3px;
-		box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.35);
-	}
-
-	&[aria-checked='false'] {
-		background: rgb(112, 112, 112, 0.5);
-	}
-
-	&[aria-checked='false']:after {
-		left: -2px;
-	}
-
-	&[aria-checked='true'] {
-		background: rgba(88, 208, 139, 0.65);
-	}
-
-	&[aria-checked='true']:after {
-		left: 8px;
-		background: ${success[500]};
-	}
-`;
-
 /**
  * These 'webStyles' are shared with Frontend and will potentially also need updating there if updated here.
  * https://github.com/guardian/frontend/blob/c2b3103e1796b9b2fc3326e792323dd919d4b85a/static/src/stylesheets/module/content-garnett/_live-blog.scss#L257
  */
 
-export const webStyles = css`
+export const toggleStyles = css`
 	width: 2.75rem;
 	height: 1.5rem;
 	border-radius: 15.5px;


### PR DESCRIPTION
## What is the purpose of this change?

This PR moves the existing `ios` and `android` playtform versions of the `ToggleSwitch` component into a new `ToggleSwitchApps` component.

This will eventually allow us to promote the `ToggleSwitch` component to Source as a web only component, free of questions around dark-mode and whether this component is most suited to use in webviews at all.

There should be no changes to functionality in this PR, only the separation of the platform versions and the updating of the corresponding storybook files so the naming makes sense.

## What does this change?

<!--
Give an overview of the changes you have made.
-->

- fix readme typo
- create new component and add `ToggleSwitchApps` to dev kitchen exports
- add stories and update existing story naming 
- remove `getPlatformStyles` function from web `ToggleSwitch`

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**
<img width="216" alt="Screenshot 2022-10-05 at 09 59 14" src="https://user-images.githubusercontent.com/77005274/194022449-f368732c-aa1a-417c-a80e-42e71551322f.png">

**After**
<img width="216" alt="Screenshot 2022-10-05 at 09 58 34" src="https://user-images.githubusercontent.com/77005274/194022470-956ea198-e9ba-4a54-94d0-8f8751c781d1.png">

