### PR TITLE
Export the Expanding Wrapper

### DIFF
--- a/.changeset/dull-lies-boil.md
+++ b/.changeset/dull-lies-boil.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Export the Expanding Wrapper

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -13,6 +13,8 @@ import {
 } from './styles';
 import type { ExpandingWrapperProps } from './types';
 
+export type { ExpandingWrapperProps } from './types';
+
 export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 	name,
 	expandCallback,

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.test.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.test.ts
@@ -5,6 +5,7 @@ import * as pkgExports from './index';
 export type {
 	EditorialButtonProps,
 	EditorialLinkButtonProps,
+	ExpandingWrapperProps,
 	FooterLinksProps,
 	FooterWithContentsProps,
 	LineCount,
@@ -27,6 +28,7 @@ it('Should have exactly these exports', () => {
 		'EditorialButton',
 		'EditorialLinkButton',
 		'ErrorSummary',
+		'ExpandingWrapper',
 		'FooterLinks',
 		'FooterWithContents',
 		'InfoSummary',

--- a/packages/@guardian/source-react-components-development-kitchen/src/index.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/index.ts
@@ -6,6 +6,9 @@ export { EditorialLinkButton } from './editorial-button/EditorialLinkButton';
 export type { EditorialButtonProps } from './editorial-button/EditorialButton';
 export type { EditorialLinkButtonProps } from './editorial-button/EditorialLinkButton';
 
+export { ExpandingWrapper } from './expanding-wrapper/ExpandingWrapper';
+export type { ExpandingWrapperProps } from './expanding-wrapper/ExpandingWrapper';
+
 export { Lines } from './lines/Lines';
 export { SquigglyLines } from './lines/SquigglyLines';
 export { DashedLines } from './lines/DashedLines';


### PR DESCRIPTION
## What is the purpose of this change?
A new Expanding Wrapper Component was added in https://github.com/guardian/source/pull/1615, but I missed adding the new component to the list of Exports so it was not available.

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://guardian.github.io/source/?path=/story/contributing-overview--page
-->

## What does this change?
Exports the Expanding Wrapper Component

<!--
Give an overview of the changes you have made.
-->