### PR TITLE
Apply correct state transitions for form element borders

### DIFF
--- a/.changeset/breezy-comics-call.md
+++ b/.changeset/breezy-comics-call.md
@@ -1,0 +1,6 @@
+---
+'@guardian/source-foundations': patch
+---
+
+- Text area, Text input, and Select active border colour persists when focused
+- Radio button and checkbox border changes on hover when unchecked and remains in the error state on hover when checked.

--- a/.changeset/breezy-comics-call.md
+++ b/.changeset/breezy-comics-call.md
@@ -2,5 +2,5 @@
 '@guardian/source-foundations': patch
 ---
 
-- Text area, Text input, and Select active border colour persists when focused
-- Radio button and checkbox border changes on hover when unchecked and remains in the error state on hover when checked.
+- `TextArea`, `TextInput`, and `Select` active border colour persists when focused
+- `Radio` and `Checkbox` border changes on hover when unchecked and remains in the error state on hover when checked.

--- a/packages/@guardian/source-react-components/src/checkbox/Checkbox.tsx
+++ b/packages/@guardian/source-react-components/src/checkbox/Checkbox.tsx
@@ -102,7 +102,7 @@ export const Checkbox = ({
 				id={checkboxId}
 				type="checkbox"
 				css={(theme: Theme) => [
-					checkbox(theme.checkbox),
+					checkbox(theme.checkbox, error),
 					error ? errorCheckbox(theme.checkbox) : '',
 					cssOverrides,
 				]}

--- a/packages/@guardian/source-react-components/src/checkbox/Checkbox.tsx
+++ b/packages/@guardian/source-react-components/src/checkbox/Checkbox.tsx
@@ -94,7 +94,7 @@ export const Checkbox = ({
 	return (
 		<div
 			css={(theme: Theme) => [
-				checkboxContainer(theme.checkbox),
+				checkboxContainer(theme.checkbox, error),
 				supporting ? checkboxContainerWithSupportingText : '',
 			]}
 		>

--- a/packages/@guardian/source-react-components/src/checkbox/styles.ts
+++ b/packages/@guardian/source-react-components/src/checkbox/styles.ts
@@ -21,6 +21,7 @@ export const fieldset = css`
 
 export const checkboxContainer = (
 	checkbox = checkboxThemeDefault.checkbox,
+	error = false,
 ): SerializedStyles => css`
 	position: relative;
 	display: flex;
@@ -30,7 +31,15 @@ export const checkboxContainer = (
 
 	&:hover {
 		input {
-			border-color: ${checkbox.borderHover};
+			border: 2px solid ${checkbox.borderHover};
+		}
+
+		input:checked {
+			${error ? `border: 4px solid ${checkbox.borderError}` : ''}
+		}
+
+		input:active {
+			border: 2px solid ${checkbox.borderHover};
 		}
 	}
 `;
@@ -181,4 +190,16 @@ export const errorCheckbox = (
 	checkbox = checkboxThemeDefault.checkbox,
 ): SerializedStyles => css`
 	border: 4px solid ${checkbox.borderError};
+	:hover {
+		border: 2px solid ${checkbox.borderHover};
+	}
+	&:checked {
+		border: 4px solid ${checkbox.borderError};
+		:hover {
+			border: 4px solid ${checkbox.borderError};
+		}
+		:active {
+			border: 2px solid ${checkbox.borderHover};
+		}
+	}
 `;

--- a/packages/@guardian/source-react-components/src/checkbox/styles.ts
+++ b/packages/@guardian/source-react-components/src/checkbox/styles.ts
@@ -31,15 +31,12 @@ export const checkboxContainer = (
 
 	&:hover {
 		input {
-			border: 2px solid ${checkbox.borderHover};
+			border-color: ${error ? checkbox.borderError : checkbox.borderHover};
 		}
-
-		input:checked {
-			${error ? `border: 4px solid ${checkbox.borderError}` : ''}
-		}
-
-		input:active {
-			border: 2px solid ${checkbox.borderHover};
+	}
+	&:active {
+		input {
+			border-color: ${checkbox.borderHover};
 		}
 	}
 `;
@@ -55,6 +52,7 @@ export const checkboxContainerWithSupportingText = css`
 
 export const checkbox = (
 	checkbox = checkboxThemeDefault.checkbox,
+	error = false,
 ): SerializedStyles => css`
 	flex: 0 0 auto;
 	box-sizing: border-box;
@@ -77,8 +75,9 @@ export const checkbox = (
 	@supports (${appearance}) {
 		appearance: none;
 		&:checked {
-			border: 2px solid ${checkbox.borderChecked};
-
+			border: ${error
+				? `4px solid ${checkbox.borderError}`
+				: `2px solid ${checkbox.borderChecked}`};
 			& ~ span:before {
 				right: 0;
 			}
@@ -190,16 +189,9 @@ export const errorCheckbox = (
 	checkbox = checkboxThemeDefault.checkbox,
 ): SerializedStyles => css`
 	border: 4px solid ${checkbox.borderError};
-	:hover {
+
+	&:not(:checked):hover,
+	&:active {
 		border: 2px solid ${checkbox.borderHover};
-	}
-	&:checked {
-		border: 4px solid ${checkbox.borderError};
-		:hover {
-			border: 4px solid ${checkbox.borderError};
-		}
-		:active {
-			border: 2px solid ${checkbox.borderHover};
-		}
 	}
 `;

--- a/packages/@guardian/source-react-components/src/radio/styles.ts
+++ b/packages/@guardian/source-react-components/src/radio/styles.ts
@@ -19,6 +19,11 @@ export const fieldset = (
 
 	&[aria-invalid='true'] input {
 		border: 4px solid ${radio.borderError};
+
+		&:not(:checked):hover,
+		&:active {
+			border: 2px solid ${radio.borderHover};
+		}
 	}
 `;
 

--- a/packages/@guardian/source-react-components/src/select/styles.ts
+++ b/packages/@guardian/source-react-components/src/select/styles.ts
@@ -85,11 +85,8 @@ export const select = (select = selectThemeDefault.select): SerializedStyles =>
 			}
 		}
 
-		&:active {
-			border: 2px solid ${select.borderActive};
-		}
-
 		&:focus {
+			border: 2px solid ${select.borderActive};
 			${focusHalo};
 		}
 

--- a/packages/@guardian/source-react-components/src/text-area/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-area/styles.ts
@@ -11,20 +11,12 @@ export const errorInput = css`
 	border: 4px solid ${palette.error[400]};
 	color: ${palette.neutral[7]};
 	margin-top: 0;
-	/* When input is active and in an error state, we want the border to remain the same. */
-	&:active {
-		border: 4px solid ${palette.error[400]};
-	}
 `;
 
 export const successInput = css`
 	border: 4px solid ${palette.success[400]};
 	color: ${palette.success[400]};
 	margin-top: 0;
-	/* When input is active and in a success state, we want the border to remain the same. */
-	&:active {
-		border: 4px solid ${palette.success[400]};
-	}
 `;
 
 export const textArea = css`
@@ -36,11 +28,8 @@ export const textArea = css`
 	border: 2px solid ${palette.neutral[46]};
 	padding: ${space[2]}px ${space[2]}px 0 ${space[2]}px;
 
-	&:active {
-		border: 2px solid ${palette.brand[500]};
-	}
-
 	&:focus {
+		border: 2px solid ${palette.brand[500]};
 		${focusHalo};
 	}
 

--- a/packages/@guardian/source-react-components/src/text-input/styles.ts
+++ b/packages/@guardian/source-react-components/src/text-input/styles.ts
@@ -15,10 +15,6 @@ export const errorInput = (
 	border: 4px solid ${textInput.borderError};
 	color: ${textInput.textError};
 	margin-top: 0;
-	/* When input is active and in an error state, we want the border to remain the same. */
-	&:active {
-		border: 4px solid ${textInput.borderError};
-	}
 `;
 
 export const successInput = (
@@ -27,10 +23,6 @@ export const successInput = (
 	border: 4px solid ${textInput.borderSuccess};
 	color: ${textInput.textSuccess};
 	margin-top: 0;
-	/* When input is active and in a success state, we want the border to remain the same. */
-	&:active {
-		border: 4px solid ${textInput.borderSuccess};
-	}
 `;
 
 export const textInput = (
@@ -46,11 +38,8 @@ export const textInput = (
 		border: 2px solid ${textInput.border};
 		padding: 0 ${space[2]}px;
 
-		&:active {
-			border: 2px solid ${textInput.borderActive};
-		}
-
 		&:focus {
+			border: 2px solid ${textInput.borderActive};
 			${focusHalo};
 		}
 


### PR DESCRIPTION
## What is the purpose of this change?

We'd like the form element hover, focus and active state behaviour to match the rules set out in Figma.

closes #1581
closes #1580 

## What does this change?

- Text area, Text input, and Select active border colour persists when focused.
- Radio and Checkbox error state border behaviour follows the changes set out in our Figma state change diagram

## Demonstration of behaviour

Screen recordings below demonstrate the active, focus and hover border states for each of the modified form elements.

### Text input

**These videos demonstrate how the focus border colour persists while the user is typing in the text input box for default, error, and success.**

<details>
<summary>Text input behaviour changes</summary>

#### Default state

https://user-images.githubusercontent.com/1771189/194708859-6b6e0b42-c77c-4e40-9a78-a82e4c7fa508.mov

#### Success state

https://user-images.githubusercontent.com/1771189/194708877-41f5a877-b7ef-43a2-800c-bdd74fd2c404.mov

#### Error state

https://user-images.githubusercontent.com/1771189/194708888-01e668dc-4aa5-433c-831e-1cfede7e781b.mov
</details>

### Text area

**These videos demonstrate how the focus border colour persists while the user is typing in the text area box for default, error, and success.**

<details>
<summary>Text area behaviour changes</summary>

#### Default state

https://user-images.githubusercontent.com/1771189/194709082-3ca297c4-d138-4541-9960-3336e02e1b74.mov

#### Success state

https://user-images.githubusercontent.com/1771189/194709101-e4d9d2a6-8c1d-4076-a740-12642f841323.mov

#### Error state

https://user-images.githubusercontent.com/1771189/194709114-e2bcf943-0dfe-4a72-91c1-0fe3c66917b9.mov

</details>

### Select

**This video demonstrates how the focus border colour persists while the select menu is open.**

<details>
<summary>Select behaviour changes</summary>

https://user-images.githubusercontent.com/1771189/194709169-18f2b03d-cf73-437c-8066-5159d6de911d.mov
</details>

### Radio button

**This video demonstrates how the radio button border changes on hover when unchecked and remains in the error state on hover when it is checked.**

<details>
<summary>Radio button behaviour changes</summary>

https://user-images.githubusercontent.com/1771189/194709481-2e613251-8ab5-4bba-81fb-636f94682cdb.mov
</details>

### Checkbox

**This video demonstrates how the checkbox border changes on hover when unchecked and remains in the error state on hover when it is checked.**

<details>
<summary>Checkbox behaviour changes</summary>

https://user-images.githubusercontent.com/1771189/194709484-a626e413-8195-43e5-b62c-c1c0bc934bab.mov
</details>

