### PR TITLE
Add e2e tests for eslint plugins

### DIFF
--- a/packages/@guardian/eslint-plugin-source-foundations/jest.config.js
+++ b/packages/@guardian/eslint-plugin-source-foundations/jest.config.js
@@ -1,6 +1,4 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
-	setupFilesAfterEnv: ['./lib/jest-matchers/index.ts'],
 };

--- a/packages/@guardian/eslint-plugin-source-foundations/jest.config.js
+++ b/packages/@guardian/eslint-plugin-source-foundations/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	setupFilesAfterEnv: ['./lib/jest-matchers/index.ts'],
+};

--- a/packages/@guardian/eslint-plugin-source-foundations/jest.e2e.setup.js
+++ b/packages/@guardian/eslint-plugin-source-foundations/jest.e2e.setup.js
@@ -1,0 +1,6 @@
+// Mock `src/index` with whatever `package.json` points at.
+// This means we can run `src/index.test.ts` against `dist` instead.
+
+const dist = require('.');
+
+jest.mock('./src/index', () => dist);

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -29,7 +29,11 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
+<<<<<<< HEAD
 		"@guardian/libs": "9.0.0",
+=======
+		"@guardian/libs": "^3.0.0",
+>>>>>>> 1874bcfb (revert libs bump)
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -18,7 +18,8 @@
 	],
 	"scripts": {
 		"build": "rollup -c",
-		"clean": "rm -rf dist"
+		"clean": "rm -rf dist",
+		"e2e": "jest src/index.test.ts --setupFilesAfterEnv=./jest.e2e.setup.js"
 	},
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "5.21.0",

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -29,11 +29,7 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
-<<<<<<< HEAD
 		"@guardian/libs": "9.0.0",
-=======
-		"@guardian/libs": "^3.0.0",
->>>>>>> 1874bcfb (revert libs bump)
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",

--- a/packages/@guardian/eslint-plugin-source-foundations/src/index.test.ts
+++ b/packages/@guardian/eslint-plugin-source-foundations/src/index.test.ts
@@ -1,0 +1,5 @@
+import * as pkgExports from './index';
+
+it('Should have exactly these exports', () => {
+	expect(Object.keys(pkgExports).sort()).toEqual(['configs', 'rules']);
+});

--- a/packages/@guardian/eslint-plugin-source-react-components/jest.config.js
+++ b/packages/@guardian/eslint-plugin-source-react-components/jest.config.js
@@ -1,6 +1,4 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
-	setupFilesAfterEnv: ['./lib/jest-matchers/index.ts'],
 };

--- a/packages/@guardian/eslint-plugin-source-react-components/jest.config.js
+++ b/packages/@guardian/eslint-plugin-source-react-components/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	setupFilesAfterEnv: ['./lib/jest-matchers/index.ts'],
+};

--- a/packages/@guardian/eslint-plugin-source-react-components/jest.e2e.setup.js
+++ b/packages/@guardian/eslint-plugin-source-react-components/jest.e2e.setup.js
@@ -1,0 +1,6 @@
+// Mock `src/index` with whatever `package.json` points at.
+// This means we can run `src/index.test.ts` against `dist` instead.
+
+const dist = require('.');
+
+jest.mock('./src/index', () => dist);

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -28,7 +28,11 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
+<<<<<<< HEAD
 		"@guardian/libs": "9.0.0",
+=======
+		"@guardian/libs": "^3.0.0",
+>>>>>>> 1874bcfb (revert libs bump)
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -18,7 +18,8 @@
 	],
 	"scripts": {
 		"build": "rollup -c",
-		"clean": "rm -rf dist"
+		"clean": "rm -rf dist",
+		"e2e": "jest src/index.test.ts --setupFilesAfterEnv=./jest.e2e.setup.js"
 	},
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "5.21.0",

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -28,11 +28,7 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
-<<<<<<< HEAD
 		"@guardian/libs": "9.0.0",
-=======
-		"@guardian/libs": "^3.0.0",
->>>>>>> 1874bcfb (revert libs bump)
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",

--- a/packages/@guardian/eslint-plugin-source-react-components/src/index.test.ts
+++ b/packages/@guardian/eslint-plugin-source-react-components/src/index.test.ts
@@ -1,0 +1,5 @@
+import * as pkgExports from './index';
+
+it('Should have exactly these exports', () => {
+	expect(Object.keys(pkgExports).sort()).toEqual(['configs', 'rules']);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,11 +2644,6 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"
   integrity sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ==
 
-"@guardian/libs@^3.0.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.9.0.tgz#330ef270b87f0262e09a5f9964b916c21d1f987a"
-  integrity sha512-2i/AvgeIVCdowSJuc/RnXVBZUROjNT48EbdQY5OtUSzgcR0o1EFoibVX7OAd6Y4nIFHULbx5XDhnH1ymYSSYlA==
-
 "@guardian/prettier@^2.1.4":
   version "2.1.4"
   resolved "https://registry.npmjs.org/@guardian/prettier/-/prettier-2.1.4.tgz#3a92c31bfe9edd82a9fdb2736d463c8fe36735a4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,6 +2644,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"
   integrity sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ==
 
+"@guardian/libs@^8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-8.0.5.tgz#b4c2a93f024322cda79a18bef5fbc0ee6f46922b"
+  integrity sha512-+1E2Okc9x306z+AjKOg52mlWm0Pzb3SCKmSdOqoVcnhXIm2SfF+ivAdnc3vPwZP6ltXDov4gYyNFxYCwbCESSA==
+
 "@guardian/prettier@^2.1.4":
   version "2.1.4"
   resolved "https://registry.npmjs.org/@guardian/prettier/-/prettier-2.1.4.tgz#3a92c31bfe9edd82a9fdb2736d463c8fe36735a4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,10 +2644,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"
   integrity sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ==
 
-"@guardian/libs@^8.0.5":
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-8.0.5.tgz#b4c2a93f024322cda79a18bef5fbc0ee6f46922b"
-  integrity sha512-+1E2Okc9x306z+AjKOg52mlWm0Pzb3SCKmSdOqoVcnhXIm2SfF+ivAdnc3vPwZP6ltXDov4gYyNFxYCwbCESSA==
+"@guardian/libs@^3.0.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.9.0.tgz#330ef270b87f0262e09a5f9964b916c21d1f987a"
+  integrity sha512-2i/AvgeIVCdowSJuc/RnXVBZUROjNT48EbdQY5OtUSzgcR0o1EFoibVX7OAd6Y4nIFHULbx5XDhnH1ymYSSYlA==
 
 "@guardian/prettier@^2.1.4":
   version "2.1.4"


### PR DESCRIPTION
## What is the purpose of this change?

This PR adds e2e tests to the eslint plugins, so that when they are migrated over to the csnx monorepo, the project e2e script will have something to run. This is linked to the PR to [create skeletons in csnx](https://github.com/guardian/csnx/pull/120).

## What does this change?

- Adds e2e tests for each plugin.
- Upgrades `@guardian/libs` dependency to latest - this resolved a peer dependency error on `web-vitals` that occurred when running the new e2e tests.
