### PR TITLE
Expanding Wrapper should manage the focus of child nodes when the wrapper is collapsed

### DIFF
--- a/.changeset/chilled-jobs-agree.md
+++ b/.changeset/chilled-jobs-agree.md
@@ -1,0 +1,5 @@
+---
+'@guardian/source-react-components-development-kitchen': patch
+---
+
+The expanding wrapper should manage the tabIndex of child nodes when the wrapper is collapsed

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -60,7 +60,7 @@ module.exports = {
 			(rule) => String(rule.test) === String(/\.(mjs|tsx?|jsx?)$/),
 		).exclude = nodeModulesExclude;
 
-		config.resolve.plugins ||= [];
+		config.resolve.plugins = [];
 		config.resolve.plugins.push(
 			new TsconfigPathsPlugin({
 				configFile: path.resolve(__dirname, '..', 'tsconfig.json'),

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -60,7 +60,7 @@ module.exports = {
 			(rule) => String(rule.test) === String(/\.(mjs|tsx?|jsx?)$/),
 		).exclude = nodeModulesExclude;
 
-		config.resolve.plugins = [];
+		config.resolve.plugins ||= [];
 		config.resolve.plugins.push(
 			new TsconfigPathsPlugin({
 				configFile: path.resolve(__dirname, '..', 'tsconfig.json'),

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { neutral } from '@guardian/source-foundations';
-import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { ExpandingWrapper } from './ExpandingWrapper';
 
@@ -20,7 +19,7 @@ const loremStyles = css`
 	background: ${neutral[97]};
 `;
 
-const getLorem = (expanded: boolean) => (
+const Lorem = (
 	<div css={loremStyles}>
 		<p>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas quis
@@ -36,7 +35,7 @@ const getLorem = (expanded: boolean) => (
 			sagittis turpis blandit eget. Sed tempor mi ut urna vehicula, vel posuere
 			ipsum egestas.
 		</p>
-		<input disabled={!expanded} placeholder="Basic Input" />
+		<input placeholder="Basic Input" />
 
 		<br />
 		<p>
@@ -51,9 +50,7 @@ const getLorem = (expanded: boolean) => (
 			Integer dapibus pulvinar condimentum. Pellentesque ultricies ligula et
 			facilisis pulvinar.
 		</p>
-		<button disabled={!expanded} onClick={() => window.alert('HELLO')}>
-			Sound the alarm
-		</button>
+		<button onClick={() => window.alert('HELLO')}>Sound the alarm</button>
 		<br />
 		<p>
 			Phasellus vel dapibus ex. Orci varius natoque penatibus et magnis dis
@@ -110,16 +107,10 @@ const renderUpdatedText = () => (
 );
 
 const expandingWrapper = (): ReactElement => {
-	const [isExpanded, setIsExpanded] = useState(false);
-	const expandCallback = (isExpanded: boolean) => setIsExpanded(isExpanded);
 	return (
 		<>
-			<ExpandingWrapper
-				renderExtra={renderUpdatedText}
-				expandCallback={expandCallback}
-				name="Lorem Ipsum Text"
-			>
-				{getLorem(isExpanded)}
+			<ExpandingWrapper renderExtra={renderUpdatedText} name="Lorem Ipsum Text">
+				{Lorem}
 			</ExpandingWrapper>
 			<button>Click me!</button>
 		</>

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.stories.tsx
@@ -17,6 +17,7 @@ import { ExpandingWrapper } from './ExpandingWrapper';
 const loremStyles = css`
 	padding: 10px;
 	background: ${neutral[97]};
+	font-family: GuardianTextSans;
 `;
 
 const Lorem = (
@@ -101,7 +102,13 @@ const Lorem = (
 );
 
 const renderUpdatedText = () => (
-	<span style={{ background: 'yellow', padding: '2px' }}>
+	<span
+		style={{
+			background: 'yellow',
+			padding: '2px',
+			fontFamily: 'GuardianTextSans',
+		}}
+	>
 		Last updated yesterday
 	</span>
 );

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { visuallyHidden } from '@guardian/source-foundations';
 import { SvgMinus, SvgPlus } from '@guardian/source-react-components';
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { FC } from 'react';
 import {
 	buttonIconStyles,
@@ -17,7 +17,7 @@ import type { ExpandingWrapperProps, TabbableElementType } from './types';
 export type { ExpandingWrapperProps } from './types';
 
 const setTabIndex = (name: string, isExpanded: boolean) => {
-	var collapsibleBody = document.getElementById(
+	const collapsibleBody = document.getElementById(
 		`expander-${name}__collapsible-body`,
 	);
 	if (!collapsibleBody) return;

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -54,7 +54,7 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 					${visuallyHidden};
 				`}
 				className="expander__checkbox"
-				id="expander-checkbox"
+				id={`expander-checkbox-${name}`}
 				onChange={(e) => {
 					expandCallback?.(e.target.checked);
 					setIsExpanded(e.target.checked);
@@ -77,7 +77,7 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 			<label
 				aria-hidden={true}
 				css={(theme: Theme) => showHideLabelStyles(theme.expander)}
-				htmlFor="expander-checkbox"
+				htmlFor={`expander-checkbox-${name}`}
 			>
 				{isExpanded ? (
 					<>

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -54,7 +54,7 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 					${visuallyHidden};
 				`}
 				className="expander__checkbox"
-				name="expander-checkbox"
+				id="expander-checkbox"
 				onChange={(e) => {
 					expandCallback?.(e.target.checked);
 					setIsExpanded(e.target.checked);

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/ExpandingWrapper.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { visuallyHidden } from '@guardian/source-foundations';
 import { SvgMinus, SvgPlus } from '@guardian/source-react-components';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { FC } from 'react';
 import {
 	buttonIconStyles,
@@ -12,25 +12,48 @@ import {
 	showHideLabelStyles,
 } from './styles';
 import type { Theme } from './theme';
-import type { ExpandingWrapperProps } from './types';
+import type { ExpandingWrapperProps, TabbableElementType } from './types';
 
 export type { ExpandingWrapperProps } from './types';
+
+const setTabIndex = (name: string, isExpanded: boolean) => {
+	var collapsibleBody = document.getElementById(
+		`expander-${name}__collapsible-body`,
+	);
+	if (!collapsibleBody) return;
+
+	const tabbableElements: TabbableElementType[] = Array.from(
+		collapsibleBody.querySelectorAll('input,textarea,select,button,a'),
+	);
+	tabbableElements.forEach((element: TabbableElementType) => {
+		element.tabIndex = isExpanded ? 0 : -1;
+	});
+};
 
 export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 	name,
 	expandCallback,
 	renderExtra,
+	disableTabbingWhenCollapsed = true,
 	children,
 }) => {
 	const [isExpanded, setIsExpanded] = useState(false);
+
+	useEffect(() => {
+		disableTabbingWhenCollapsed && setTabIndex(name, isExpanded);
+	}, [disableTabbingWhenCollapsed, isExpanded]);
+
 	return (
-		<div id="expander" css={(theme: Theme) => containerStyles(theme.expander)}>
+		<div
+			id={`expander-${name}`}
+			css={(theme: Theme) => containerStyles(theme.expander)}
+		>
 			<input
 				type="checkbox"
 				css={css`
 					${visuallyHidden};
 				`}
-				id="expander-checkbox"
+				className="expander__checkbox"
 				name="expander-checkbox"
 				onChange={(e) => {
 					expandCallback?.(e.target.checked);
@@ -39,7 +62,8 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 				aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${name && name}`}
 			/>
 			<div
-				id="collapsible-body"
+				className="expander__collapsible-body"
+				id={`expander-${name}__collapsible-body`}
 				css={collapsibleBodyStyles}
 				aria-hidden={!isExpanded}
 			>
@@ -47,17 +71,13 @@ export const ExpandingWrapper: FC<ExpandingWrapperProps> = ({
 			</div>
 
 			{!isExpanded && (
-				<div
-					id="expander-overlay"
-					css={(theme: Theme) => overlayStyles(theme.expander)}
-				/>
+				<div css={(theme: Theme) => overlayStyles(theme.expander)} />
 			)}
 			{renderExtra && <span css={extraStyles}>{renderExtra()}</span>}
 			<label
 				aria-hidden={true}
 				css={(theme: Theme) => showHideLabelStyles(theme.expander)}
 				htmlFor="expander-checkbox"
-				id="expander-button"
 			>
 				{isExpanded ? (
 					<>

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
@@ -25,7 +25,7 @@ export const containerStyles = (
 	position: relative;
 	margin-bottom: ${remSpace[12]};
 
-	#expander-checkbox:checked ~ label {
+	.expander__checkbox:checked ~ label {
 		background: ${expander.collapseBackground};
 		color: ${expander.collapseText};
 		border: 1px solid ${expander.collapseText};
@@ -33,16 +33,16 @@ export const containerStyles = (
 			fill: ${expander.collapseText};
 		}
 	}
-	#expander-checkbox ~ label #svgplus {
+	.expander__checkbox ~ label #svgplus {
 		fill: ${expander.expandText};
 	}
 
-	#expander-checkbox:checked ~ #collapsible-body {
+	.expander__checkbox:checked ~ .expander__collapsible-body {
 		max-height: fit-content;
 		margin-bottom: ${remSpace[6]};
 	}
 
-	#expander-checkbox:focus ~ #collapsible-body {
+	.expander__checkbox:focus ~ .expander__collapsible-body {
 		${focusHalo};
 	}
 `;

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/styles.ts
@@ -23,7 +23,7 @@ export const containerStyles = (
 	background: ${expander.collapseBackground};
 	box-shadow: none;
 	position: relative;
-	margin-bottom: ${remSpace[12]};
+	margin-bottom: ${remSpace[9]};
 
 	.expander__checkbox:checked ~ label {
 		background: ${expander.collapseBackground};
@@ -83,6 +83,7 @@ export const showHideLabelStyles = (
 	height: ${remHeight.ctaMedium}rem;
 	min-height: ${remHeight.ctaMedium}rem;
 	${textSans.medium({ fontWeight: 'bold' })};
+	margin-left: ${remSpace[2]};
 `;
 
 export const collapsibleBodyStyles = css`

--- a/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/types.ts
+++ b/packages/@guardian/source-react-components-development-kitchen/src/expanding-wrapper/types.ts
@@ -3,6 +3,14 @@ import type { ReactElement } from 'react';
 export interface ExpandingWrapperProps {
 	children: ReactElement;
 	name: string;
+	disableTabbingWhenCollapsed?: boolean;
 	renderExtra?: () => ReactElement;
 	expandCallback?: (expanded: boolean) => void;
 }
+
+export type TabbableElementType =
+	| HTMLInputElement
+	| HTMLTextAreaElement
+	| HTMLSelectElement
+	| HTMLButtonElement
+	| HTMLAnchorElement;


### PR DESCRIPTION
## What is the purpose of this change?
Previously the expanding wrapper wasn't managing the focus of any children, which meant this had to be managed by the parent. If this was not managed, it was possible to tab through the interactive elements within the collapsed ExpandingWrapper, which was a bad ux experience (see video).

Now, these elements are non-tabbable when the wrapper is collapsed by default (although the disableTabbingWhenCollapsed=false prop can be passed to prevent this).

**Before**
This was possible as the component wasn't managing focus (the button isn't scrolled into view, but is focused and on pressing space triggers the alert)

https://user-images.githubusercontent.com/26366706/205097996-ac1a0bb2-95b7-41a6-bbbe-581cb3ebe3b5.mov

**After**
By default, the component manages focus so that the children are only tabbable when the component is expanded

https://user-images.githubusercontent.com/26366706/205098316-7c6589fd-ffab-456f-9c4c-ca9ea9fba450.mov


