### PR TITLE
Add empty deps array to `ToggleSwitch` browser check useEffect

### DIFF
--- a/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/toggle-switch/ToggleSwitch.tsx
@@ -107,7 +107,7 @@ export const ToggleSwitch = ({
 
 	useEffect(() => {
 		setIsBrowser(true);
-	});
+	}, []);
 
 	if (!isBrowser) {
 		tooltiptext = 'tooltiptext';


### PR DESCRIPTION
## What is the purpose of this change?

We were missing an empty dependancy array in the `ToggleSwitch` useEffect. This created a bug where on pages where JS was slow to load the tooltip would show erroneously. 

Adding an empty `[]` fixes this.

