### PR TITLE
Fix issue with NumericInput prefixes and suffixes not receiving error or success styling

### DIFF
--- a/.changeset/afraid-stingrays-mate.md
+++ b/.changeset/afraid-stingrays-mate.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+fix issue with error and success state display on NumericInput component

--- a/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/InputExtension.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/InputExtension.tsx
@@ -4,19 +4,32 @@ import {
 	inputSuffix,
 } from './inputExtensionStyles';
 import type { InputTheme } from './NumericInput';
+import { errorInput, successInput } from './sharedStyles';
 
 type InputExtensionProps = {
 	children: string;
 	type: 'prefix' | 'suffix';
+	error?: string;
+	success?: string;
 };
 
-export const InputExtension = ({ children, type }: InputExtensionProps) => {
+export const InputExtension = ({
+	children,
+	type,
+	error,
+	success,
+}: InputExtensionProps) => {
 	const style = type === 'prefix' ? inputPrefix : inputSuffix;
 
 	return (
 		<span
 			aria-hidden="true"
-			css={(theme: InputTheme) => [inputExtension(theme.textInput), style]}
+			css={(theme: InputTheme) => [
+				inputExtension(theme.textInput),
+				error ? errorInput(theme.textInput) : '',
+				!error && success ? successInput(theme.textInput) : '',
+				style,
+			]}
 		>
 			{children}
 		</span>

--- a/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.stories.tsx
@@ -129,3 +129,19 @@ WithPrefixAndSuffix.args = {
 	label: 'Contribution amount',
 	supporting: 'Will be charged monthly starting from today',
 };
+
+// *****************************************************************************
+export const WithPrefixAndError = Template.bind({});
+WithPrefixAndError.args = {
+	prefixText: '£',
+	label: 'Contribution amount',
+	error: 'The amount entered is not valid',
+};
+
+// *****************************************************************************
+export const WithSuffixAndSuccess = Template.bind({});
+WithSuffixAndSuccess.args = {
+	suffixText: 'kr.',
+	label: 'Contribution amount',
+	success: 'success',
+};

--- a/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/NumericInput.tsx
@@ -12,12 +12,10 @@ import {
 } from '@guardian/source-react-components';
 import { InputExtension } from './InputExtension';
 import {
-	errorInput,
 	hasExtensions,
 	inlineMessageMargin,
 	inputWrapper,
 	labelMargin,
-	successInput,
 	supportingTextMargin,
 	textInput,
 	width10,
@@ -25,6 +23,7 @@ import {
 	width4,
 	widthFluid,
 } from './numericInputStyles';
+import { errorInput, successInput } from './sharedStyles';
 
 export interface InputTheme extends Theme {
 	textInput?: typeof textInputThemeDefault.textInput;
@@ -109,7 +108,9 @@ export const NumericInput = ({
 				]}
 			>
 				{prefixText && (
-					<InputExtension type="prefix">{prefixText}</InputExtension>
+					<InputExtension type="prefix" error={error} success={success}>
+						{prefixText}
+					</InputExtension>
 				)}
 				<input
 					css={(theme: InputTheme) => [
@@ -129,7 +130,9 @@ export const NumericInput = ({
 					{...props}
 				/>
 				{suffixText && (
-					<InputExtension type="suffix">{suffixText}</InputExtension>
+					<InputExtension type="suffix" error={error} success={success}>
+						{suffixText}
+					</InputExtension>
 				)}
 			</div>
 		</>

--- a/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/numericInputStyles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/numericInputStyles.ts
@@ -2,7 +2,7 @@ import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import { focusHalo, space } from '@guardian/source-foundations';
 import { textInputThemeDefault } from '@guardian/source-react-components';
-import { inputBase } from './sharedStyles';
+import { errorInput, inputBase } from './sharedStyles';
 
 export const inputWrapper = css`
 	display: flex;
@@ -28,30 +28,6 @@ export const width10 = css`
 
 export const width4 = css`
 	width: 9ex;
-`;
-
-export const errorInput = (
-	textInput = textInputThemeDefault.textInput,
-): SerializedStyles => css`
-	border: 4px solid ${textInput.borderError};
-	color: ${textInput.textError};
-	margin-top: 0;
-	/* When input is active and in an error state, we want the border to remain the same. */
-	&:active {
-		border: 4px solid ${textInput.borderError};
-	}
-`;
-
-export const successInput = (
-	textInput = textInputThemeDefault.textInput,
-): SerializedStyles => css`
-	border: 4px solid ${textInput.borderSuccess};
-	color: ${textInput.textSuccess};
-	margin-top: 0;
-	/* When input is active and in a success state, we want the border to remain the same. */
-	&:active {
-		border: 4px solid ${textInput.borderSuccess};
-	}
 `;
 
 export const textInput = (

--- a/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/sharedStyles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/numeric-input/sharedStyles.ts
@@ -18,3 +18,27 @@ export const inputBase = (
 		border: 2px solid ${textInput.border};
 		padding: 0 ${space[2]}px;
 	`;
+
+export const errorInput = (
+	textInput = textInputThemeDefault.textInput,
+): SerializedStyles => css`
+	border: 4px solid ${textInput.borderError};
+	color: ${textInput.textError};
+	margin-top: 0;
+	/* When input is active and in an error state, we want the border to remain the same. */
+	&:active {
+		border: 4px solid ${textInput.borderError};
+	}
+`;
+
+export const successInput = (
+	textInput = textInputThemeDefault.textInput,
+): SerializedStyles => css`
+	border: 4px solid ${textInput.borderSuccess};
+	color: ${textInput.textSuccess};
+	margin-top: 0;
+	/* When input is active and in a success state, we want the border to remain the same. */
+	&:active {
+		border: 4px solid ${textInput.borderSuccess};
+	}
+`;


### PR DESCRIPTION
## What is the purpose of this change?

This is to fix an issue with the `NumericInput` component not applying error/success styling to the prefix/suffix elements.

## What does this change?

- Apply error and success state styling to the `InputExtension` component used by `NumericInput`
- Add stories for the error and success states that use prefixes and suffixes

## Screenshots

**Before**
![Support-the-Guardian-Make-a-Contribution (1)](https://user-images.githubusercontent.com/29146931/199001451-0c562820-a635-44cb-a1e0-162247b705f3.png)

**After**
![Packages-source-react-components-development-kitchen-NumericInput-With-Prefix-And-Error-⋅-Storybook](https://user-images.githubusercontent.com/29146931/199001479-df87d1a1-85e4-4c50-b199-e1c5cc59f1bf.png)