### PR TITLE
Bump @guardian/libs to latest major version

### DIFF
--- a/.changeset/gold-keys-swim.md
+++ b/.changeset/gold-keys-swim.md
@@ -1,0 +1,7 @@
+---
+'@guardian/eslint-plugin-source-foundations': major
+'@guardian/eslint-plugin-source-react-components': major
+'@guardian/source-react-components-development-kitchen': major
+---
+
+Bump @guardian/libs to latest major version

--- a/.changeset/gold-keys-swim.md
+++ b/.changeset/gold-keys-swim.md
@@ -4,4 +4,4 @@
 '@guardian/source-react-components-development-kitchen': major
 ---
 
-Bump @guardian/libs to latest major version
+Bump @guardian/libs to `^9.0.0`

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@emotion/react": "11.0.0",
 		"@guardian/eslint-config": "^2.0.1",
 		"@guardian/eslint-config-typescript": "^1.0.9",
-		"@guardian/libs": "3.0.0",
+		"@guardian/libs": "8.0.0",
 		"@guardian/prettier": "^2.1.4",
 		"@guardian/tsconfig": "^0.1.4",
 		"@nrwl/cli": "14.0.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@emotion/react": "11.0.0",
 		"@guardian/eslint-config": "^2.0.1",
 		"@guardian/eslint-config-typescript": "^1.0.9",
-		"@guardian/libs": "8.0.0",
+		"@guardian/libs": "9.0.0",
 		"@guardian/prettier": "^2.1.4",
 		"@guardian/tsconfig": "^0.1.4",
 		"@nrwl/cli": "14.0.5",

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -28,7 +28,7 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
-		"@guardian/libs": "8.0.0",
+		"@guardian/libs": "9.0.0",
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",
@@ -36,7 +36,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/source-foundations": "^7.0.0",
-		"@guardian/libs": "^8.0.5",
+		"@guardian/libs": "^9.0.0",
 		"eslint": "^8.0.0"
 	},
 	"publishConfig": {

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -28,15 +28,15 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
-		"@guardian/libs": "^3.0.0",
+		"@guardian/libs": "8.0.0",
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",
 		"typescript": "~4.6.4"
 	},
 	"peerDependencies": {
-		"@guardian/libs": "^3.0.0",
 		"@guardian/source-foundations": "^7.0.0",
+		"@guardian/libs": "^8.0.5",
 		"eslint": "^8.0.0"
 	},
 	"publishConfig": {

--- a/packages/@guardian/eslint-plugin-source-foundations/package.json
+++ b/packages/@guardian/eslint-plugin-source-foundations/package.json
@@ -32,11 +32,13 @@
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",
-		"typescript": "~4.6.4"
+		"tslib": "^2.4.0",
+		"typescript": "~4.6.4",
+		"web-vitals": "^2.0.0"
 	},
 	"peerDependencies": {
-		"@guardian/source-foundations": "^7.0.0",
 		"@guardian/libs": "^9.0.0",
+		"@guardian/source-foundations": "^7.0.0",
 		"eslint": "^8.0.0"
 	},
 	"publishConfig": {

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -31,11 +31,13 @@
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",
-		"typescript": "~4.6.4"
+		"tslib": "^2.4.0",
+		"typescript": "~4.6.4",
+		"web-vitals": "^2.0.0"
 	},
 	"peerDependencies": {
-		"@guardian/source-react-components": "^9.0.0",
 		"@guardian/libs": "^9.0.0",
+		"@guardian/source-react-components": "^9.0.0",
 		"eslint": "^8.0.0"
 	},
 	"publishConfig": {

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -27,7 +27,7 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
-		"@guardian/libs": "8.0.0",
+		"@guardian/libs": "9.0.0",
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",
@@ -35,7 +35,7 @@
 	},
 	"peerDependencies": {
 		"@guardian/source-react-components": "^9.0.0",
-		"@guardian/libs": "^8.0.5",
+		"@guardian/libs": "^9.0.0",
 		"eslint": "^8.0.0"
 	},
 	"publishConfig": {

--- a/packages/@guardian/eslint-plugin-source-react-components/package.json
+++ b/packages/@guardian/eslint-plugin-source-react-components/package.json
@@ -27,15 +27,15 @@
 	"devDependencies": {
 		"@guardian/eslint-config": "^1.0.0",
 		"@guardian/eslint-config-typescript": "^1.0.0",
-		"@guardian/libs": "^3.0.0",
+		"@guardian/libs": "8.0.0",
 		"@types/estree": "^0.0.51",
 		"rollup": "^2.75.4",
 		"rollup-plugin-ts": "^2.0.7",
 		"typescript": "~4.6.4"
 	},
 	"peerDependencies": {
-		"@guardian/libs": "^3.0.0",
 		"@guardian/source-react-components": "^9.0.0",
+		"@guardian/libs": "^8.0.5",
 		"eslint": "^8.0.0"
 	},
 	"publishConfig": {

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -24,7 +24,7 @@
 		"@emotion/react": "^11.0.0",
 		"@guardian/source-foundations": "^7.0.0",
 		"@guardian/source-react-components": "^9.0.0",
-		"@guardian/libs": "^8.0.5",
+		"@guardian/libs": "^9.0.0",
 		"react": "^17.0.1"
 	},
 	"publishConfig": {

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -22,9 +22,9 @@
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.0.0",
-		"@guardian/libs": "^3.0.0",
 		"@guardian/source-foundations": "^7.0.0",
 		"@guardian/source-react-components": "^9.0.0",
+		"@guardian/libs": "^8.0.5",
 		"react": "^17.0.1"
 	},
 	"publishConfig": {

--- a/packages/@guardian/source-react-components-development-kitchen/package.json
+++ b/packages/@guardian/source-react-components-development-kitchen/package.json
@@ -18,13 +18,15 @@
 		"mini-svg-data-uri": "^1.3.3",
 		"npm-run-all": "^4.1.5",
 		"rollup": "^2.75.4",
-		"rollup-plugin-ts": "^2.0.7"
+		"rollup-plugin-ts": "^2.0.7",
+		"tslib": "^2.4.0",
+		"web-vitals": "^2.0.0"
 	},
 	"peerDependencies": {
 		"@emotion/react": "^11.0.0",
+		"@guardian/libs": "^9.0.0",
 		"@guardian/source-foundations": "^7.0.0",
 		"@guardian/source-react-components": "^9.0.0",
-		"@guardian/libs": "^9.0.0",
 		"react": "^17.0.1"
 	},
 	"publishConfig": {

--- a/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/editorial-button/styles.ts
@@ -14,6 +14,7 @@ import {
 	neutral,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
@@ -159,6 +160,10 @@ export const decideFont = (
 				case ArticleSpecial.SpecialReport:
 					return css`
 						color: ${specialReport[400]};
+					`;
+				case ArticleSpecial.SpecialReportAlt:
+					return css`
+						color: ${palette.specialReportAlt[200]};
 					`;
 			}
 	}

--- a/packages/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/quote-icon/QuoteIcon.tsx
@@ -8,6 +8,7 @@ import {
 	lifestyle,
 	news,
 	opinion,
+	palette,
 	specialReport,
 	sport,
 } from '@guardian/source-foundations';
@@ -54,6 +55,13 @@ const quoteColor = (format: ArticleFormat) => {
 			return css`
 				svg {
 					fill: ${specialReport[400]};
+				}
+			`;
+		}
+		case ArticleSpecial.SpecialReportAlt: {
+			return css`
+				svg {
+					fill: ${palette.specialReportAlt[200]};
 				}
 			`;
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,15 +2639,10 @@
     eslint-plugin-import "2.26.0"
     eslint-plugin-prettier "4.0.0"
 
-"@guardian/libs@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/@guardian/libs/-/libs-3.0.0.tgz#d54813f12f77cede9ee681033f251383ea379acd"
-  integrity sha512-s2NEuE+rX2IyQohFWjKA0OV2GT7HPmh/2QO7cXaZirvMAhrgmEDXu7MSfHfqaLJybpDskUCyik6Yo73qgfnJdg==
-
-"@guardian/libs@^3.0.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.9.0.tgz#330ef270b87f0262e09a5f9964b916c21d1f987a"
-  integrity sha512-2i/AvgeIVCdowSJuc/RnXVBZUROjNT48EbdQY5OtUSzgcR0o1EFoibVX7OAd6Y4nIFHULbx5XDhnH1ymYSSYlA==
+"@guardian/libs@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-8.0.0.tgz#e1b67528ab35c66a513a181b059789ffd9b3e4c0"
+  integrity sha512-PRl+zB3/MI3FtnMXa5SEzHDMbMatODbCxynqjRfkrwItWsBgOtC2m8liVRqZGg9IqpliCCGEgJqcy1pnittOBg==
 
 "@guardian/prettier@^2.1.4":
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2639,10 +2639,10 @@
     eslint-plugin-import "2.26.0"
     eslint-plugin-prettier "4.0.0"
 
-"@guardian/libs@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-8.0.0.tgz#e1b67528ab35c66a513a181b059789ffd9b3e4c0"
-  integrity sha512-PRl+zB3/MI3FtnMXa5SEzHDMbMatODbCxynqjRfkrwItWsBgOtC2m8liVRqZGg9IqpliCCGEgJqcy1pnittOBg==
+"@guardian/libs@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.0.tgz#bb16cbfa4b367d2488e45dfab5d86add893eb028"
+  integrity sha512-VTNP04HisGts8ebnigRwsT255Wcf4ask9puc0AeP29Fj93Hs0rVkh8TAZ5VHEZ5ncNARiJTGAKc7ahatd7QYGQ==
 
 "@guardian/prettier@^2.1.4":
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15784,6 +15784,11 @@ web-namespaces@^1.0.0:
   resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+web-vitals@^2.0.0:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.4.tgz#76563175a475a5e835264d373704f9dde718290c"
+  integrity sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"


### PR DESCRIPTION
## What is the purpose of this change?

As part of our work to prepare Source packages for migration, we identified that `@guardian/libs` should be pinned in dev dependencies to the lowest latest major version and set in the peer dependencies to the latest version.

## What does this change?

- bumps version in eslint plugins
- bumps version in dev kitchen
