### PR TITLE
Make textSans default line-height "regular"

### DIFF
--- a/.changeset/thin-eyes-wonder.md
+++ b/.changeset/thin-eyes-wonder.md
@@ -1,0 +1,7 @@
+---
+'@guardian/source-foundations': major
+'@guardian/source-react-components': major
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Set default textSans line height to regular

--- a/packages/@guardian/source-foundations/src/typography/api.ts
+++ b/packages/@guardian/source-foundations/src/typography/api.ts
@@ -52,7 +52,7 @@ export const body: TypographyFunctions<BodySizes> = {
 };
 
 const textSansDefaults: TypographyConfiguration = {
-	lineHeight: 'loose',
+	lineHeight: 'regular',
 	fontWeight: 'regular',
 	fontStyle: null,
 	unit: 'rem',

--- a/packages/@guardian/source-react-components-development-kitchen/src/summary/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/summary/styles.ts
@@ -24,7 +24,10 @@ export const messageStyles = (
 	color: string,
 	isBold = true,
 ): SerializedStyles => css`
-	${textSans.medium({ fontWeight: isBold ? 'bold' : 'regular' })}
+	${textSans.medium({
+		fontWeight: isBold ? 'bold' : 'regular',
+		lineHeight: 'loose',
+	})}
 	color: ${color};
 `;
 

--- a/packages/@guardian/source-react-components/src/checkbox/styles.ts
+++ b/packages/@guardian/source-react-components/src/checkbox/styles.ts
@@ -84,7 +84,7 @@ export const checkbox = (
 				color: ${checkbox.textIndeterminate};
 				content: '-';
 				position: absolute;
-				top: -10px;
+				top: -${space[2]}px;
 				left: 5px;
 				z-index: 5;
 			}
@@ -95,19 +95,19 @@ export const checkbox = (
 export const labelText = (
 	checkbox = checkboxThemeDefault.checkbox,
 ): SerializedStyles => css`
-	${textSans.medium({ lineHeight: 'regular' })};
+	${textSans.medium()};
 	color: ${checkbox.textLabel};
 	width: 100%;
 `;
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium({ lineHeight: 'regular' })};
+	${textSans.medium()};
 `;
 
 export const supportingText = (
 	checkbox = checkboxThemeDefault.checkbox,
 ): SerializedStyles => css`
-	${textSans.small({ lineHeight: 'regular' })};
+	${textSans.small()};
 	color: ${checkbox.textLabelSupporting};
 `;
 

--- a/packages/@guardian/source-react-components/src/choice-card/styles.ts
+++ b/packages/@guardian/source-react-components/src/choice-card/styles.ts
@@ -173,7 +173,7 @@ export const contentWrapper = css`
 	}
 
 	& > * {
-		${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
+		${textSans.medium({ fontWeight: 'bold' })};
 		text-align: center;
 	}
 

--- a/packages/@guardian/source-react-components/src/label/styles.ts
+++ b/packages/@guardian/source-react-components/src/label/styles.ts
@@ -10,14 +10,14 @@ export const legend = css`
 export const labelText = (
 	label = labelThemeDefault.label,
 ): SerializedStyles => css`
-	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
+	${textSans.medium({ fontWeight: 'bold' })};
 	color: ${label.textLabel};
 `;
 
 export const optionalText = (
 	label = labelThemeDefault.label,
 ): SerializedStyles => css`
-	${textSans.small({ lineHeight: 'regular' })};
+	${textSans.small()};
 	color: ${label.textOptional};
 	font-style: italic;
 `;
@@ -25,7 +25,7 @@ export const optionalText = (
 export const supportingText = (
 	label = labelThemeDefault.label,
 ): SerializedStyles => css`
-	${textSans.small({ lineHeight: 'regular' })};
+	${textSans.small()};
 	color: ${label.textSupporting};
 	margin: 2px 0 0;
 `;

--- a/packages/@guardian/source-react-components/src/radio/styles.ts
+++ b/packages/@guardian/source-react-components/src/radio/styles.ts
@@ -107,18 +107,18 @@ export const radio = (radio = radioThemeDefault.radio): SerializedStyles => css`
 export const labelText = (
 	radio = radioThemeDefault.radio,
 ): SerializedStyles => css`
-	${textSans.medium({ lineHeight: 'regular' })};
+	${textSans.medium()};
 	color: ${radio.textLabel};
 	width: 100%;
 `;
 
 export const labelTextWithSupportingText = css`
-	${textSans.medium({ fontWeight: 'bold', lineHeight: 'regular' })};
+	${textSans.medium({ fontWeight: 'bold' })};
 `;
 
 export const supportingText = (
 	radio = radioThemeDefault.radio,
 ): SerializedStyles => css`
-	${textSans.small({ lineHeight: 'regular' })};
+	${textSans.small()};
 	color: ${radio.textLabelSupporting};
 `;

--- a/packages/@guardian/source-react-components/src/select/styles.ts
+++ b/packages/@guardian/source-react-components/src/select/styles.ts
@@ -71,7 +71,7 @@ export const select = (select = selectThemeDefault.select): SerializedStyles =>
 		box-sizing: border-box;
 		height: ${height.inputMedium}px;
 		width: 100%;
-		${textSans.medium({ lineHeight: 'regular' })};
+		${textSans.medium()};
 		background-color: ${select.backgroundInput};
 		border: 2px solid ${select.border};
 		padding-left: ${space[2]}px;

--- a/packages/@guardian/source-react-components/src/text-area/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-area/styles.ts
@@ -30,7 +30,7 @@ export const successInput = css`
 export const textArea = css`
 	${resets.input};
 	box-sizing: border-box;
-	${textSans.medium({ lineHeight: 'regular' })};
+	${textSans.medium()};
 	color: ${palette.neutral[7]};
 	background-color: ${palette.neutral[100]};
 	border: 2px solid ${palette.neutral[46]};

--- a/packages/@guardian/source-react-components/src/text-input/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-input/styles.ts
@@ -40,7 +40,7 @@ export const textInput = (
 		${resets.input};
 		box-sizing: border-box;
 		height: ${height.inputMedium}px;
-		${textSans.medium({ lineHeight: 'regular' })};
+		${textSans.medium()};
 		color: ${textInput.textUserInput};
 		background-color: ${textInput.backgroundInput};
 		border: 2px solid ${textInput.border};

--- a/packages/@guardian/source-react-components/src/user-feedback/styles.ts
+++ b/packages/@guardian/source-react-components/src/user-feedback/styles.ts
@@ -6,7 +6,7 @@ import { userFeedbackThemeDefault } from './theme';
 const inlineMessage = css`
 	display: flex;
 	align-items: flex-start;
-	${textSans.medium({ lineHeight: 'regular' })};
+	${textSans.medium()};
 
 	svg {
 		fill: currentColor;


### PR DESCRIPTION
## What is the purpose of this change?

We'd like to set a default line height for each main font that we provide in Source.

Text Sans has had a line height of 150 as a default for many years. In design, we mostly use Text Sans with a line height of 135.

This work is centred around changing that line height and managing the knock-on effects of doing so. We'd like to have as little impact on the external teams as possible.

Recreation of: https://github.com/guardian/source/pull/1531

Issues around accessibility have been resolved by @akemitakagi and DAC:

Success Criterion 1.4.12 Text Spacing (Level AA) doesn’t mean all of the line height needs to be at least 1.5 times the font size.

Its author responsibility mentions
‘This SC (Success Criterion) does not dictate that authors must set all their content to the specified metrics. Rather, it specifies that an author's content has the ability to be set to those metrics without loss of content or functionality.’

We can set any line height we want as long as the user can override the styles.
The Guardian supports custom css to override our style.
Therefore we cleared this Success Criterion.

## What does this change?

- Updates textSans line-height default to `regular` 
- Removes overrides which were setting line-height to `regular` on a per-component basis
- Removes additional padding in `Button` component which was added to correct layout with incorrect line-height
- Removes additional margin which was used to correct alignment in `Summary` component

## UI Changes

The intention behind this PR is that we should update the line height but not cause any UI changes. See Chromatic for a full list of components effected.
