### PR TITLE
Remove `!important` from `visuallyHidden`

### DIFF
--- a/.changeset/large-mice-attack.md
+++ b/.changeset/large-mice-attack.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-foundations': patch
+---
+
+Remove !important from visuallyHidden

--- a/.changeset/large-mice-attack.md
+++ b/.changeset/large-mice-attack.md
@@ -2,4 +2,4 @@
 '@guardian/source-foundations': patch
 ---
 
-Remove !important from visuallyHidden
+Remove `!important` from `visuallyHidden`

--- a/packages/@guardian/source-foundations/src/accessibility/visually-hidden.ts
+++ b/packages/@guardian/source-foundations/src/accessibility/visually-hidden.ts
@@ -8,15 +8,15 @@
  * @see https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
  */
 export const visuallyHidden = `
-	position: absolute !important;
-	overflow: hidden !important; /* gets rid of horizontal scrollbar that appears in some circumstances */
-	white-space: nowrap !important; /* The white-space property forces the content to render on one line. */
-	width: 1px !important;  /* ensures content is announced by VoiceOver. */
-	height: 1px !important; /* ensures content is announced by VoiceOver. */
-	margin: -1px !important; /* hide or clip content that does not fit into a 1-pixel visible area. */
-	padding: 0 !important; /* hide or clip content that does not fit into a 1-pixel visible area. */
-	border: 0 !important;
-	clip: rect(1px, 1px, 1px, 1px) !important; /* clip removes any visible trace of the element */
-	-webkit-clip-path: inset(50%) !important; /* clip removes any visible trace of the element */
-	clip-path: inset(50%) !important; /* clip removes any visible trace of the element */
+	position: absolute;
+	overflow: hidden; /* gets rid of horizontal scrollbar that appears in some circumstances */
+	white-space: nowrap; /* The white-space property forces the content to render on one line. */
+	width: 1px;  /* ensures content is announced by VoiceOver. */
+	height: 1px; /* ensures content is announced by VoiceOver. */
+	margin: -1px; /* hide or clip content that does not fit into a 1-pixel visible area. */
+	padding: 0; /* hide or clip content that does not fit into a 1-pixel visible area. */
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px); /* clip removes any visible trace of the element */
+	-webkit-clip-path: inset(50%); /* clip removes any visible trace of the element */
+	clip-path: inset(50%); /* clip removes any visible trace of the element */
 `;


### PR DESCRIPTION
## What is the purpose of this change?

CSS containing `!important` [doesn't pass AMP validation on DCR](https://github.com/guardian/dotcom-rendering/actions/runs/3242851146/jobs/5316727377). 

This PR suggests a (potentially temporary) version of `visuallyHidden` that doesn't use `!important`.

If we decide we **need** to use `!important` we can always reintroduce that or discuss further, for now though the changes in this PR will unblock us so we're able to [bump Source in DCR](https://github.com/guardian/dotcom-rendering/pull/6178).