### PR TITLE
Add theming and a dark theme to expanding wrapper

### DIFF
--- a/.changeset/gorgeous-peas-trade.md
+++ b/.changeset/gorgeous-peas-trade.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+Add theming and a dark theme to the Expanding Wrapper

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -11,10 +11,10 @@ import {
 	overlayStyles,
 	showHideLabelStyles,
 } from './styles';
+import type { Theme } from './theme';
 import type { ExpandingWrapperProps } from './types';
 
 export type { ExpandingWrapperProps } from './types';
-import type { Theme } from './theme';
 
 export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 	name,

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -14,6 +14,7 @@ import {
 import type { ExpandingWrapperProps } from './types';
 
 export type { ExpandingWrapperProps } from './types';
+import type { Theme } from './theme';
 
 export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 	name,
@@ -23,7 +24,7 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);
 	return (
-		<div id="expander" css={containerStyles}>
+		<div id="expander" css={(theme: Theme) => containerStyles(theme.expander)}>
 			<input
 				type="checkbox"
 				css={css`
@@ -45,11 +46,16 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 				{children}
 			</div>
 
-			{!isExpanded && <div id="expander-overlay" css={overlayStyles} />}
+			{!isExpanded && (
+				<div
+					id="expander-overlay"
+					css={(theme: Theme) => overlayStyles(theme.expander)}
+				/>
+			)}
 			{renderExtra && <span css={extraStyles}>{renderExtra()}</span>}
 			<label
 				aria-hidden={true}
-				css={showHideLabelStyles}
+				css={(theme: Theme) => showHideLabelStyles(theme.expander)}
 				htmlFor="expander-checkbox"
 				id="expander-button"
 			>

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
@@ -1,37 +1,40 @@
 import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
 import {
 	focusHalo,
-	neutral,
 	remHeight,
 	remSpace,
 	textSans,
 } from '@guardian/source-foundations';
+import { expandingWrapperThemeDefault } from './theme';
 
-export const containerStyles = css`
+export const containerStyles = (
+	expander = expandingWrapperThemeDefault.expander,
+): SerializedStyles => css`
 	border-image: repeating-linear-gradient(
 			to bottom,
-			${neutral[86]},
-			${neutral[86]} 1px,
+			${expander.border},
+			${expander.border} 1px,
 			transparent 1px,
 			transparent 4px
 		)
 		13;
-	border-top: 13px solid ${neutral[86]};
-	background: ${neutral[97]};
+	border-top: 13px solid ${expander.border};
+	background: ${expander.collapseBackground};
 	box-shadow: none;
 	position: relative;
 	margin-bottom: ${remSpace[12]};
 
 	#expander-checkbox:checked ~ label {
-		background: ${neutral[100]};
-		color: ${neutral[7]};
-
+		background: ${expander.collapseBackground};
+		color: ${expander.collapseText};
+		border: 1px solid ${expander.collapseText};
 		#svgminus {
-			fill: ${neutral[7]};
+			fill: ${expander.collapseText};
 		}
 	}
 	#expander-checkbox ~ label #svgplus {
-		fill: ${neutral[100]};
+		fill: ${expander.expandText};
 	}
 
 	#expander-checkbox:checked ~ #collapsible-body {
@@ -44,11 +47,13 @@ export const containerStyles = css`
 	}
 `;
 
-export const overlayStyles = css`
+export const overlayStyles = (
+	expander = expandingWrapperThemeDefault.expander,
+): SerializedStyles => css`
 	background-image: linear-gradient(
 		0deg,
-		${neutral[97]},
-		${neutral[97]} 40%,
+		${expander.collapseBackground},
+		${expander.collapseBackground} 40%,
 		rgba(255, 255, 255, 0)
 	);
 	height: 5rem;
@@ -57,7 +62,10 @@ export const overlayStyles = css`
 	width: 100%;
 	display: block;
 `;
-export const showHideLabelStyles = css`
+
+export const showHideLabelStyles = (
+	expander = expandingWrapperThemeDefault.expander,
+): SerializedStyles => css`
 	display: inline-flex;
 	justify-content: space-between;
 	box-shadow: none;
@@ -68,10 +76,10 @@ export const showHideLabelStyles = css`
 	bottom: -${remSpace[6]};
 	border-radius: ${remHeight.ctaMedium}rem;
 	padding: 0 ${remSpace[5]};
-	border: 1px solid ${neutral[7]};
+	border: 1px solid ${expander.expandBackground};
 	text-decoration: none;
-	background: ${neutral[7]};
-	color: ${neutral[100]};
+	background: ${expander.expandBackground};
+	color: ${expander.expandText};
 	height: ${remHeight.ctaMedium}rem;
 	min-height: ${remHeight.ctaMedium}rem;
 	${textSans.medium({ fontWeight: 'bold' })};

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/theme.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/theme.ts
@@ -1,5 +1,5 @@
-import { palette } from '@guardian/source-foundations';
 import type { Theme as EmotionTheme } from '@emotion/react';
+import { palette } from '@guardian/source-foundations';
 
 export const expandingWrapperThemeDefault = {
 	expander: {

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/theme.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/theme.ts
@@ -1,0 +1,25 @@
+import { palette } from '@guardian/source-foundations';
+import type { Theme as EmotionTheme } from '@emotion/react';
+
+export const expandingWrapperThemeDefault = {
+	expander: {
+		border: palette.neutral[86],
+		expandBackground: palette.neutral[7],
+		expandText: palette.neutral[100],
+		collapseBackground: palette.neutral[100],
+		collapseText: palette.neutral[7],
+	},
+};
+export const expandingWrapperDarkTheme = {
+	expander: {
+		border: palette.neutral[60],
+		expandBackground: palette.neutral[86],
+		expandText: palette.neutral[7],
+		collapseBackground: palette.neutral[10],
+		collapseText: palette.neutral[86],
+	},
+};
+
+export interface Theme extends EmotionTheme {
+	expander?: typeof expandingWrapperThemeDefault.expander;
+}


### PR DESCRIPTION
## What is the purpose of this change?
This change uses theming for the Expanding Wrapper, so it can be changed if necessary
It also adds a dark theme for the expanding wrapper.

<!--
Give a brief summary of why you are proposing this change or new feature.
Please ensure you have read our Contributing Guidelines:
https://guardian.github.io/source/?path=/story/contributing-overview--page
-->

## What does this change?
The expanding wrapper is used in Callouts, which need to support dark mode on mobile.

## Screenshots

<!--
If you are not making changes to the design, please delete this section.
-->

**Before**
There was no dark theme
**After**
The dark theme:
![image](https://user-images.githubusercontent.com/26366706/204523050-47253a58-8337-417a-a008-c1bce1233047.png)


## Checklist

### Accessibility

- [x] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
- [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
- [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
- [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

### Cross browser and device testing

- [x] Tested with touch screen device

### Responsiveness

<!--
If there are guidelines around how much content the
component can support, or how wide its container
may get, please specify them in the documentation section
-->

- [x] Tested at all breakpoints
- [x] Tested with with long text
- [x] Stretched to fill a wide container

### Documentation

- [x] Full API surface area is documented in the README
- [x] Examples in Storybook
