### PR TITLE
Remove unused tooltip type from `ToggleSwitch` props types

### DIFF
--- a/.changeset/kind-donuts-double.md
+++ b/.changeset/kind-donuts-double.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Remove unused 'tooltip' prop from ToggleSwitch component

--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -61,10 +61,6 @@ export interface ToggleSwitchProps extends Props {
 	 */
 	fontSize?: ToggleSwitchFontSize;
 	/**
-	 * Whether the toggle has a tooltip.
-	 * The default is false. */
-	tooltip?: boolean;
-	/**
 	 * A callback function called when the component is checked or unchecked.
 	 * Receives the click event as an argument.
 	 */


### PR DESCRIPTION
## What is the purpose of this change?

Removing the `tooltip` prop from the types on the `ToggleSwitch` component as it does nothing.

