### PR TITLE
Visually hide `figcaption` in StarRating

### DIFF
--- a/.changeset/dirty-cougars-invite.md
+++ b/.changeset/dirty-cougars-invite.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': minor
+---
+
+Remove aria-role=complementary from StarRating

--- a/.changeset/spicy-queens-dream.md
+++ b/.changeset/spicy-queens-dream.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Change StarRating caption for 0 stars from 'zero star' to 'zero stars'

--- a/.changeset/wild-cheetahs-judge.md
+++ b/.changeset/wild-cheetahs-judge.md
@@ -1,5 +1,5 @@
 ---
-'@guardian/source-react-components-development-kitchen': minor
+'@guardian/source-react-components-development-kitchen': major
 ---
 
 Visually hide StarRating's <figcaption> element

--- a/.changeset/wild-cheetahs-judge.md
+++ b/.changeset/wild-cheetahs-judge.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': minor
+---
+
+Visually hide StarRating's <figcaption> element

--- a/packages/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.tsx
@@ -70,11 +70,7 @@ export const StarRating = ({
 	...props
 }: StarRatingProps): EmotionJSX.Element => {
 	return (
-		<figure
-			role="complementary"
-			css={[figureStyles(size), cssOverrides]}
-			{...props}
-		>
+		<figure css={[figureStyles(size), cssOverrides]} {...props}>
 			<svg
 				css={svgSize(size)}
 				viewBox={`0 0 ${24 * 5} 24`}

--- a/packages/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.tsx
@@ -1,7 +1,11 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css } from '@emotion/react';
 import type { EmotionJSX } from '@emotion/react/types/jsx-namespace';
-import { neutral, remSpace } from '@guardian/source-foundations';
+import {
+	neutral,
+	remSpace,
+	visuallyHidden,
+} from '@guardian/source-foundations';
 
 // https://docs.google.com/spreadsheets/d/1QUa5Kh734J4saFc8ERjCYHZu10_-Hj7llNa2rr8urNg/edit?usp=sharing
 // A list style variations for each breakpoint
@@ -36,10 +40,6 @@ const figureStyles = (size: Size) => css`
 	padding: ${size === 'large' ? '0.125rem' : '0.0625rem'};
 	margin: 0;
 	overflow: hidden;
-
-	figcaption {
-		text-indent: -1000px;
-	}
 `;
 
 export interface StarRatingProps {
@@ -101,7 +101,11 @@ export const StarRating = ({
 					})}
 			</svg>
 
-			<figcaption>
+			<figcaption
+				css={css`
+					${visuallyHidden}
+				`}
+			>
 				{rating} star{rating > 1 && 's'} out of 5
 			</figcaption>
 		</figure>

--- a/packages/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/star-rating/StarRating.tsx
@@ -106,7 +106,7 @@ export const StarRating = ({
 					${visuallyHidden}
 				`}
 			>
-				{rating} star{rating > 1 && 's'} out of 5
+				{rating} star{rating !== 1 && 's'} out of 5
 			</figcaption>
 		</figure>
 	);


### PR DESCRIPTION
> **Note**
> There are 3 separate (small) changes here. I'm happy to split these off into separate PRs if that's preferred!

## What is the purpose of this change?

Remove unnecessary vertical space from the component.

This space makes it difficult to add a background to the component (as happens in Guardian review articles). DCR currently uses its own Star Rating component. Converting it to use Source's leads to an awkward space at the bottom:

<img width="528" alt="DCR screenshot" src="https://user-images.githubusercontent.com/37048459/203956834-fcd63e5e-7ee8-4e19-8072-e14ca122b917.png">

The figcaption was being visually hidden from the DOM via a -1000px text indent. This was adopted when the `<figure>` had an explicit height set, with the stars being added as a background, and no other block or inline content in the `<figure>`. Now that we're using `<svg>` for the stars, the `<figcaption>` stacks below it, adding height to the component.

`visuallyHidden` styles remove the element's height, while accomplishing the same effect as the previous -1000px text indent.

## What does this change?

1. Removes the `text-indent` style from `figcaption`, and adds the `visuallyHidden` styles from `@guardian/source-foundations` instead.
2. Pass-by refactor to remove `aria-role="complementary"` from the component. It's not clear that the component will always be used with that role, so (imo) it makes sense to allow users of the library to decide this for themselves. They can do this without reaching into the component itself if they wrap the component in an `<aside>` which is also [the preferred way to implement complementary role according to MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/complementary_role#prefer_html).
3. Also adds a pass-by refactor of the logic which decides whether to use 'star' or 'stars' in the caption text. ("zero star" -> "zero stars")


## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**
|total height|space taken up by caption|
|--|--|
|<img width="509" alt="image" src="https://user-images.githubusercontent.com/37048459/203957959-6e9e7bd5-c6da-4818-8754-2ca3cbf22e97.png">|<img width="443" alt="image" src="https://user-images.githubusercontent.com/37048459/203958033-4c70d73a-2cd8-4cc7-8733-99a36792167e.png">|



**After**
|total height|space taken up by caption|
|--|--|
|<img width="472" alt="image" src="https://user-images.githubusercontent.com/37048459/203962203-853c4663-32ce-4485-85d8-40eafa11eda4.png">|<img width="507" alt="image" src="https://user-images.githubusercontent.com/37048459/203958473-dce16ca6-f289-4c24-a513-ec28a545f3c7.png">|


## Checklist

### Accessibility

- [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
- [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
- [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

- [ ] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

- [ ] Tested at all breakpoints
- [ ] Tested with with long text
- [ ] Stretched to fill a wide container

### Documentation

I don't know what constitutes a breaking change for this library, but the change in vertical height and in the `aria-role` might count, here?

<!--
If we need to make changes to the documentation website,
please specify them here
-->